### PR TITLE
[MRG+1]: Allow unicode in code and outputs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
         if [ "$PYTHON_VERSION" == "2.7" ]; then
           conda install --yes --quiet mayavi;
           conda upgrade --yes --all;
-          conda upgrade --yes pyface;
+          pip install --upgrade pyface;
         fi;
       fi;
     - pip install -r requirements.txt

--- a/examples/plot_quantum.py
+++ b/examples/plot_quantum.py
@@ -43,8 +43,8 @@ plt.show()
 print('pass')
 
 ###############################################################################
-# (Does not work in Sphinx-Gallery)
-# ---------------------------------
+# And then:
+# ---------
 
 plt.plot(x, (1 - x) / 4)
 plt.ylabel(r'$\langle n_\uparrow n_\downarrow \rangle$')

--- a/examples/plot_quantum.py
+++ b/examples/plot_quantum.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+r"""
+======================
+Some Quantum Mechanics
+======================
+
+We start with a two spin system :math:`\uparrow` and :math:`\downarrow`
+
+"""
+# Author: Óscar Nájera
+
+from __future__ import division, absolute_import, print_function
+
+
+def hamiltonian(M, mu):
+    r"""Generate a single orbital isolated atom Hamiltonian in particle-hole
+    symmetry. Include chemical potential for grand Canonical calculations
+
+    .. math::
+        \mathcal{H} - \mu N = M(n_\uparrow - n_\downarrow)
+        - \mu(n_\uparrow + n_\downarrow)
+    """
+    pass
+
+###############################################################################
+# Double occupation
+# -----------------
+#
+# To find out the double occupation one uses the relation
+# (Works in Sphinx-Gallery)
+
+import matplotlib.pylab as plt
+import numpy as np
+x = np.linspace(0, 1, 20)
+plt.plot(x, (1 - x**2) / 4)
+plt.ylabel('$\\langle n_\\uparrow n_\\downarrow \\rangle$')
+plt.show()
+
+###############################################################################
+#
+# .. math:: \langle n_\uparrow n_\downarrow \rangle = \frac{2\langle V \rangle}{U}+\frac{1}{4}
+
+print('pass')
+
+###############################################################################
+# (Does not work in Sphinx-Gallery)
+# ---------------------------------
+
+plt.plot(x, (1 - x) / 4)
+plt.ylabel(r'$\langle n_\uparrow n_\downarrow \rangle$')
+plt.xlabel('U')
+plt.show()

--- a/examples/plot_quantum.py
+++ b/examples/plot_quantum.py
@@ -1,52 +1,67 @@
 # -*- coding: utf-8 -*-
 r"""
-======================
-Some Quantum Mechanics
-======================
+=================================================
+Some Quantum Mechanics, filling an atomic orbital
+=================================================
 
-We start with a two spin system :math:`\uparrow` and :math:`\downarrow`
+Considering an atomic single orbital and how to fill it by use of the
+chemical potential. This system has a four element basis, :math:`B =
+\{ \lvert \emptyset \rangle, \lvert \uparrow \rangle, \lvert
+\downarrow \rangle, \lvert \uparrow\downarrow \rangle \}`, that is the
+empty orbital, one spin up electron, one spin down electron and the
+filled orbital.
 
+The environment of the orbital is set up by an energy cost for
+occupying the orbital, that is :math:`\epsilon` and when both
+electrons meet a contact interaction corresponding to the Coulomb
+repulsion :math:`U`. Finally the chemical potential :math:`\mu` is
+what allows in the Grand canonical picture, to fill up our atomic
+orbital from a reservoir of electrons.
+
+ The the simple Hamiltonian to model this system is given by:
+
+.. math::
+   \mathcal{H} =
+        \sum_{\sigma=\uparrow,\downarrow} \epsilon c^\dagger_\sigma c_\sigma
+       + Un_\uparrow n_\downarrow - \mu \hat{N}
+
+Here :math:`c^\dagger,c` creation and annihilation operators,
+:math:`n=c^\dagger c`, and
+:math:`\hat{N}=n_\uparrow+n_\downarrow`. This Hamiltonian is diagonal
+in the basis of particle number we have chosen earlier, as the basis
+elements are also eigenvectors.
+
+.. math::
+   \mathcal{H} \lvert \emptyset \rangle &= 0 \\
+   \mathcal{H} \lvert \uparrow  \rangle &= (\epsilon - \mu) | \uparrow  \rangle \\
+   \mathcal{H} \lvert \downarrow  \rangle &= (\epsilon - \mu) | \downarrow  \rangle \\
+   \mathcal{H} \lvert \uparrow\downarrow \rangle &= (2\epsilon - 2\mu +U) \lvert \uparrow\downarrow \rangle
+
+It is easy to see, that the system will prefer to be empty if
+:math:`\mu \in [0,\epsilon)`, be single occupied if :math:`\mu \in (\epsilon, \epsilon +U)`
+and doubly occupied if :math:`\mu > \epsilon +U`.
+
+For a more rigorous treatment, the partition function has to be
+calculated and then the expected particle number can be
+found. Introducing a new variable :math:`\xi = \epsilon - \mu`, and
+:math:`\beta` corresponding to the inverse temperature of the system.
+
+.. math::
+   \mathcal{Z} &= Tr(e^{-\beta \mathcal{H}}) = 1 + 2e^{-\beta\xi} + e^{-\beta(2\xi + U)} \\
+   \langle \hat{N} \rangle &= \frac{1}{\beta} \frac{\partial}{\partial \mu} \ln \mathcal{Z}
 """
-# Author: Óscar Nájera
 
-from __future__ import division, absolute_import, print_function
-
-
-def hamiltonian(M, mu):
-    r"""Generate a single orbital isolated atom Hamiltonian in particle-hole
-    symmetry. Include chemical potential for grand Canonical calculations
-
-    .. math::
-        \mathcal{H} - \mu N = M(n_\uparrow - n_\downarrow)
-        - \mu(n_\uparrow + n_\downarrow)
-    """
-    pass
-
-###############################################################################
-# Double occupation
-# -----------------
-#
-# To find out the double occupation one uses the relation
-# (Works in Sphinx-Gallery)
+# Code source: Óscar Nájera
+# License: BSD 3 clause
 
 import matplotlib.pylab as plt
 import numpy as np
-x = np.linspace(0, 1, 20)
-plt.plot(x, (1 - x**2) / 4)
-plt.ylabel('$\\langle n_\\uparrow n_\\downarrow \\rangle$')
-plt.show()
-
-###############################################################################
-#
-# .. math:: \langle n_\uparrow n_\downarrow \rangle = \frac{2\langle V \rangle}{U}+\frac{1}{4}
-
-print('pass')
-
-###############################################################################
-# And then:
-# ---------
-
-plt.plot(x, (1 - x) / 4)
-plt.ylabel(r'$\langle n_\uparrow n_\downarrow \rangle$')
-plt.xlabel('U')
+mu = np.linspace(0, 3, 800)
+for b in [10, 20, 30]:
+    n = 2 * (np.exp(b * (mu - 1)) + np.exp(b * (2 * mu - 3))) / \
+        (1 + np.exp(b * (mu - 1)) * (2 + np.exp(b * (mu - 2))))
+    plt.plot(mu, n, label=r"$\beta={}$".format(b))
+plt.xlabel(r'$\mu$ ($\epsilon=1$, $U=1$)')
+plt.ylabel(r'$\langle N \rangle=\langle n_\uparrow \rangle+\langle n_\downarrow\rangle$')
+plt.legend(loc=0)
 plt.show()

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -12,8 +12,9 @@ example files.
 Files that generate images should start with 'plot'
 
 """
-from __future__ import (division, print_function, absolute_import,
-                        unicode_literals)
+# Don't use unicode_literals here (be explicit with u"..." instead) otherwise
+# tricky errors come up with exec(code_blocks, ...) calls
+from __future__ import division, print_function, absolute_import
 from time import time
 import ast
 import codecs
@@ -139,7 +140,8 @@ SINGLE_IMAGE = """
 """
 
 
-CODE_OUTPUT = """.. rst-class:: sphx-glr-script-out
+# This one could contain unicode
+CODE_OUTPUT = u""".. rst-class:: sphx-glr-script-out
 
  Out::
 
@@ -486,6 +488,8 @@ def execute_script(code_block, example_globals, image_path, fig_count,
         sys.stdout = my_stdout
 
         t_start = time()
+        # don't use unicode_literals at the top of this file or you get
+        # nasty errors here on Py2.7
         exec(code_block, example_globals)
         time_elapsed = time() - t_start
 
@@ -493,7 +497,7 @@ def execute_script(code_block, example_globals, image_path, fig_count,
 
         my_stdout = my_buffer.getvalue().strip().expandtabs()
         if my_stdout:
-            stdout = CODE_OUTPUT.format(indent(my_stdout, ' ' * 4))
+            stdout = CODE_OUTPUT.format(indent(my_stdout, u' ' * 4))
         os.chdir(cwd)
         figure_list = save_figures(image_path, fig_count, gallery_conf)
 
@@ -527,7 +531,7 @@ def execute_script(code_block, example_globals, image_path, fig_count,
 
         # Breaks build on first example error
 
-        if gallery_conf['abort_on_example_error']:
+        if gallery_conf.get('abort_on_example_error', True):
             raise
 
     finally:
@@ -535,7 +539,7 @@ def execute_script(code_block, example_globals, image_path, fig_count,
         os.chdir(cwd)
 
     print(" - time elapsed : %.2g sec" % time_elapsed)
-    code_output = "\n{0}\n\n{1}\n\n".format(image_list, stdout)
+    code_output = u"\n{0}\n\n{1}\n\n".format(image_list, stdout)
 
     return code_output, time_elapsed, fig_count + len(figure_list)
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -163,6 +163,8 @@ def get_docstring_and_rest(filename):
        isinstance(node.body[0].value, ast.Str):
         docstring_node = node.body[0]
         docstring = docstring_node.value.s
+        if hasattr(docstring, 'decode'):  # python2.7
+            docstring = docstring.decode('utf-8')
         # This get the content of the file after the docstring last line
         # Note: 'maxsplit' argument is not a keyword argument in python2
         rest = content.decode('utf-8').split('\n', docstring_node.lineno)[-1]

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -535,8 +535,8 @@ def execute_script(code_block, example_globals, image_path, fig_count,
             raise
 
     finally:
-        sys.stdout = orig_stdout
         os.chdir(cwd)
+        sys.stdout = orig_stdout
 
     print(" - time elapsed : %.2g sec" % time_elapsed)
     code_output = u"\n{0}\n\n{1}\n\n".format(image_list, stdout)
@@ -635,7 +635,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
     time_m, time_s = divmod(time_elapsed, 60)
     example_nb.save_file()
     with codecs.open(os.path.join(target_dir, base_image_name + '.rst'),
-                     'w', 'utf-8') as f:
+                     mode='w', encoding='utf-8') as f:
         example_rst += CODE_DOWNLOAD.format(time_m, time_s, fname,
                                             example_nb.file_name)
         f.write(example_rst)

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -530,7 +530,7 @@ def execute_script(code_block, example_globals, image_path, fig_count,
         fig_count += 1  # raise count to avoid overwriting image
 
         # Breaks build on first example error
-
+        # Eventually this should hopefully be unified with the default conf
         if gallery_conf.get('abort_on_example_error', True):
             raise
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -20,7 +20,7 @@ CONTENT = ['"""'
            '================',
            '',
            'This is the description of the example',
-           'which goes on and on',
+           u'which goes on and on, Óscar',
            '',
            '',
            'And this is a second paragraph',
@@ -93,7 +93,7 @@ def test_extract_intro():
     assert_false('Docstring' in result)
     assert_equal(
         result,
-        'This is the description of the example which goes on and on')
+        u'This is the description of the example which goes on and on, Óscar')
     assert_false('second paragraph' in result)
 
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -17,29 +17,31 @@ import sphinx_gallery.gen_rst as sg
 from sphinx_gallery import notebook
 
 
-CONTENT = ['"""'
-           'Docstring header',
-           '================',
-           '',
-           'This is the description of the example',
-           'which goes on and on, Óscar',
-           '',
-           '',
-           'And this is a second paragraph',
-           '"""',
-           '',
-           '# and now comes the module code',
-           'import logging',
-           'import sys',
-           'x, y = 1, 2',
-           'print(u"Óscar output") # need some code output',
-           'logger = logging.getLogger()',
-           'logger.setLevel(logging.INFO)',
-           'lh = logging.StreamHandler(sys.stdout)',
-           'lh.setFormatter(logging.Formatter("log:%(message)s"))',
-           'logger.addHandler(lh)',
-           'logger.info(u"Óscar")',
-           ]
+CONTENT = [
+    '"""'
+    'Docstring header',
+    '================',
+    '',
+    'This is the description of the example',
+    'which goes on and on, Óscar',
+    '',
+    '',
+    'And this is a second paragraph',
+    '"""',
+    '',
+    '# and now comes the module code',
+    'import logging',
+    'import sys',
+    'x, y = 1, 2',
+    'print(u"Óscar output") # need some code output',
+    'logger = logging.getLogger()',
+    'logger.setLevel(logging.INFO)',
+    'lh = logging.StreamHandler(sys.stdout)',
+    'lh.setFormatter(logging.Formatter("log:%(message)s"))',
+    'logger.addHandler(lh)',
+    'logger.info(u"Óscar")',
+    'print(r"$\\langle n_\\uparrow n_\\downarrow \\rangle$")',
+]
 
 
 def test_split_code_and_text_blocks():
@@ -137,7 +139,12 @@ def test_pattern_matching():
         'reference_url': {},
     }
 
-    code_output = '\n Out::\n\n      Óscar output\n    log:Óscar\n\n'
+    code_output = ('\n Out::\n'
+                   '\n'
+                   '      Óscar output\n'
+                   '    log:Óscar\n'
+                   '    $\\langle n_\\uparrow n_\\downarrow \\rangle$\n\n'
+                   )
     # create three files in tempdir (only one matches the pattern)
     fnames = ['plot_0.py', 'plot_1.py', 'plot_2.py']
     for fname in fnames:

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -28,7 +28,7 @@ CONTENT = ['"""'
            '',
            '# and now comes the module code',
            'x, y = 1, 2',
-           'print("'"output"'") # need some code output']
+           'print(u"' u"Óscar output" '") # need some code output']
 
 
 def test_split_code_and_text_blocks():
@@ -84,17 +84,17 @@ def test_codestr2rst():
 
 
 def test_extract_intro():
-    with tempfile.NamedTemporaryFile('w') as f:
-        f.write('\n'.join(CONTENT))
+    with tempfile.NamedTemporaryFile('wb') as f:
+        f.write(u'\n'.join(CONTENT).encode('utf-8'))
 
         f.flush()
 
         result = sg.extract_intro(f.name)
-        assert_false('Docstring' in result)
-        assert_equal(
-            result,
-            'This is the description of the example which goes on and on')
-        assert_false('second paragraph' in result)
+    assert_false('Docstring' in result)
+    assert_equal(
+        result,
+        'This is the description of the example which goes on and on')
+    assert_false('second paragraph' in result)
 
 
 def test_md5sums():
@@ -129,19 +129,19 @@ def test_pattern_matching():
         'reference_url': {},
     }
 
-    code_output = '\n Out::\n\n      output\n\n'
+    code_output = u'\n Out::\n\n      Óscar output\n\n'
     # create three files in tempdir (only one matches the pattern)
     fnames = ['plot_0.py', 'plot_1.py', 'plot_2.py']
     for fname in fnames:
-        with open(os.path.join(examples_dir, fname), 'w') as f:
-            f.write('\n'.join(CONTENT))
+        with open(os.path.join(examples_dir, fname), 'wb') as f:
+            f.write('\n'.join(CONTENT).encode('utf-8'))
             f.flush()
         # generate rst file
         sg.generate_file_rst(fname, gallery_dir, examples_dir, gallery_conf)
         # read rst file and check if it contains code output
         rst_fname = os.path.splitext(fname)[0] + '.rst'
-        with open(os.path.join(gallery_dir, rst_fname), 'r') as f:
-            rst = f.read()
+        with open(os.path.join(gallery_dir, rst_fname), 'rb') as f:
+            rst = f.read().decode('utf-8')
             if re.search(gallery_conf['filename_pattern'],
                          os.path.join(gallery_dir, rst_fname)):
                 assert_true(code_output in rst)

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -27,8 +27,17 @@ CONTENT = ['"""'
            '"""',
            '',
            '# and now comes the module code',
+           'import logging',
+           'import sys',
            'x, y = 1, 2',
-           'print(u"' u"Óscar output" '") # need some code output']
+           'print(u"' u"Óscar output" '") # need some code output',
+           'logger = logging.getLogger()',
+           'logger.setLevel(logging.INFO)',
+           'lh = logging.StreamHandler(sys.stdout)',
+           'lh.setFormatter(logging.Formatter("log:%(message)s"))',
+           'logger.addHandler(lh)',
+           'logger.info(u"' u"Óscar" '")',
+           ]
 
 
 def test_split_code_and_text_blocks():
@@ -129,7 +138,7 @@ def test_pattern_matching():
         'reference_url': {},
     }
 
-    code_output = u'\n Out::\n\n      Óscar output\n\n'
+    code_output = u'\n Out::\n\n      Óscar output\n    log:Óscar\n\n'
     # create three files in tempdir (only one matches the pattern)
     fnames = ['plot_0.py', 'plot_1.py', 'plot_2.py']
     for fname in fnames:
@@ -144,6 +153,9 @@ def test_pattern_matching():
             rst = f.read().decode('utf-8')
             if re.search(gallery_conf['filename_pattern'],
                          os.path.join(gallery_dir, rst_fname)):
+                print(code_output)
+                print('')
+                print(rst)
                 assert_true(code_output in rst)
             else:
                 assert_false(code_output in rst)

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -148,20 +148,18 @@ def test_pattern_matching():
     # create three files in tempdir (only one matches the pattern)
     fnames = ['plot_0.py', 'plot_1.py', 'plot_2.py']
     for fname in fnames:
-        with codecs.open(os.path.join(examples_dir, fname), 'w', 'utf-8') as f:
+        with codecs.open(os.path.join(examples_dir, fname), mode='w',
+                         encoding='utf-8') as f:
             f.write('\n'.join(CONTENT))
         # generate rst file
         sg.generate_file_rst(fname, gallery_dir, examples_dir, gallery_conf)
         # read rst file and check if it contains code output
         rst_fname = os.path.splitext(fname)[0] + '.rst'
         with codecs.open(os.path.join(gallery_dir, rst_fname),
-                         'r', 'utf-8') as f:
+                         mode='r', encoding='utf-8') as f:
             rst = f.read()
         if re.search(gallery_conf['filename_pattern'],
                      os.path.join(gallery_dir, rst_fname)):
-            print(code_output)
-            print('')
-            print(rst)
             assert_true(code_output in rst)
         else:
             assert_false(code_output in rst)


### PR DESCRIPTION
Previously, [our] (https://github.com/mne-tools/mne-python) code had unicode in the `stdout` which gave:
```
../examples/preprocessing/plot_maxwell_filter.py is not compiling:
Traceback (most recent call last):
  File "/home/larsoner/custombuilds/sphinx-gallery/sphinx_gallery/gen_rst.py", line 474, in execute_script
    my_stdout = my_buffer.getvalue().strip().expandtabs()
  File "/usr/lib/python2.7/StringIO.py", line 271, in getvalue
    self.buf += ''.join(self.buflist)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xce in position 36: ordinal not in range(128)
```
Modified a test that fails on `master` and passes on this PR.

Works on my system (™) on Py3k and Python 2.7.

Closes #18.
Closes #19.