### PR TITLE
STYLE: CSS tweak

### DIFF
--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -67,15 +67,16 @@
 }
 .sphx-glr-script-out .highlight {
   background-color: transparent;
-}
-.sphx-glr-script-out pre {
-  background-color: #fafae2;
-  border: 0;
   margin-left: 2.5em;
   margin-top: -1.4em;
+}
+.sphx-glr-script-out .highlight pre {
+  background-color: #fafae2;
+  border: 0;
   max-height: 30em;
   overflow: auto;
   padding-left: 1ex;
+  margin: 0px;
   word-break: break-word;
 }
 .sphx-glr-script-out + p {

--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -78,10 +78,12 @@
   padding-left: 1ex;
   word-break: break-word;
 }
-.sphx-glr-script-out + p {
+blockquote.sphx-glr-script-out + p {
   margin-top: 1.8em;
 }
-
+blockquote.sphx-glr-script-out {
+  margin-left: 0pt;
+}
 .sphx-glr-download {
   background-color: #ffc;
   border: 1px solid #c2c22d;

--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -71,14 +71,14 @@
 .sphx-glr-script-out pre {
   background-color: #fafae2;
   border: 0;
-  margin-left: 1ex;
-  margin-top: 0;
+  margin-left: 2.5em;
+  margin-top: -1.4em;
   max-height: 30em;
   overflow: auto;
   padding-left: 1ex;
   word-break: break-word;
 }
-blockquote.sphx-glr-script-out + p {
+.sphx-glr-script-out + p {
   margin-top: 1.8em;
 }
 blockquote.sphx-glr-script-out {

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -120,9 +120,7 @@ SINGLE_IMAGE = """
 
 CODE_OUTPUT = """.. rst-class:: sphx-glr-script-out
 
- **Output**:\n
-
-  ::
+ Out::
 
 {0}\n"""
 


### PR DESCRIPTION
1. The matching on .sphx-glr-script-out+p is too general and could
   introduce space where we don't want it. I don't know why it was
   dropped in
   https://github.com/sphinx-gallery/sphinx-gallery/commit/3a8d9dcef6487f1d89434b2487c160cb37e430fa
   This seems an error too me.

2. I have made the space on the right of the output blocks disappear.
   While working on a course, I realized that it was distracting.