### PR TITLE
Fix indexing with mayavi figures.

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -334,7 +334,7 @@ def save_figures(image_path, fig_count, gallery_conf):
         e = mlab.get_engine()
         last_matplotlib_fig_num = len(figure_list)
         total_fig_num = last_matplotlib_fig_num + len(e.scenes)
-        mayavi_fig_nums = range(last_matplotlib_fig_num, total_fig_num)
+        mayavi_fig_nums = range(last_matplotlib_fig_num + 1, total_fig_num + 1)
 
         for scene, mayavi_fig_num in zip(e.scenes, mayavi_fig_nums):
             current_fig = image_path.format(mayavi_fig_num)


### PR DESCRIPTION
There is an issue with indexing mayavi figures. This manifests itself in thumbnail figures not being rendered here https://circle-artifacts.com/gh/mne-tools/mne-python/621/artifacts/0/home/ubuntu/mne-python/doc/_build/html/auto_examples/index.html
See  for example ``plot all-to-all connectivity in sensor space``.
I'm not sure if this is the correct fix, but it seems to at least work around the issue.
cc @agramfort 