### PR TITLE
Make Travis test the Mayavi aware version of the Gallery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
     - python-matplotlib
     - python-pip
     - python-coverage
+    - xvfb # For mayavi headless
 
 virtualenv:
         system_site_packages: true
@@ -38,6 +39,9 @@ install:
         if [ "$PYTHON_VERSION" == "2.7" ]; then
           conda install --yes --quiet mayavi;
           conda upgrade --yes --all;
+          # virtual framebuffer for mayavi rendering
+          Xvfb :1 -screen 0 1280x1024x24 -auth localhost &
+          export DISPLAY=:1
         fi;
       fi;
     - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,11 @@ install:
     - if [ "$DISTRIB" == "conda" ]; then
         conda create --yes -n testenv python=$PYTHON_VERSION pip numpy
         setuptools matplotlib pillow sphinx nose coverage;
+        source activate testenv;
         if [ "$PYTHON_VERSION" == "2.7" ]; then
           conda install --yes --quiet mayavi;
+          conda upgrade --yes --all;
         fi;
-        source activate testenv;
       fi;
     - pip install -r requirements.txt
     - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,8 @@ install:
         if [ "$PYTHON_VERSION" == "2.7" ]; then
           conda install --yes --quiet mayavi;
           conda upgrade --yes --all;
-          # virtual framebuffer for mayavi rendering
-          Xvfb :1 -screen 0 1280x1024x24 -auth localhost &
-          export DISPLAY=:1
+          Xvfb :1 -screen 0 1280x1024x24 -auth localhost &;
+          export DISPLAY=:1;
         fi;
       fi;
     - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
         if [ "$PYTHON_VERSION" == "2.7" ]; then
           conda install --yes --quiet mayavi;
           conda upgrade --yes --all;
+          conda upgrade --yes pyface;
         fi;
       fi;
     - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,12 +39,17 @@ install:
         if [ "$PYTHON_VERSION" == "2.7" ]; then
           conda install --yes --quiet mayavi;
           conda upgrade --yes --all;
-          Xvfb :1 -screen 0 1280x1024x24 -auth localhost &;
-          export DISPLAY=:1;
         fi;
       fi;
     - pip install -r requirements.txt
     - python setup.py install
+
+# To test the mayavi environmen follow the instructions at
+# https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 
 script:
     - if [ "$DISTRIB" == "ubuntu" ]; then python setup.py nosetests; fi


### PR DESCRIPTION
This closes #78 
The travis-ci test file is accordingly modified to provide a conda virtual environment where the mayavi example is successfully executed and the gallery is build.
I could not reproduce the notified bug, the mayavi example runs as is. Provided one has an X server or or a headless X server running (8d926fd specifically for travis-ci) and the correct pyface version that does not clashes with the sphinx and pygments version. For this case just an up to date version, which fortunately enough does not clash with mayavi either(Its conda version dependencies, require to this date an older version of pyface, but the new one does not seem to give problems, see 4f303c7)