### PR TITLE
Including a minimal unicode support for examples docstrings

### DIFF
--- a/examples/plot_strings.py
+++ b/examples/plot_strings.py
@@ -13,4 +13,4 @@ framed into a text area.
 # Code source: Óscar Nájera
 # License: BSD 3 clause
 
-print('This is a long test Output\n'*50)
+print('This is a long test Output\n' * 50)

--- a/examples/plot_strings.py
+++ b/examples/plot_strings.py
@@ -13,4 +13,4 @@ framed into a text area.
 # Code source: Óscar Nájera
 # License: BSD 3 clause
 
-print('This is a long test Output\n'*800)
+print('This is a long test Output\n'*100)

--- a/examples/plot_strings.py
+++ b/examples/plot_strings.py
@@ -13,4 +13,4 @@ framed into a text area.
 # Code source: Óscar Nájera
 # License: BSD 3 clause
 
-print('This is a long test Output\n'*100)
+print('This is a long test Output\n'*50)

--- a/examples/plot_unicode.py
+++ b/examples/plot_unicode.py
@@ -15,7 +15,7 @@ import matplotlib.pyplot as plt
 
 
 N = 50
-x = np.linspace(-1,2,50)
+x = np.linspace(-1, 2, 50)
 colors = np.random.rand(N)
 area = np.pi * (15 * np.random.rand(N))**2
 for i in range(5):

--- a/examples/plot_unicode.py
+++ b/examples/plot_unicode.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""
+=======================================
+Únîcödè support in documentation string
+=======================================
+
+In this example we include Unicode characters that are so required this days.✓
+"""
+
+# Code source: Óscar Nájera
+# License: BSD 3 clause
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+N = 50
+x = np.linspace(-1,2,50)
+colors = np.random.rand(N)
+area = np.pi * (15 * np.random.rand(N))**2
+for i in range(5):
+    plt.scatter(x, -np.cos(i*x), s=area, c=colors, alpha=0.5)
+plt.show()

--- a/sphinxgallery/gen_gallery.py
+++ b/sphinxgallery/gen_gallery.py
@@ -5,6 +5,7 @@ Created on Wed Jan 28 10:38:13 2015
 @author: oscar
 """
 import os
+import codecs
 from sphinxgallery.gen_rst import generate_dir_rst
 from sphinxgallery.docs_resolv import embed_code_links
 
@@ -37,7 +38,7 @@ def generate_gallery_rst(app):
             os.makedirs(workdir)
 
     # we create an index.rst with all examples
-    fhindex = open(os.path.join(gallery_dir, 'index.rst'), 'w')
+    fhindex = codecs.open(os.path.join(gallery_dir, 'index.rst'), 'w', 'utf8')
     fhindex.write("""
 
 .. _examples-index:
@@ -66,6 +67,7 @@ DEFAULT_CONF = {
         'numpy': 'http://docs.scipy.org/doc/numpy-1.9.1',
         'scipy': 'http://docs.scipy.org/doc/scipy-0.15.1/reference'}
     }
+
 
 def setup(app):
     app.add_config_value('plot_gallery', True, 'html')
@@ -96,6 +98,7 @@ def setup(app):
         for filename in filelist:
             if filename.endswith('png'):
                 os.remove(os.path.join(build_image_dir, filename))
+
 
 def setup_module():
     # HACK: Stop nosetests running setup() above

--- a/sphinxgallery/gen_rst.py
+++ b/sphinxgallery/gen_rst.py
@@ -12,6 +12,7 @@ from time import time
 import ast
 import os
 import re
+import codecs
 import shutil
 import traceback
 import glob
@@ -132,7 +133,7 @@ SINGLE_IMAGE = """
 def extract_docstring(filename, ignore_heading=False):
     """ Extract a module-level docstring, if any
     """
-    lines = open(filename).readlines()
+    lines = codecs.open(filename, 'r', 'utf8').readlines()
     start_row = 0
     if lines[0].startswith('#!'):
         lines.pop(0)
@@ -146,7 +147,7 @@ def extract_docstring(filename, ignore_heading=False):
         if tok_type in ('NEWLINE', 'COMMENT', 'NL', 'INDENT', 'DEDENT'):
             continue
         elif tok_type == 'STRING':
-            docstring = eval(tok_content)
+            docstring = eval(tok_content).decode('utf8')
             # If the docstring is formatted with several paragraphs, extract
             # the first one:
             paragraphs = '\n'.join(
@@ -225,7 +226,7 @@ def _thumbnail_div(subdir, full_dir, fname, snippet):
     else:
         target = './%s.html' % link_name[:-3]
 
-    out = """
+    out = u"""
 .. raw:: html
 
     <div class="thumbnailContainer" tooltip="{}">
@@ -288,7 +289,7 @@ def generate_dir_rst(directory, fhindex, root_dir, example_dir, gallery_conf, pl
             for backref in backrefs:
                 include_path = os.path.join(gallery_conf['mod_generated'], '%s.examples' % backref)
                 seen = backref in seen_backrefs
-                with open(include_path, 'a' if seen else 'w') as ex_file:
+                with codecs.open(include_path, 'a' if seen else 'w', 'utf8') as ex_file:
                     if not seen:
                         # heading
                         print(file=ex_file)
@@ -585,7 +586,7 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, gallery_conf, plot_g
             image_list += HLIST_IMAGE_TEMPLATE % figure_name.lstrip('/')
 
     time_m, time_s = divmod(time_elapsed, 60)
-    f = open(os.path.join(target_dir, base_image_name + '.rst'), 'w')
+    f = codecs.open(os.path.join(target_dir, base_image_name + '.rst'), 'w', 'utf8')
     f.write(this_template % locals())
     f.flush()
 

--- a/sphinxgallery/gen_rst.py
+++ b/sphinxgallery/gen_rst.py
@@ -586,9 +586,9 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, gallery_conf, plot_g
             image_list += HLIST_IMAGE_TEMPLATE % figure_name.lstrip('/')
 
     time_m, time_s = divmod(time_elapsed, 60)
-    f = codecs.open(os.path.join(target_dir, base_image_name + '.rst'), 'w', 'utf8')
-    f.write(this_template.format(**locals()))
-    f.flush()
+    with codecs.open(os.path.join(target_dir, base_image_name + '.rst'),
+                     'w', 'utf8') as output_file:
+        output_file.write(this_template.format(**locals()))
 
     # save variables so we can later add links to the documentation
     example_code_obj = identify_names(open(example_file).read())

--- a/sphinxgallery/gen_rst.py
+++ b/sphinxgallery/gen_rst.py
@@ -147,7 +147,10 @@ def extract_docstring(filename, ignore_heading=False):
         if tok_type in ('NEWLINE', 'COMMENT', 'NL', 'INDENT', 'DEDENT'):
             continue
         elif tok_type == 'STRING':
-            docstring = eval(tok_content).decode('utf8')
+            try:
+                docstring = eval(tok_content).decode('utf8')
+            except AttributeError:
+                docstring = eval(tok_content) # Because py3 works without decode
             # If the docstring is formatted with several paragraphs, extract
             # the first one:
             paragraphs = '\n'.join(

--- a/sphinxgallery/gen_rst.py
+++ b/sphinxgallery/gen_rst.py
@@ -79,35 +79,35 @@ class Tee(object):
 
 
 ###############################################################################
-rst_template = """
+rst_template = u"""
 
-.. _example_%(short_fname)s:
+.. _example_{short_fname}:
 
-%(docstring)s
+{docstring}
 
-**Python source code:** :download:`%(fname)s <%(fname)s>`
+**Python source code:** :download:`{fname} <{fname}>`
 
-.. literalinclude:: %(fname)s
-    :lines: %(end_row)s-
+.. literalinclude:: {fname}
+    :lines: {end_row}-
     """
 
-plot_rst_template = """
+plot_rst_template = u"""
 
-.. _example_%(short_fname)s:
+.. _example_{short_fname}:
 
-%(docstring)s
+{docstring}
 
-%(image_list)s
+{image_list}
 
-%(stdout)s
+{stdout}
 
-**Python source code:** :download:`%(fname)s <%(fname)s>`
+**Python source code:** :download:`{fname} <{fname}>`
 
-.. literalinclude:: %(fname)s
-    :lines: %(end_row)s-
+.. literalinclude:: {fname}
+    :lines: {end_row}-
 
-**Total running time of the example:** %(time_elapsed) .2f seconds
-(%(time_m) .0f minutes %(time_s) .2f seconds)
+**Total running time of the example:** {time_elapsed:.2} seconds
+({time_m:.0f} minutes {time_s:.2} seconds)
     """
 
 # The following strings are used when we have several pictures: we use
@@ -255,7 +255,7 @@ def generate_dir_rst(directory, fhindex, root_dir, example_dir, gallery_conf, pl
         target_dir = example_dir
     if not os.path.exists(os.path.join(src_dir, 'README.txt')):
         print( 80 * '_')
-        print ('Example directory %s does not have a README.txt file' %
+        print('Example directory %s does not have a README.txt file' %
                src_dir)
         print( 'Skipping this directory')
         print( 80 * '_')
@@ -587,7 +587,7 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, gallery_conf, plot_g
 
     time_m, time_s = divmod(time_elapsed, 60)
     f = codecs.open(os.path.join(target_dir, base_image_name + '.rst'), 'w', 'utf8')
-    f.write(this_template % locals())
+    f.write(this_template.format(**locals()))
     f.flush()
 
     # save variables so we can later add links to the documentation


### PR DESCRIPTION
This is proposed as a short solution to address issue #18. Problem never arises in python 3 as unicode is default string. For dealing with python2 the use of the codecs module is included.