### PR TITLE
Illustrated that links between gallery examples are possible.

### DIFF
--- a/examples/sin_func/plot_sin.py
+++ b/examples/sin_func/plot_sin.py
@@ -14,6 +14,10 @@ it corresponds mathematically to the function:
 
     x \\rightarrow \\sin(x)
 
+Note that ``sphinx-gallery`` automatically creates labels for each example from
+its filename. You can thus refer to it from any part of the documentation,
+including from other examples, as here
+
 .. seealso::
     :ref:`sphx_glr_auto_examples_sin_func_plot_sin_black_background.py` for a
     fancier plot

--- a/examples/sin_func/plot_sin.py
+++ b/examples/sin_func/plot_sin.py
@@ -14,6 +14,9 @@ it corresponds mathematically to the function:
 
     x \\rightarrow \\sin(x)
 
+.. seealso::
+    :ref:`sphx_glr_auto_examples_sin_func_plot_sin_black_background.py` for a
+    fancier plot
 """
 
 # Code source: Óscar Nájera


### PR DESCRIPTION
Links between gallery examples are a useful feature. I added such a link to one of the ``sin_func`` gallery examples. Maybe this feature could be documented in ``advanced_configuration.rst`` as well?