### PR TITLE
Fix gen_rst.split_code_and_text_blocks with comment right after the docstring

### DIFF
--- a/sphinxgallery/tests/reference_parse.txt
+++ b/sphinxgallery/tests/reference_parse.txt
@@ -17,7 +17,6 @@
  ('text',
   'New lines can be included in you block comments and the parser\nis capable of retaining this significant whitespace to work with sphinx\n\nSo the reStructuredText headers survive\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n'),
  ('code', "\n\nprint('one')\n\nprint('two')\n"),
- ('text', '\n'),
  ('code', 'B = 1\n\n'),
  ('text',
   "End comments\n\nThat's all folks !\n\n.. literalinclude:: plot_parse.py\n\n\n")]

--- a/sphinxgallery/tests/test_gen_rst.py
+++ b/sphinxgallery/tests/test_gen_rst.py
@@ -32,6 +32,28 @@ def test_bug_cases_of_notebook_syntax():
         assert_equal(blocks, ref_blocks)
 
 
+def test_direct_comment_after_docstring():
+    # For more details see
+    # https://github.com/sphinx-gallery/sphinx-gallery/pull/49
+    with tempfile.NamedTemporaryFile('w') as f:
+        f.write('\n'.join(['"Docstring"',
+                           '# and now comes the module code',
+                           '# with a second line of comment',
+                           'x, y = 1, 2',
+                           '']))
+        f.flush()
+
+        result = sg.split_code_and_text_blocks(f.name)
+
+    expected_result = [
+        ('text', 'Docstring'),
+        ('code', '\n'.join(['# and now comes the module code',
+                            '# with a second line of comment',
+                            'x, y = 1, 2',
+                            '']))]
+    assert_equal(result, expected_result)
+
+
 def test_codestr2rst():
     """Test the correct translation of a code block into rst"""
     output = sg.codestr2rst('print("hello world")')


### PR DESCRIPTION
plus test. Also not adding text block if it contains only whitespace hence the modification of reference_parse.txt.

Fix #49.