### PR TITLE
[MRG+1] ENH: Better catch for import

### DIFF
--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -75,7 +75,7 @@ def get_short_module_name(module_name, obj_name):
         short_name = '.'.join(parts[:i])
         try:
             exec('from %s import %s' % (short_name, obj_name))
-        except ImportError:
+        except Exception:  # libraries can throw all sorts of exceptions...
             # get the last working module name
             short_name = '.'.join(parts[:(i + 1)])
             break


### PR DESCRIPTION
I had a problem with Mayavi throwing a `ValueError` during import when using sphinx-gallery. This makes the catch more general and thus safer.