### PR TITLE
[MRG+1] BUG fix don't show example thumbnails in latex docs

### DIFF
--- a/sphinxgallery/backreferences.py
+++ b/sphinxgallery/backreferences.py
@@ -128,24 +128,32 @@ THUMBNAIL_TEMPLATE = """
 
     <div class="sphx-glr-thumbContainer" tooltip="{snippet}">
 
-.. figure:: /{thumbnail}
+.. only:: html
 
-    :ref:`sphx_glr_{ref_name}`
+    .. figure:: /{thumbnail}
+
+        :ref:`sphx_glr_{ref_name}`
 
 .. raw:: html
 
     </div>
 """
 
+BACKREF_THUMBNAIL_TEMPLATE = THUMBNAIL_TEMPLATE + """
+.. only:: not html
 
-def _thumbnail_div(full_dir, fname, snippet):
+    * :ref:`sphx_glr_{ref_name}`
+"""
+
+
+def _thumbnail_div(full_dir, fname, snippet, is_backref=False):
     """Generates RST to place a thumbnail in a gallery"""
     thumb = os.path.join(full_dir, 'images', 'thumb',
                          'sphx_glr_%s_thumb.png' % fname[:-3])
     ref_name = os.path.join(full_dir, fname).replace(os.path.sep, '_')
 
-    return THUMBNAIL_TEMPLATE.format(snippet=snippet,
-                                     thumbnail=thumb, ref_name=ref_name)
+    template = BACKREF_THUMBNAIL_TEMPLATE if is_backref else THUMBNAIL_TEMPLATE
+    return template.format(snippet=snippet, thumbnail=thumb, ref_name=ref_name)
 
 
 def write_backreferences(seen_backrefs, gallery_conf,
@@ -163,5 +171,6 @@ def write_backreferences(seen_backrefs, gallery_conf,
                 heading = 'Examples using ``%s``' % backref
                 ex_file.write(heading + '\n')
                 ex_file.write('-' * len(heading) + '\n')
-            ex_file.write(_thumbnail_div(target_dir, fname, snippet))
+            ex_file.write(_thumbnail_div(target_dir, fname, snippet,
+                                         is_backref=True))
             seen_backrefs.add(backref)

--- a/sphinxgallery/tests/test_backreferences.py
+++ b/sphinxgallery/tests/test_backreferences.py
@@ -19,13 +19,44 @@ def test_thumbnail_div():
 
     <div class="sphx-glr-thumbContainer" tooltip="test formating">
 
-.. figure:: /fake_dir/images/thumb/sphx_glr_test_file_thumb.png
+.. only:: html
 
-    :ref:`sphx_glr_fake_dir_test_file.py`
+    .. figure:: /fake_dir/images/thumb/sphx_glr_test_file_thumb.png
+
+        :ref:`sphx_glr_fake_dir_test_file.py`
 
 .. raw:: html
 
     </div>
+"""
+
+    assert_equal(html_div, reference)
+
+
+def test_backref_thumbnail_div():
+    """Test if the thumbnail div generates the correct string"""
+
+    html_div = sg._thumbnail_div('fake_dir', 'test_file.py', 'test formating',
+                                 is_backref=True)
+
+    reference = """
+.. raw:: html
+
+    <div class="sphx-glr-thumbContainer" tooltip="test formating">
+
+.. only:: html
+
+    .. figure:: /fake_dir/images/thumb/sphx_glr_test_file_thumb.png
+
+        :ref:`sphx_glr_fake_dir_test_file.py`
+
+.. raw:: html
+
+    </div>
+
+.. only:: not html
+
+    * :ref:`sphx_glr_fake_dir_test_file.py`
 """
 
     assert_equal(html_div, reference)


### PR DESCRIPTION
In the LaTeX builds of scikit-learn docs, we land up with (gallery) thumbnails showing immediately before examples in which the image is shown again. The thumbnails should not be shown in the latex docs.

While the API-to-example backreferences are useful in PDF too, there the images bloat everything (they are quite large), and are confusing because they float (not inline). Instead of images in the LaTeX, there should just be a list of links to examples... or the images should be smaller than they're showing in LaTeX.