### PR TITLE
Image clean

### DIFF
--- a/sphinxgallery/gen_gallery.py
+++ b/sphinxgallery/gen_gallery.py
@@ -46,7 +46,6 @@ def generate_gallery_rst(app):
     if not plot_gallery:
         return
 
-    dir(app.builder)
     build_image_dir = os.path.join(app.builder.outdir, '_images')
     clean_gallery_out(build_image_dir)
 

--- a/sphinxgallery/gen_gallery.py
+++ b/sphinxgallery/gen_gallery.py
@@ -7,6 +7,28 @@ from sphinxgallery.gen_rst import generate_dir_rst
 from sphinxgallery.docs_resolv import embed_code_links
 
 
+def clean_gallery_out(build_image_dir):
+    # Sphinx hack: sphinx copies generated images to the build directory
+    #  each time the docs are made.  If the desired image name already
+    #  exists, it appends a digit to prevent overwrites.  The problem is,
+    #  the directory is never cleared.  This means that each time you build
+    #  the docs, the number of images in the directory grows.
+    #
+    # This question has been asked on the sphinx development list, but there
+    #  was no response: http://osdir.com/ml/sphinx-dev/2011-02/msg00123.html
+    #
+    # The following is a hack that prevents this behavior by clearing the
+    #  image build directory each time the docs are built.  If sphinx
+    #  changes their layout between versions, this will not work (though
+    #  it should probably not cause a crash).  Tested successfully
+    #  on Sphinx 1.0.7
+    if os.path.exists(build_image_dir):
+        filelist = os.listdir(build_image_dir)
+        for filename in filelist:
+            if filename.startswith('sphx_glr') and filename.endswith('png'):
+                os.remove(os.path.join(build_image_dir, filename))
+
+
 def generate_gallery_rst(app):
     """Starts the gallery configuration and recursively scans the examples
     directory in order to populate the examples gallery
@@ -23,6 +45,10 @@ def generate_gallery_rst(app):
 
     if not plot_gallery:
         return
+
+    dir(app.builder)
+    build_image_dir = os.path.join(app.builder.outdir, '_images')
+    clean_gallery_out(build_image_dir)
 
     examples_dir = os.path.join(app.builder.srcdir, gallery_conf['examples_dir'])
     gallery_dir = os.path.join(app.builder.srcdir, gallery_conf['gallery_dir'])
@@ -69,26 +95,6 @@ def setup(app):
 
     app.connect('build-finished', embed_code_links)
 
-    # Sphinx hack: sphinx copies generated images to the build directory
-    #  each time the docs are made.  If the desired image name already
-    #  exists, it appends a digit to prevent overwrites.  The problem is,
-    #  the directory is never cleared.  This means that each time you build
-    #  the docs, the number of images in the directory grows.
-    #
-    # This question has been asked on the sphinx development list, but there
-    #  was no response: http://osdir.com/ml/sphinx-dev/2011-02/msg00123.html
-    #
-    # The following is a hack that prevents this behavior by clearing the
-    #  image build directory each time the docs are built.  If sphinx
-    #  changes their layout between versions, this will not work (though
-    #  it should probably not cause a crash).  Tested successfully
-    #  on Sphinx 1.0.7
-    build_image_dir = '_build/html/_images'
-    if os.path.exists(build_image_dir):
-        filelist = os.listdir(build_image_dir)
-        for filename in filelist:
-            if filename.endswith('png'):
-                os.remove(os.path.join(build_image_dir, filename))
 
 def setup_module():
     # HACK: Stop nosetests running setup() above

--- a/sphinxgallery/gen_rst.py
+++ b/sphinxgallery/gen_rst.py
@@ -214,7 +214,8 @@ def line_count_sort(file_list, target_dir):
 
 def _thumbnail_div(subdir, full_dir, fname, snippet):
     """Generates RST to place a thumbnail in a gallery"""
-    thumb = os.path.join(full_dir, 'images', 'thumb', fname[:-3] + '.png')
+    thumb = os.path.join(full_dir, 'images', 'thumb',
+                         'sphx_glr_%s.png' % fname[:-3])
     link_name = os.path.join(full_dir, fname).replace(os.path.sep, '_')
     ref_name = os.path.join(subdir, fname).replace(os.path.sep, '_')
     if ref_name.startswith('._'):

--- a/sphinxgallery/gen_rst.py
+++ b/sphinxgallery/gen_rst.py
@@ -445,7 +445,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf, plot_gallery):
     Returns the set of functions/classes imported in the example.
     """
     base_image_name = os.path.splitext(fname)[0]
-    image_fname = '%s_%%03d.png' % base_image_name
+    image_fname = 'sphx_glr_%s_%%03d.png' % base_image_name
 
     this_template = rst_template
     last_dir = os.path.split(src_dir)[-1]
@@ -473,7 +473,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf, plot_gallery):
                                'stdout_%s.txt' % base_image_name)
     time_path = os.path.join(image_dir,
                              'time_%s.txt' % base_image_name)
-    thumb_file = os.path.join(thumb_dir, base_image_name + '.png')
+    thumb_file = os.path.join(thumb_dir, 'sphx_glr_%s.png' % base_image_name)
     time_elapsed = 0
     if plot_gallery and fname.startswith('plot'):
         # generate the plot as png image if file name


### PR DESCRIPTION
This change was first motivated by #29 to remove the explicit use of the _build directory path in any instruction in sphinx-gallery(PR #30 also related).

The hack in sphinx-gallery that cleans the images is now more specific as it now scans for png images with the sphx_glr prefix that should be only created by us. Is solves the competition with the maplotlib plot directive #8 at least in my known case.  