### PR TITLE
[MRG] MISC: add vertical space

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -581,7 +581,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
                     example_rst += code_output
                 else:
                     example_rst += code_output
-                    if code_output:
+                    if 'sphx-glr-script-out' in code_output:
                         # Add some vertical space after output
                         example_rst += "\n\n|\n\n"
                     example_rst += codestr2rst(bcontent) + '\n'

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -581,6 +581,9 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
                     example_rst += code_output
                 else:
                     example_rst += code_output
+                    if code_output:
+                        # Add some vertical space after output
+                        example_rst += "\n\n|\n\n"
                     example_rst += codestr2rst(bcontent) + '\n'
 
             else:


### PR DESCRIPTION
This commit adds vertical between the output of the script and the code
of the script, when there is only one output and it comes on top of the
code (non notebook behavior).

This is to avoid ugly-looking rendering like the following:

https://circle-artifacts.com/gh/nilearn/nilearn/1108/artifacts/0/home/ubuntu/nilearn/doc/_build/html/auto_examples/01_plotting/plot_overlay.html#sphx-glr-auto-examples-01-plotting-plot-overlay-py