### PR TITLE
Naming convention for configuration

### DIFF
--- a/doc/_static/theme_override.css
+++ b/doc/_static/theme_override.css
@@ -1,5 +1,5 @@
 .wy-side-nav-search {
-    background-color: #FF8C38;
+    background-color: #FF8C38 !important;
 }
 
 

--- a/doc/_static/theme_override.css
+++ b/doc/_static/theme_override.css
@@ -1,0 +1,12 @@
+.wy-side-nav-search {
+    background-color: #FF8C38;
+}
+
+
+div[class^="highlight"] a {
+    background-color: #E6E6E6;
+}
+
+div[class^="highlight"] a:hover {
+    background-color: #ABECFC;
+}

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -3,7 +3,7 @@ Advanced Configuration
 ======================
 
 Here are the personal configurations that you can modify within Sphinx-Gallery.
-What is writen from here on are the default values.
+
 
 Changing default directories
 ============================
@@ -19,45 +19,63 @@ Within your Sphinx ``conf.py`` file you need to add a configuration dictionary:
 
 Directory paths are relative to your ``conf.py`` location.
 
+
 Linking to external documentations
 ==================================
 
-If you want to hyperlink commands in your example scripts you can. Again within
-your Sphinx ``conf.py`` file you need to add a configuration dictionary:
+Sphinx-Gallery enables you to hyperlink commands in your example scripts to the
+matching location in their online documentation . Have a look at this in action
+in our example :ref:`example_plot_gallery_version.py`.
+
+To make this work in your documentation you need to include to the configuration
+dictionary within your Sphinx ``conf.py`` file :
 
 .. code-block:: python
 
     sphinxgallery_conf = {
-        'doc_module'        : 'sphinxgallery',      # Your module
-        'resolver_urls'     : {                     # External python modules documentation websites
-            'matplotlib': 'http://matplotlib.org',
-            'numpy': 'http://docs.scipy.org/doc/numpy-1.9.1',
-            'scipy': 'http://docs.scipy.org/doc/scipy-0.15.1/reference'}
+        'reference_url':  {
+                 # Modules you locally document use an empty string
+                'sphinxgallery': '',
+
+                # External python modules use their documentation websites
+                'matplotlib': 'http://matplotlib.org',
+                'numpy': 'http://docs.scipy.org/doc/numpy-1.9.1'}
         }
 
-Establishing local calls to examples
-====================================
 
-Maybe when you are documenting your modules you would like to reference
-to examples that use that particular module. In that case within
-your Sphinx ``conf.py`` file you need to add a configuration dictionary:
+
+Establishing local references to examples
+=========================================
+
+Certainly comands in your examples linking to their documentation is not enough.
+Sphinx-Gallery alse enables you, when documenting your modules, to reference
+into examples that use that particular module.
+
+In that case within your Sphinx ``conf.py`` file you need to add to their
+configuration dictionary:
 
 .. code-block:: python
 
     sphinxgallery_conf = {
-        'mod_generated'     : 'modules/generated', # path where to store your example linker
-        'doc_module'        : 'numpy'}             # Your module (In this example we use numpy)
+        # path where to store your example linker templat
+        'mod_generated'     : 'modules/generated',
+        # Your documented modules. You can use a string or a list of strings
+        'doc_module'        : ('sphinxgallery', 'numpy')}
 
-Then within your sphinx documentation files you include this lines::
+The path you specified will get populated with the links to examples using your
+module and their methods. Then within your sphinx documentation files you
+include this lines to include this links::
 
     .. include:: modules/generated/numpy.linspace.examples
     .. raw:: html
 
         <div style='clear:both'></div>
 
-where you have include an ``*.example`` file that is stored in your ``mod_generated``
-directory you put in the configuration. And then the file you call has all the path
-of your module. In this case ``numpy.linspace``. That will be rendered as
+The file you are including is referenced with its relative path to your defined
+directory and includes all the module specific location. In this case
+``numpy.linspace``.
+
+That will be rendered as
 
 .. include:: modules/generated/numpy.linspace.examples
 .. raw:: html

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -47,8 +47,8 @@ dictionary within your Sphinx ``conf.py`` file :
 Establishing local references to examples
 =========================================
 
-Certainly comands in your examples linking to their documentation is not enough.
-Sphinx-Gallery alse enables you, when documenting your modules, to reference
+Linking commands in your examples to their documentation is not enough.
+Sphinx-Gallery also enables you, when documenting your modules, to reference
 into examples that use that particular module.
 
 In that case within your Sphinx ``conf.py`` file you need to add to their
@@ -57,7 +57,7 @@ configuration dictionary:
 .. code-block:: python
 
     sphinxgallery_conf = {
-        # path where to store your example linker templat
+        # path where to store your example linker templates
         'mod_example_dir'     : 'modules/generated',
 
         # Your documented modules. You can use a string or a list of strings

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -23,8 +23,18 @@ Directory paths are relative to your ``conf.py`` location.
 Linking to external documentations
 ==================================
 
-Sphinx-Gallery enables you to hyperlink commands in your example scripts to the
-matching location in their online documentation . Have a look at this in action
+Sphinx-Gallery enables you to add hyperlinks in your example scripts so that
+you can link the used functions to their matching online documentation. As such
+code snippets within the gallery appear like this
+
+.. raw:: html
+
+    <div class="highlight-python"><div class="highlight"><pre>
+    <span class="n">y</span> <span class="o">=</span> <a href="http://docs.scipy.org/doc/numpy-1.9.1/reference/generated/numpy.sin.html#numpy.sin"><span class="n">np</span><span class="o">.</span><span class="n">sin</span></a><span class="p">(</span><span class="n">x</span><span class="p">)</span>
+    </pre></div>
+    </div>
+
+Have a look at this in full action
 in our example :ref:`example_plot_gallery_version.py`.
 
 To make this work in your documentation you need to include to the configuration

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -34,8 +34,8 @@ dictionary within your Sphinx ``conf.py`` file :
 
     sphinxgallery_conf = {
         'reference_url':  {
-                 # Modules you locally document use an empty string
-                'sphinxgallery': '',
+                 # Modules you locally document use a None
+                'sphinxgallery': None,
 
                 # External python modules use their documentation websites
                 'matplotlib': 'http://matplotlib.org',
@@ -65,7 +65,7 @@ configuration dictionary:
 
 The path you specified will get populated with the links to examples using your
 module and their methods. Then within your sphinx documentation files you
-include this lines to include this links::
+include these lines to include these links::
 
     .. include:: modules/generated/numpy.linspace.examples
     .. raw:: html

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -13,8 +13,8 @@ Within your Sphinx ``conf.py`` file you need to add a configuration dictionary:
 .. code-block:: python
 
     sphinxgallery_conf = {
-        'root_dir'          : '../examples',              # path to your examples scripts
-        'examples_gallery'  : 'auto_examples'}            # path where to save gallery generated examples
+        'examples_dir' : '../examples',              # path to your examples scripts
+        'gallery_dir'  : 'auto_examples'}            # path where to save gallery generated examples
 
 
 Directory paths are relative to your ``conf.py`` location.
@@ -58,9 +58,10 @@ configuration dictionary:
 
     sphinxgallery_conf = {
         # path where to store your example linker templat
-        'mod_generated'     : 'modules/generated',
+        'mod_example_dir'     : 'modules/generated',
+
         # Your documented modules. You can use a string or a list of strings
-        'doc_module'        : ('sphinxgallery', 'numpy')}
+        'doc_module'          : ('sphinxgallery', 'numpy')}
 
 The path you specified will get populated with the links to examples using your
 module and their methods. Then within your sphinx documentation files you

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -271,5 +271,9 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'http://docs.python.org/': None}
 
-sphinxgallery_conf = {'doc_module' : ('sphinxgallery', 'numpy'),
-                      'reference_url': {'sphinxgallery' : ''}}
+sphinxgallery_conf = {'doc_module': ('sphinxgallery', 'numpy'),
+                      'reference_url': {
+        'sphinxgallery': '',
+        'matplotlib': 'http://matplotlib.org',
+        'numpy': 'http://docs.scipy.org/doc/numpy-1.9.1'},
+    }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -271,4 +271,5 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'http://docs.python.org/': None}
 
-sphinxgallery_conf = {'doc_module' : 'numpy'}
+sphinxgallery_conf = {'doc_module' : ('sphinxgallery', 'numpy'),
+                      'reference_url': {'sphinxgallery' : ''}}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -273,7 +273,7 @@ intersphinx_mapping = {'http://docs.python.org/': None}
 
 sphinxgallery_conf = {'doc_module': ('sphinxgallery', 'numpy'),
                       'reference_url': {
-        'sphinxgallery': '',
+        'sphinxgallery': None,
         'matplotlib': 'http://matplotlib.org',
         'numpy': 'http://docs.scipy.org/doc/numpy-1.9.1'},
     }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -110,6 +110,9 @@ pygments_style = 'sphinx'
 # a list of builtin themes.
 html_theme = 'default'
 
+def setup(app):
+    app.add_stylesheet('theme_override.css')
+
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,13 +11,18 @@ It is extracted from the scikit-learn project and aims to be an
 independent general purpose extension.
 
 Contents:
+---------
 
 .. toctree::
    :maxdepth: 2
 
    getting_started
    advanced_configuration
-   auto_examples/index
+   reference
+
+Sphinx-Gallery Show: :ref:`examples-index`
+''''''''''''''''''''''''''''''''''''''''''
+
 
 
 Indices and tables

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -1,0 +1,10 @@
+========================
+Sphinx-Gallery Reference
+========================
+
+
+.. automodule:: sphinxgallery
+    :members:
+
+.. autodata:: sphinxgallery.__version__
+    :annotation: Sphinx Gallery current version

--- a/examples/plot_gallery_version.py
+++ b/examples/plot_gallery_version.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""
+===========================
+Sphinx-Gallery introduction
+===========================
+
+A cartoon like plot to present Sphinx-Gallery using itself to display its
+version.
+"""
+
+# Code source: Óscar Nájera
+# License: BSD 3 clause
+
+import numpy as np
+import matplotlib.pyplot as plt
+import sphinxgallery
+
+np.random.seed(32)
+def layers(n, m):
+    """
+    Return *n* random Gaussian mixtures, each of length *m*.
+    """
+    def bump(a):
+        x = 1 / (.1 + np.random.random())
+        y = 2 * np.random.random() - .3
+        z = 13 / (.1 + np.random.random())
+        for i in range(m):
+            w = (i / float(m) - y) * z
+            a[i] += x * np.exp(-w * w)
+    a = np.zeros((m, n))
+    for i in range(n):
+        for j in range(12):
+            bump(a[:, i])
+    return np.abs(a)
+
+with plt.xkcd():
+
+    fig = plt.figure()
+    plt.xticks([])
+    plt.yticks([])
+
+    plt.annotate(
+        'Introducing Sphinx-Gallery ' + sphinxgallery.__version__,
+        xy=(12, 4), arrowprops=dict(arrowstyle='->'), xytext=(15, -4))
+
+    d = layers(3, 100)
+    plt.stackplot(range(100), d.T, baseline='wiggle')
+
+plt.show()

--- a/examples/plot_strings.py
+++ b/examples/plot_strings.py
@@ -13,4 +13,4 @@ framed into a text area.
 # Code source: Óscar Nájera
 # License: BSD 3 clause
 
-print('This is a long test Output\n'*800)
+print('This is a long test Output\n' * 50)

--- a/sphinxgallery/docs_resolv.py
+++ b/sphinxgallery/docs_resolv.py
@@ -324,12 +324,16 @@ def embed_code_links(app, exception):
     gallery_conf = app.config.sphinxgallery_conf
     # Add resolvers for the packages for which we want to show links
     doc_resolvers = {}
-    doc_resolvers[gallery_conf['doc_module']] = SphinxDocLinkResolver(app.builder.outdir,
-                                                     relative=True)
 
-    for this_module, url in gallery_conf['resolver_urls'].items():
+    for this_module, url in gallery_conf['reference_url'].items():
         try:
-            doc_resolvers[this_module] = SphinxDocLinkResolver(url)
+            if url == '':
+                doc_resolvers[this_module] = SphinxDocLinkResolver(
+                                                            app.builder.outdir,
+                                                            relative=True)
+            else:
+                doc_resolvers[this_module] = SphinxDocLinkResolver(url)
+
         except HTTPError as e:
             print("The following HTTP Error has occurred:\n")
             print(e.code)

--- a/sphinxgallery/docs_resolv.py
+++ b/sphinxgallery/docs_resolv.py
@@ -345,21 +345,21 @@ def embed_code_links(app, exception):
                   "Error:\n".format(this_module))
             print(e.args)
 
-    example_dir = os.path.join(app.builder.srcdir, 'auto_examples')
-    html_example_dir = os.path.abspath(os.path.join(app.builder.outdir,
-                                                    'auto_examples'))
+    gallery_dir = os.path.join(app.builder.srcdir, gallery_conf['gallery_dir'])
+    html_gallery_dir = os.path.abspath(os.path.join(app.builder.outdir,
+                                                    gallery_conf['gallery_dir']))
 
     # patterns for replacement
     link_pattern = '<a href="%s">%s</a>'
     orig_pattern = '<span class="n">%s</span>'
     period = '<span class="o">.</span>'
 
-    for dirpath, _, filenames in os.walk(html_example_dir):
+    for dirpath, _, filenames in os.walk(html_gallery_dir):
         for fname in filenames:
             print('\tprocessing: %s' % fname)
-            full_fname = os.path.join(html_example_dir, dirpath, fname)
-            subpath = dirpath[len(html_example_dir) + 1:]
-            pickle_fname = os.path.join(example_dir, subpath,
+            full_fname = os.path.join(html_gallery_dir, dirpath, fname)
+            subpath = dirpath[len(html_gallery_dir) + 1:]
+            pickle_fname = os.path.join(gallery_dir, subpath,
                                         fname[:-5] + '_codeobj.pickle')
 
             if os.path.exists(pickle_fname):

--- a/sphinxgallery/docs_resolv.py
+++ b/sphinxgallery/docs_resolv.py
@@ -327,7 +327,7 @@ def embed_code_links(app, exception):
 
     for this_module, url in gallery_conf['reference_url'].items():
         try:
-            if url == '':
+            if url is None:
                 doc_resolvers[this_module] = SphinxDocLinkResolver(
                                                             app.builder.outdir,
                                                             relative=True)

--- a/sphinxgallery/gen_gallery.py
+++ b/sphinxgallery/gen_gallery.py
@@ -19,7 +19,9 @@ def generate_gallery_rst(app):
     if not plot_gallery:
         return
 
-    gallery_conf.update(app.config.sphinxgallery_conf)
+    tmp_conf = app.config.sphinxgallery_conf
+    gallery_conf['reference_url'].update(tmp_conf.pop('reference_url'))
+    gallery_conf.update(tmp_conf)
 
     # this assures I can call the config in other places
     app.config.sphinxgallery_conf = gallery_conf
@@ -38,8 +40,8 @@ def generate_gallery_rst(app):
 
 .. _examples-index:
 
-Examples
-========
+Gallery of Examples
+===================
 
 """)
     # Here we don't use an os.walk, but we recurse only twice: flat is
@@ -56,8 +58,8 @@ gallery_conf = {
     'root_dir'          : '../examples',
     'examples_gallery'  : 'auto_examples',
     'mod_generated'     : 'modules/generated',
-    'doc_module'        : 'sphinxgallery',
-    'resolver_urls'     : {
+    'doc_module'        : (),
+    'reference_url' : {
         'matplotlib': 'http://matplotlib.org',
         'numpy': 'http://docs.scipy.org/doc/numpy-1.9.1',
         'scipy': 'http://docs.scipy.org/doc/scipy-0.15.1/reference'}

--- a/sphinxgallery/gen_gallery.py
+++ b/sphinxgallery/gen_gallery.py
@@ -8,8 +8,8 @@ from sphinxgallery.docs_resolv import embed_code_links
 
 
 def generate_gallery_rst(app):
-    """ Generate the list of examples, as well as the contents of
-        examples.
+    """Starts the gallery configuration and recursively scans the examples
+    directory in order to populate the examples gallery
     """
     try:
         plot_gallery = eval(app.builder.config.plot_gallery)
@@ -24,11 +24,11 @@ def generate_gallery_rst(app):
     # this assures I can call the config in other places
     app.config.sphinxgallery_conf = gallery_conf
 
-    root_dir = os.path.join(app.builder.srcdir, gallery_conf['root_dir'])
-    gallery_dir = os.path.join(app.builder.srcdir, gallery_conf['examples_gallery'])
-    generated_dir = os.path.join(app.builder.srcdir, gallery_conf['mod_generated'])
+    examples_dir = os.path.join(app.builder.srcdir, gallery_conf['examples_dir'])
+    gallery_dir = os.path.join(app.builder.srcdir, gallery_conf['gallery_dir'])
+    mod_examples_dir = os.path.join(app.builder.srcdir, gallery_conf['mod_example_dir'])
 
-    for workdir in [root_dir, gallery_dir, generated_dir]:
+    for workdir in [examples_dir, gallery_dir, mod_examples_dir]:
         if not os.path.exists(workdir):
             os.makedirs(workdir)
 
@@ -45,19 +45,19 @@ Gallery of Examples
     # Here we don't use an os.walk, but we recurse only twice: flat is
     # better than nested.
     seen_backrefs = set()
-    generate_dir_rst('.', fhindex, root_dir, gallery_dir, gallery_conf, plot_gallery, seen_backrefs)
-    for directory in sorted(os.listdir(root_dir)):
-        if os.path.isdir(os.path.join(root_dir, directory)):
-            generate_dir_rst(directory, fhindex, root_dir, gallery_dir, gallery_conf, plot_gallery, seen_backrefs)
+    generate_dir_rst('.', fhindex, examples_dir, gallery_dir, gallery_conf, plot_gallery, seen_backrefs)
+    for directory in sorted(os.listdir(examples_dir)):
+        if os.path.isdir(os.path.join(examples_dir, directory)):
+            generate_dir_rst(directory, fhindex, examples_dir, gallery_dir, gallery_conf, plot_gallery, seen_backrefs)
     fhindex.flush()
 
 
 gallery_conf = {
-    'root_dir'          : '../examples',
-    'examples_gallery'  : 'auto_examples',
-    'mod_generated'     : 'modules/generated',
-    'doc_module'        : (),
-    'reference_url'     : {},
+    'examples_dir'   : '../examples',
+    'gallery_dir'    : 'auto_examples',
+    'mod_example_dir': 'modules/generated',
+    'doc_module'     : (),
+    'reference_url'  : {},
 }
 
 def setup(app):

--- a/sphinxgallery/gen_gallery.py
+++ b/sphinxgallery/gen_gallery.py
@@ -19,9 +19,7 @@ def generate_gallery_rst(app):
     if not plot_gallery:
         return
 
-    tmp_conf = app.config.sphinxgallery_conf
-    gallery_conf['reference_url'].update(tmp_conf.pop('reference_url'))
-    gallery_conf.update(tmp_conf)
+    gallery_conf.update(app.config.sphinxgallery_conf)
 
     # this assures I can call the config in other places
     app.config.sphinxgallery_conf = gallery_conf
@@ -59,11 +57,8 @@ gallery_conf = {
     'examples_gallery'  : 'auto_examples',
     'mod_generated'     : 'modules/generated',
     'doc_module'        : (),
-    'reference_url' : {
-        'matplotlib': 'http://matplotlib.org',
-        'numpy': 'http://docs.scipy.org/doc/numpy-1.9.1',
-        'scipy': 'http://docs.scipy.org/doc/scipy-0.15.1/reference'}
-    }
+    'reference_url'     : {},
+}
 
 def setup(app):
     app.add_config_value('plot_gallery', True, 'html')

--- a/sphinxgallery/gen_rst.py
+++ b/sphinxgallery/gen_rst.py
@@ -442,7 +442,7 @@ def identify_names(code):
 def generate_file_rst(fname, target_dir, src_dir, gallery_conf, plot_gallery):
     """ Generate the rst file for a given example.
 
-    Returns the set of sklearn functions/classes imported in the example.
+    Returns the set of functions/classes imported in the example.
     """
     base_image_name = os.path.splitext(fname)[0]
     image_fname = '%s_%%03d.png' % base_image_name

--- a/sphinxgallery/gen_rst.py
+++ b/sphinxgallery/gen_rst.py
@@ -244,15 +244,15 @@ def _thumbnail_div(subdir, full_dir, fname, snippet):
     return out
 
 
-def generate_dir_rst(directory, fhindex, root_dir, example_dir, gallery_conf, plot_gallery, seen_backrefs):
+def generate_dir_rst(directory, fhindex, examples_dir, gallery_dir, gallery_conf, plot_gallery, seen_backrefs):
     """ Generate the rst file for an example directory.
     """
     if not directory == '.':
-        src_dir = os.path.join(root_dir, directory)
-        target_dir = os.path.join(example_dir, directory)
+        src_dir = os.path.join(examples_dir, directory)
+        target_dir = os.path.join(gallery_dir, directory)
     else:
-        src_dir = root_dir
-        target_dir = example_dir
+        src_dir = examples_dir
+        target_dir = gallery_dir
     if not os.path.exists(os.path.join(src_dir, 'README.txt')):
         print( 80 * '_')
         print ('Example directory %s does not have a README.txt file' %
@@ -274,7 +274,7 @@ def generate_dir_rst(directory, fhindex, root_dir, example_dir, gallery_conf, pl
                                      src_dir)
     for fname in sorted_listdir:
         if fname.endswith('py'):
-            backrefs = generate_file_rst(fname, target_dir, src_dir, example_dir, gallery_conf, plot_gallery)
+            backrefs = generate_file_rst(fname, target_dir, src_dir, gallery_conf, plot_gallery)
             new_fname = os.path.join(src_dir, fname)
             _, snippet, _ = extract_docstring(new_fname, True)
             fhindex.write(_thumbnail_div(directory, directory, fname, snippet))
@@ -287,7 +287,7 @@ def generate_dir_rst(directory, fhindex, root_dir, example_dir, gallery_conf, pl
 
 """ % (directory, fname[:-3]))
             for backref in backrefs:
-                include_path = os.path.join(gallery_conf['mod_generated'], '%s.examples' % backref)
+                include_path = os.path.join(gallery_conf['mod_example_dir'], '%s.examples' % backref)
                 seen = backref in seen_backrefs
                 with open(include_path, 'a' if seen else 'w') as ex_file:
                     if not seen:
@@ -297,7 +297,7 @@ def generate_dir_rst(directory, fhindex, root_dir, example_dir, gallery_conf, pl
                         print('-----------------%s--' % ('-' * len(backref)),
                               file=ex_file)
                         print(file=ex_file)
-                    rel_dir = os.path.join(gallery_conf['examples_gallery'], directory)
+                    rel_dir = os.path.join(gallery_conf['gallery_dir'], directory)
                     ex_file.write(_thumbnail_div(directory, rel_dir, fname, snippet))
                     seen_backrefs.add(backref)
 
@@ -439,7 +439,7 @@ def identify_names(code):
     return example_code_obj
 
 
-def generate_file_rst(fname, target_dir, src_dir, root_dir, gallery_conf, plot_gallery):
+def generate_file_rst(fname, target_dir, src_dir, gallery_conf, plot_gallery):
     """ Generate the rst file for a given example.
 
     Returns the set of sklearn functions/classes imported in the example.
@@ -601,5 +601,3 @@ def generate_file_rst(fname, target_dir, src_dir, root_dir, gallery_conf, plot_g
                    for entry in example_code_obj.values()
                    if entry['module'].startswith(gallery_conf['doc_module']))
     return backrefs
-
-


### PR DESCRIPTION
This pull request includes my proposal for the names in the configuration/setup of the sphinx-gallery.
* I decided to keep the configuration in a dictionary, and a nested dictionary in it for the reference urls of other documentations. Keywords refering to directories have the _dir suffix.
* Keyword `doc_module` is a string or list of stings containing the local modules for which examples are provided, and one later wants to link when documenting modules.
example: http://sphinx-gallery-local.readthedocs.org/en/config/advanced_configuration.html#establishing-local-references-to-examples

* Keyword `reference_url` is a new dictionary containing module name and url to online documentation of that same module. This is the one that allows to put the links in each command of the python scripts presented in the gallery to the online reference 

The default configuration dictionary is stored in `gen_gallery.py` and the extension of it, used for the sphinx-gallery documentation is in the `conf.py`. The documentation has been extended to match the new setup.

This pull request is build at http://sphinx-gallery-local.readthedocs.org/en/config/
