### PR TITLE
Test over the thumbnail generator

### DIFF
--- a/sphinxgallery/backreferences.py
+++ b/sphinxgallery/backreferences.py
@@ -131,7 +131,7 @@ THUMBNAIL_TEMPLATE = """
 
 .. figure:: /{thumbnail}
 
-    :ref:`example_{file_name}`
+    :ref:`example_{filename}`
 
 .. raw:: html
 
@@ -149,7 +149,7 @@ def _thumbnail_div(full_dir, fname, snippet):
 
 
     return THUMBNAIL_TEMPLATE.format(snippet=snippet,
-                                     thumbnail=thumb, file_name=ref_name)
+                                     thumbnail=thumb, filename=ref_name)
 
 
 def write_backreferences(seen_backrefs, gallery_conf,

--- a/sphinxgallery/backreferences.py
+++ b/sphinxgallery/backreferences.py
@@ -124,6 +124,21 @@ def scan_used_functions(example_file, gallery_conf):
     return backrefs
 
 
+THUMBNAIL_TEMPLATE = """
+.. raw:: html
+
+    <div class="sphx-glr-thumbContainer" tooltip="{snippet}">
+
+.. figure:: /{thumbnail}
+
+    :ref:`example_{file_name}`
+
+.. raw:: html
+
+    </div>
+"""
+
+
 def _thumbnail_div(full_dir, fname, snippet):
     """Generates RST to place a thumbnail in a gallery"""
     thumb = os.path.join(full_dir, 'images', 'thumb',
@@ -132,21 +147,9 @@ def _thumbnail_div(full_dir, fname, snippet):
     if ref_name.startswith('._'):
         ref_name = ref_name[2:]
 
-    out = """
-.. raw:: html
 
-    <div class="sphx-glr-thumbContainer" tooltip="{}">
-
-.. figure:: /{}
-
-    :ref:`example_{}`
-
-.. raw:: html
-
-    </div>
-""".format(snippet, thumb, ref_name)
-
-    return out
+    return THUMBNAIL_TEMPLATE.format(snippet=snippet,
+                                     thumbnail=thumb, file_name=ref_name)
 
 
 def write_backreferences(seen_backrefs, gallery_conf,

--- a/sphinxgallery/backreferences.py
+++ b/sphinxgallery/backreferences.py
@@ -131,7 +131,7 @@ THUMBNAIL_TEMPLATE = """
 
 .. figure:: /{thumbnail}
 
-    :ref:`example_{filename}`
+    :ref:`example_{ref_name}`
 
 .. raw:: html
 
@@ -149,7 +149,7 @@ def _thumbnail_div(full_dir, fname, snippet):
 
 
     return THUMBNAIL_TEMPLATE.format(snippet=snippet,
-                                     thumbnail=thumb, filename=ref_name)
+                                     thumbnail=thumb, ref_name=ref_name)
 
 
 def write_backreferences(seen_backrefs, gallery_conf,

--- a/sphinxgallery/tests/test_backreferences.py
+++ b/sphinxgallery/tests/test_backreferences.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Author: Óscar Nájera
+# License: 3-clause BSD
+"""
+Testing the rst files generator
+"""
+from __future__ import division, absolute_import, print_function
+import sphinxgallery.backreferences as sg
+from nose.tools import assert_equals
+
+
+def test_thumbnail_div():
+    """Test if the thumbnail div generates the correct string"""
+
+    html_div = sg._thumbnail_div('fake_dir', 'test_file.py', 'test formating')
+
+    reference = """
+.. raw:: html
+
+    <div class="sphx-glr-thumbContainer" tooltip="test formating">
+
+.. figure:: /fake_dir/images/thumb/sphx_glr_test_file_thumb.png
+
+    :ref:`example_fake_dir_test_file.py`
+
+.. raw:: html
+
+    </div>
+"""
+
+    assert_equals(html_div, reference)


### PR DESCRIPTION
Recently I discovered that in python 2.6 one needs to specify(at least with positional arguments) which variable needs to be replaced in a string using the format method. So this PR specifies the thumbnail template string with the replaced variable names. It additional provides a simple test.

Side question. Do we have to support python 2.6. Scikit-learn does support it, but will users be building the docs in python 2.6?