### PR TITLE
[MRG+1] IPython notebook parser

### DIFF
--- a/examples/sin_func/plot_sin.py
+++ b/examples/sin_func/plot_sin.py
@@ -14,6 +14,9 @@ it corresponds mathematically to the function:
 
     x \\rightarrow \\sin(x)
 
+Here the function :math:`\\sin` is evaluated at each point the variable
+:math:`x` is defined.
+
 Note that ``sphinx-gallery`` automatically creates labels for each example from
 its filename. You can thus refer to it from any part of the documentation,
 including from other examples, as here

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ matplotlib
 pillow
 sphinx
 nose
-nbformat

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 pillow
 sphinx
 nose
+nbformat

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -66,6 +66,7 @@ except ImportError:
 
 from . import glr_path_static
 from .backreferences import write_backreferences, _thumbnail_div
+from .notebook import notebook_file
 
 try:
     basestring
@@ -97,7 +98,10 @@ CODE_DOWNLOAD = """**Total running time of the script:**
 ({0:.0f} minutes {1:.3f} seconds)\n\n
 \n.. container:: sphx-glr-download
 
-    **Download Python source code:** :download:`{2} <{2}>`\n"""
+    **Download Python source code:** :download:`{2} <{2}>`\n
+\n.. container:: sphx-glr-download
+
+    **Download IPython notebook:** :download:`{3} <{3}>`\n"""
 
 # The following strings are used when we have several pictures: we use
 # an html div tag that our CSS uses to turn the lists into horizontal
@@ -547,6 +551,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
 
     ref_fname = example_file.replace(os.path.sep, '_')
     example_rst = """\n\n.. _sphx_glr_{0}:\n\n""".format(ref_fname)
+    example_nb = notebook_file(fname, target_dir)
 
     filename_pattern = gallery_conf.get('filename_pattern')
     if re.search(filename_pattern, src_file):
@@ -571,6 +576,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
                                                                gallery_conf)
 
                 time_elapsed += rtime
+                example_nb.add_code(bcontent)
 
                 if is_example_notebook_like:
                     example_rst += codestr2rst(bcontent) + '\n'
@@ -581,6 +587,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
 
             else:
                 example_rst += text2string(bcontent) + '\n'
+                example_nb.add_markdown(bcontent)
     else:
         convert_func = dict(code=codestr2rst, text=text2string)
         for blabel, bcontent in script_blocks:
@@ -589,7 +596,9 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
     save_thumbnail(image_path, base_image_name, gallery_conf)
 
     time_m, time_s = divmod(time_elapsed, 60)
+    example_nb.save_file()
     with open(os.path.join(target_dir, base_image_name + '.rst'), 'w') as f:
-        example_rst += CODE_DOWNLOAD.format(time_m, time_s, fname)
+        example_rst += CODE_DOWNLOAD.format(time_m, time_s, fname, example_nb.file_name)
         f.write(example_rst)
+
     return amount_of_code

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -587,7 +587,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
 
             else:
                 example_rst += text2string(bcontent) + '\n'
-                example_nb.add_markdown_cell(bcontent)
+                example_nb.add_markdown_cell(text2string(bcontent))
     else:
         convert_func = dict(code=codestr2rst, text=text2string)
         for blabel, bcontent in script_blocks:

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -66,7 +66,7 @@ except ImportError:
 
 from . import glr_path_static
 from .backreferences import write_backreferences, _thumbnail_div
-from .notebook import notebook_file
+from .notebook import Notebook
 
 try:
     basestring
@@ -551,7 +551,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
 
     ref_fname = example_file.replace(os.path.sep, '_')
     example_rst = """\n\n.. _sphx_glr_{0}:\n\n""".format(ref_fname)
-    example_nb = notebook_file(fname, target_dir)
+    example_nb = Notebook(fname, target_dir)
 
     filename_pattern = gallery_conf.get('filename_pattern')
     if re.search(filename_pattern, src_file):
@@ -576,7 +576,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
                                                                gallery_conf)
 
                 time_elapsed += rtime
-                example_nb.add_code(bcontent)
+                example_nb.add_code_cell(bcontent)
 
                 if is_example_notebook_like:
                     example_rst += codestr2rst(bcontent) + '\n'
@@ -587,7 +587,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
 
             else:
                 example_rst += text2string(bcontent) + '\n'
-                example_nb.add_markdown(bcontent)
+                example_nb.add_markdown_cell(bcontent)
     else:
         convert_func = dict(code=codestr2rst, text=text2string)
         for blabel, bcontent in script_blocks:
@@ -598,7 +598,8 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
     time_m, time_s = divmod(time_elapsed, 60)
     example_nb.save_file()
     with open(os.path.join(target_dir, base_image_name + '.rst'), 'w') as f:
-        example_rst += CODE_DOWNLOAD.format(time_m, time_s, fname, example_nb.file_name)
+        example_rst += CODE_DOWNLOAD.format(time_m, time_s, fname,
+                                            example_nb.file_name)
         f.write(example_rst)
 
     return amount_of_code

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -589,9 +589,13 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
                 example_rst += text2string(bcontent) + '\n'
                 example_nb.add_markdown_cell(text2string(bcontent))
     else:
-        convert_func = dict(code=codestr2rst, text=text2string)
         for blabel, bcontent in script_blocks:
-            example_rst += convert_func[blabel](bcontent) + '\n'
+            if blabel == 'code':
+                example_rst += codestr2rst(bcontent) + '\n'
+                example_nb.add_code_cell(bcontent)
+            else:
+                example_rst += bcontent + '\n'
+                example_nb.add_markdown_cell(text2string(bcontent))
 
     save_thumbnail(image_path, base_image_name, gallery_conf)
 

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -6,6 +6,7 @@ Parser for Jupyter notebooks
 
 from __future__ import division, absolute_import, print_function
 import nbformat
+import os
 import warnings
 
 notebook_skeleton = {
@@ -35,8 +36,9 @@ notebook_skeleton = {
 
 
 class notebook_file(object):
-    def __init__(self, nb_file_name):
-        self.file_name = nb_file_name
+    def __init__(self, file_name, target_dir):
+        self.file_name = file_name.replace('.py', '.ipynb')
+        self.write_file = os.path.join(target_dir, self.file_name)
         self.work_notebook = nbformat.from_dict(notebook_skeleton)
         self.add_code("%matplotlib inline")
 
@@ -58,5 +60,5 @@ class notebook_file(object):
         })
         self.work_notebook["cells"].append(markdown_cell)
 
-    def write_file(self):
-        nbformat.write(self.work_notebook, self.file_name)
+    def save_file(self):
+        nbformat.write(self.work_notebook, self.write_file)

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -14,6 +14,7 @@ from __future__ import division, absolute_import, print_function
 from copy import deepcopy
 import json
 import os
+import re
 
 NOTEBOOK_SKELETON = {
     "cells": [],
@@ -88,6 +89,8 @@ class Notebook(object):
         code : str
             Cell content
         """
+        top_heading = re.compile(r'^=+$\s^([\w\s]+)^=+$', flags=re.M)
+        text = re.sub(top_heading, r'# \1', text)
         markdown_cell = {
             "cell_type": "markdown",
             "metadata": {},

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -91,6 +91,8 @@ class Notebook(object):
         """
         top_heading = re.compile(r'^=+$\s^([\w\s]+)^=+$', flags=re.M)
         text = re.sub(top_heading, r'# \1', text)
+        one_line_math = re.compile(r'^.. math::(.+)', flags=re.M)
+        text = re.sub(one_line_math, r'\\begin{equation}\n\1\n\end{equation}\n', text)
         markdown_cell = {
             "cell_type": "markdown",
             "metadata": {},

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -1,15 +1,20 @@
 # -*- coding: utf-8 -*-
 r"""
+============================
 Parser for Jupyter notebooks
+============================
+
+Class that holds the Ipython notebook information
+
 """
 # Author: Óscar Nájera
+# License: 3-clause BSD
 
 from __future__ import division, absolute_import, print_function
 import nbformat
 import os
-import warnings
 
-notebook_skeleton = {
+NOTEBOOK_SKELETON = {
     "cells": [],
     "metadata": {
         "kernelspec": {
@@ -35,14 +40,35 @@ notebook_skeleton = {
 }
 
 
-class notebook_file(object):
+class Notebook(object):
+    """Ipython notebook object
+
+    Constructs the file cell-by-cell and writes it at the end"""
+
     def __init__(self, file_name, target_dir):
+        """Declare the skeleton of the notebook
+
+        Parameters
+        ----------
+        file_name : str
+            original script file name, .py extension will be renamed
+        target_dir: str
+            directory where notebook file is to be saved
+        """
+
         self.file_name = file_name.replace('.py', '.ipynb')
         self.write_file = os.path.join(target_dir, self.file_name)
-        self.work_notebook = nbformat.from_dict(notebook_skeleton)
-        self.add_code("%matplotlib inline")
+        self.work_notebook = nbformat.from_dict(NOTEBOOK_SKELETON)
+        self.add_code_cell("%matplotlib inline")
 
-    def add_code(self, code):
+    def add_code_cell(self, code):
+        """Add a code cell to the notebook
+
+        Parameters
+        ----------
+        code : str
+            Cell content
+        """
         code_cell = nbformat.from_dict({
             "cell_type": "code",
             "execution_count": None,
@@ -52,7 +78,14 @@ class notebook_file(object):
             })
         self.work_notebook["cells"].append(code_cell)
 
-    def add_markdown(self, text):
+    def add_markdown_cell(self, text):
+        """Add a markdown cell to the notebook
+
+        Parameters
+        ----------
+        code : str
+            Cell content
+        """
         markdown_cell = nbformat.from_dict({
             "cell_type": "markdown",
             "metadata": {},
@@ -61,4 +94,5 @@ class notebook_file(object):
         self.work_notebook["cells"].append(markdown_cell)
 
     def save_file(self):
+        """Saves the notebook to a file"""
         nbformat.write(self.work_notebook, self.write_file)

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -69,12 +69,13 @@ class Notebook(object):
         code : str
             Cell content
         """
+
         code_cell = nbformat.from_dict({
             "cell_type": "code",
             "execution_count": None,
             "metadata": {"collapsed": False},
             "outputs": [],
-            "source": [code]
+            "source": [code.strip()]
             })
         self.work_notebook["cells"].append(code_cell)
 

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -22,21 +22,21 @@ def ipy_notebook_skeleton():
         "cells": [],
         "metadata": {
             "kernelspec": {
-                "display_name": "Python " + str(py_version.major),
+                "display_name": "Python " + str(py_version[0]),
                 "language": "python",
-                "name": "python" + str(py_version.major)
+                "name": "python" + str(py_version[0])
             },
             "language_info": {
                 "codemirror_mode": {
                     "name": "ipython",
-                    "version": py_version.major
+                    "version": py_version[0]
                 },
                 "file_extension": ".py",
                 "mimetype": "text/x-python",
                 "name": "python",
                 "nbconvert_exporter": "python",
-                "pygments_lexer": "ipython" + str(py_version.major),
-                "version": '{}.{}.{}'.format(*sys.version_info[:3])
+                "pygments_lexer": "ipython" + str(py_version[0]),
+                "version": '{0}.{1}.{2}'.format(*sys.version_info[:3])
             }
         },
         "nbformat": 4,

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+r"""
+Parser for Jupyter notebooks
+"""
+# Author: Óscar Nájera
+
+from __future__ import division, absolute_import, print_function
+import nbformat
+import warnings
+
+notebook_skeleton = {
+    "cells": [],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 2",
+            "language": "python2",
+            "name": "python2"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 2
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython2",
+            "version": "2.7.10"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 0
+}
+
+
+class notebook_file(object):
+    def __init__(self, nb_file_name):
+        self.file_name = nb_file_name
+        self.work_notebook = nbformat.from_dict(notebook_skeleton)
+        self.add_code("%matplotlib inline")
+
+    def add_code(self, code):
+        code_cell = nbformat.from_dict({
+            "cell_type": "code",
+            "execution_count": None,
+            "metadata": {"collapsed": False},
+            "outputs": [],
+            "source": [code]
+            })
+        self.work_notebook["cells"].append(code_cell)
+
+    def add_markdown(self, text):
+        markdown_cell = nbformat.from_dict({
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [text]
+        })
+        self.work_notebook["cells"].append(markdown_cell)
+
+    def write_file(self):
+        nbformat.write(self.work_notebook, self.file_name)

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -11,41 +11,45 @@ Class that holds the Ipython notebook information
 # License: 3-clause BSD
 
 from __future__ import division, absolute_import, print_function
-from copy import deepcopy
 import json
 import os
 import re
+import sys
 
-NOTEBOOK_SKELETON = {
-    "cells": [],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "Python 2",
-            "language": "python2",
-            "name": "python2"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 2
+def ipy_notebook_skeleton():
+    py_version = sys.version_info
+    notebook_skeleton = {
+        "cells": [],
+        "metadata": {
+            "kernelspec": {
+                "display_name": "Python " + str(py_version.major),
+                "language": "python",
+                "name": "python" + str(py_version.major)
             },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython2",
-            "version": "2.7.10"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 0
-}
+            "language_info": {
+                "codemirror_mode": {
+                    "name": "ipython",
+                    "version": py_version.major
+                },
+                "file_extension": ".py",
+                "mimetype": "text/x-python",
+                "name": "python",
+                "nbconvert_exporter": "python",
+                "pygments_lexer": "ipython" + str(py_version.major),
+                "version": '{}.{}.{}'.format(*sys.version_info[:3])
+            }
+        },
+        "nbformat": 4,
+        "nbformat_minor": 0
+    }
+    return notebook_skeleton
+
 
 def rst2md(text):
     """Converts the RST text from the examples docstrigs and comments
     into markdown text for the IPython notebooks"""
 
-    top_heading = re.compile(r'^=+$\s^([\w\s]+)^=+$', flags=re.M)
+    top_heading = re.compile(r'^=+$\s^([\w\s-]+)^=+$', flags=re.M)
     text = re.sub(top_heading, r'# \1', text)
 
     math_eq = re.compile(r'^\.\. math::((?:.+)?(?:\n+^  .+)*)', flags=re.M)
@@ -75,7 +79,7 @@ class Notebook(object):
 
         self.file_name = file_name.replace('.py', '.ipynb')
         self.write_file = os.path.join(target_dir, self.file_name)
-        self.work_notebook = deepcopy(NOTEBOOK_SKELETON)
+        self.work_notebook = ipy_notebook_skeleton()
         self.add_code_cell("%matplotlib inline")
 
     def add_code_cell(self, code):

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -41,6 +41,21 @@ NOTEBOOK_SKELETON = {
     "nbformat_minor": 0
 }
 
+def rst2md(text):
+    """Converts the RST text from the examples docstrigs and comments
+    into markdown text for the IPython notebooks"""
+
+    top_heading = re.compile(r'^=+$\s^([\w\s]+)^=+$', flags=re.M)
+    text = re.sub(top_heading, r'# \1', text)
+
+    math_eq = re.compile(r'^\.\. math::((?:.+)?(?:\n+^  .+)*)', flags=re.M)
+    text = re.sub(math_eq,
+                  lambda match: r'$${0}$$'.format(match.group(1).strip()),
+                  text)
+    inline_math = re.compile(r':math:`(.+)`')
+    text = re.sub(inline_math, r'$\1$', text)
+
+    return text
 
 class Notebook(object):
     """Ipython notebook object
@@ -89,14 +104,10 @@ class Notebook(object):
         code : str
             Cell content
         """
-        top_heading = re.compile(r'^=+$\s^([\w\s]+)^=+$', flags=re.M)
-        text = re.sub(top_heading, r'# \1', text)
-        one_line_math = re.compile(r'^.. math::(.+)', flags=re.M)
-        text = re.sub(one_line_math, r'\\begin{equation}\n\1\n\end{equation}\n', text)
         markdown_cell = {
             "cell_type": "markdown",
             "metadata": {},
-            "source": [text]
+            "source": [rst2md(text)]
         }
         self.work_notebook["cells"].append(markdown_cell)
 

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -17,6 +17,7 @@ import re
 import sys
 
 def ipy_notebook_skeleton():
+    """Returns a dictionary with the elements of a Jupyter notebook"""
     py_version = sys.version_info
     notebook_skeleton = {
         "cells": [],
@@ -60,6 +61,7 @@ def rst2md(text):
     text = re.sub(inline_math, r'$\1$', text)
 
     return text
+
 
 class Notebook(object):
     """Ipython notebook object

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -11,7 +11,8 @@ Class that holds the Ipython notebook information
 # License: 3-clause BSD
 
 from __future__ import division, absolute_import, print_function
-import nbformat
+from copy import deepcopy
+import json
 import os
 
 NOTEBOOK_SKELETON = {
@@ -58,7 +59,7 @@ class Notebook(object):
 
         self.file_name = file_name.replace('.py', '.ipynb')
         self.write_file = os.path.join(target_dir, self.file_name)
-        self.work_notebook = nbformat.from_dict(NOTEBOOK_SKELETON)
+        self.work_notebook = deepcopy(NOTEBOOK_SKELETON)
         self.add_code_cell("%matplotlib inline")
 
     def add_code_cell(self, code):
@@ -70,13 +71,13 @@ class Notebook(object):
             Cell content
         """
 
-        code_cell = nbformat.from_dict({
+        code_cell = {
             "cell_type": "code",
             "execution_count": None,
             "metadata": {"collapsed": False},
             "outputs": [],
             "source": [code.strip()]
-            })
+            }
         self.work_notebook["cells"].append(code_cell)
 
     def add_markdown_cell(self, text):
@@ -87,13 +88,14 @@ class Notebook(object):
         code : str
             Cell content
         """
-        markdown_cell = nbformat.from_dict({
+        markdown_cell = {
             "cell_type": "markdown",
             "metadata": {},
             "source": [text]
-        })
+        }
         self.work_notebook["cells"].append(markdown_cell)
 
     def save_file(self):
         """Saves the notebook to a file"""
-        nbformat.write(self.work_notebook, self.write_file)
+        with open(self.write_file, 'w') as out_nb:
+            json.dump(self.work_notebook, out_nb, indent=2)

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -11,6 +11,7 @@ import re
 import os
 from nose.tools import assert_equal, assert_false, assert_true
 import sphinx_gallery.gen_rst as sg
+import sphinx_gallery.notebook as gnb
 
 
 CONTENT = ['"""'
@@ -144,3 +145,21 @@ def test_pattern_matching():
                 assert_true(code_output in rst)
             else:
                 assert_false(code_output in rst)
+
+
+def test_ipy_notebook():
+    """Test that written ipython notebook file corresponds to python object"""
+    with tempfile.NamedTemporaryFile('w+') as f:
+        example_nb = gnb.Notebook(f.name, os.path.dirname(f.name))
+        blocks = sg.split_code_and_text_blocks('tutorials/plot_parse.py')
+
+        for blabel, bcontent in blocks:
+            if blabel == 'code':
+                example_nb.add_code_cell(bcontent)
+            else:
+                example_nb.add_markdown_cell(sg.text2string(bcontent))
+
+        example_nb.save_file()
+
+        f.flush()
+        assert_equal(gnb.json.load(f), example_nb.work_notebook)

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -6,12 +6,13 @@ Testing the rst files generator
 """
 from __future__ import division, absolute_import, print_function
 import ast
+import json
 import tempfile
 import re
 import os
 from nose.tools import assert_equal, assert_false, assert_true
 import sphinx_gallery.gen_rst as sg
-import sphinx_gallery.notebook as gnb
+from sphinx_gallery import notebook
 
 
 CONTENT = ['"""'
@@ -150,7 +151,7 @@ def test_pattern_matching():
 def test_ipy_notebook():
     """Test that written ipython notebook file corresponds to python object"""
     with tempfile.NamedTemporaryFile('w+') as f:
-        example_nb = gnb.Notebook(f.name, os.path.dirname(f.name))
+        example_nb = notebook.Notebook(f.name, os.path.dirname(f.name))
         blocks = sg.split_code_and_text_blocks('tutorials/plot_parse.py')
 
         for blabel, bcontent in blocks:
@@ -162,4 +163,4 @@ def test_ipy_notebook():
         example_nb.save_file()
 
         f.flush()
-        assert_equal(gnb.json.load(f), example_nb.work_notebook)
+        assert_equal(json.load(f), example_nb.work_notebook)


### PR DESCRIPTION
This PR addresses #39 
Using the block splitting of the scripts introduced for the notebook styled example. It is now simple to construct an IPython notebook cell by cell.
I now include as a dependency the nbformat which defines the cell nodes of the Ipython notebook.
Code is tidy in the notebooks. The RST text is understood by the Notebook quite fine.

Now that I see on travis python2.6 fails