### PR TITLE
add mayavi support

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,15 +18,6 @@ Contents:
    getting_started
    auto_examples/index
 
-.. include:: modules/generated/numpy.linspace.examples
-.. raw:: html
-
-    <div style='clear:both'></div>
-
-.. include:: modules/generated/numpy.exp.examples
-.. raw:: html
-
-    <div style='clear:both'></div>
 
 Indices and tables
 ==================

--- a/examples/plot_strings.py
+++ b/examples/plot_strings.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""
+==============================
+Constrainded Text output frame
+==============================
+
+This example captures the stdout and includes it in the
+example. If output is too long it becomes automatically
+framed into a text area.
+
+"""
+
+# Code source: Óscar Nájera
+# License: BSD 3 clause
+
+print('This is a long test Output\n'*800)

--- a/sphinxgallery/_static/gallery.css
+++ b/sphinxgallery/_static/gallery.css
@@ -71,3 +71,9 @@ div.thumbnailContainer div p {
 div.thumbnailContainer div a {
     display: block; /* To have a better hover behavior */
 }
+
+.max-height pre {
+    /* For very long outpt: restrict the max height */
+    overflow-y: scroll;
+    max-height: 30em;
+}

--- a/sphinxgallery/gen_gallery.py
+++ b/sphinxgallery/gen_gallery.py
@@ -57,6 +57,7 @@ gallery_conf = {
     'examples_gallery'  : 'auto_examples',
     'mod_generated'     : 'modules/generated',
     'doc_module'        : 'sphinxgallery',
+    'use_mayavi'        : False,
     'resolver_urls'     : {
         'matplotlib': 'http://matplotlib.org',
         'numpy': 'http://docs.scipy.org/doc/numpy-1.9.1',

--- a/sphinxgallery/gen_rst.py
+++ b/sphinxgallery/gen_rst.py
@@ -34,11 +34,11 @@ has_mayavi = False
 try:
     from mayavi import mlab
     has_mayavi = True
-except Exception, e:
+except Exception as e:
     try:
         from enthought.mayavi import mlab
         has_mayavi = True
-    except Exception, e:
+    except Exception as e:
         pass
 
 try:

--- a/sphinxgallery/gen_rst.py
+++ b/sphinxgallery/gen_rst.py
@@ -611,7 +611,7 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, gallery_conf, plot_g
 
     if not os.path.exists(thumb_file):
         # create something to replace the thumbnail
-        scale_image(sphinxgallery._path_static()+'/no_image.png', thumb_file, 200, 140)
+        scale_image(sphinxgallery.path_static()+'/no_image.png', thumb_file, 200, 140)
 
     docstring, short_desc, end_row = extract_docstring(example_file)
 

--- a/sphinxgallery/gen_rst.py
+++ b/sphinxgallery/gen_rst.py
@@ -517,8 +517,12 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, gallery_conf, plot_g
                         '')
                 my_stdout = my_stdout.strip().expandtabs()
                 if my_stdout:
-                    stdout = '**Script output**::\n\n  %s\n\n' % (
-                        '\n  '.join(my_stdout.split('\n')))
+                    stdout = """**Script output**:\n
+.. rst-class:: max_height
+
+  ::
+
+    {}\n""".format('\n    '.join(my_stdout.split('\n')))
                 open(stdout_path, 'w').write(stdout)
                 open(time_path, 'w').write('%f' % time_elapsed)
                 os.chdir(cwd)

--- a/sphinxgallery/gen_rst.py
+++ b/sphinxgallery/gen_rst.py
@@ -30,16 +30,21 @@ except ImportError:
     from io import StringIO
     import pickle
 
-has_mayavi = False
-try:
-    from mayavi import mlab
-    has_mayavi = True
-except Exception as e:
-    try:
-        from enthought.mayavi import mlab
-        has_mayavi = True
-    except Exception as e:
-        pass
+def config_mayavi(gallery_config):
+    if gallery_config['use_mayavi']:
+        global mlab
+        try:
+            from mayavi import mlab
+            return True
+        except Exception as e:
+            try:
+                from enthought.mayavi import mlab
+                return True
+            except Exception as e:
+                raise
+    else:
+        return False
+
 
 try:
     # Python 2 built-in
@@ -258,6 +263,8 @@ def _thumbnail_div(subdir, full_dir, fname, snippet):
 def generate_dir_rst(directory, fhindex, root_dir, example_dir, gallery_conf, plot_gallery, seen_backrefs):
     """ Generate the rst file for an example directory.
     """
+    gallery_conf['use_mayavi'] = config_mayavi(gallery_conf)
+
     if not directory == '.':
         src_dir = os.path.join(root_dir, directory)
         target_dir = os.path.join(example_dir, directory)
@@ -511,7 +518,7 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, gallery_conf, plot_g
             import matplotlib.pyplot as plt
             plt.close('all')
 
-            if has_mayavi:
+            if gallery_conf['use_mayavi']:
                 mlab.close(all=True)
 
             cwd = os.getcwd()
@@ -569,7 +576,7 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, gallery_conf, plot_g
                     fig.savefig(image_path % fig_mngr.num, **kwargs)
                     figure_list.append(image_fname % fig_mngr.num)
 
-                if has_mayavi:
+                if gallery_conf['use_mayavi']:
                     e = mlab.get_engine()
                     last_fig_num = len(figure_list)
                     for scene in e.scenes:


### PR DESCRIPTION
Based on the PR of @agramfort to incorporate mayavi support as default.

to use the documentation references in the example scripts
the sphinx `conf.py` needs to include
```python
    sphinxgallery_conf = {
        'doc_module'        : 'yourmodule',      # Your module
        'resolver_urls'     : {                     # External python modules documentation websites
            'matplotlib': 'http://matplotlib.org',
            'numpy': 'http://docs.scipy.org/doc/numpy-1.6.0',
            'scipy': 'http://docs.scipy.org/doc/scipy-0.11.0/reference',
            'mayavi': 'http://docs.enthought.com/mayavi/mayavi'}
```
more info in: http://sphinx-gallery.readthedocs.org/en/latest/advanced_configuration.html#linking-to-external-documentations