### PR TITLE
Fix to mayavi figure indexing.

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -332,7 +332,7 @@ def save_figures(image_path, fig_count, gallery_conf):
     if gallery_conf.get('find_mayavi_figures', False):
         from mayavi import mlab
         e = mlab.get_engine()
-        last_matplotlib_fig_num = len(figure_list)
+        last_matplotlib_fig_num = fig_count + len(figure_list)
         total_fig_num = last_matplotlib_fig_num + len(e.scenes)
         mayavi_fig_nums = range(last_matplotlib_fig_num + 1, total_fig_num + 1)
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -184,9 +184,12 @@ def test_ipy_notebook():
 
 
 def test_save_figures():
-    """Test file naming when saving figures."""
+    """Test file naming when saving figures. Requires mayavi."""
     import matplotlib.pylab as plt
-    from mayavi import mlab
+    try:
+        from mayavi import mlab
+    except ImportError:
+        return  # Skip if mayavi is not available.
     examples_dir = tempfile.mkdtemp()
     gallery_conf = {
         'examples_dirs': examples_dir,

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -15,10 +15,10 @@ import os
 import nose
 import shutil
 from nose.tools import assert_equal, assert_false, assert_true
-import matplotlib.pylab as plt
+
 import sphinx_gallery.gen_rst as sg
 from sphinx_gallery import notebook
-
+import matplotlib.pylab as plt  # Import gen_rst first to enable 'Agg' backend.
 
 CONTENT = [
     '"""'

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -181,3 +181,33 @@ def test_ipy_notebook():
 
         f.flush()
         assert_equal(json.load(f), example_nb.work_notebook)
+
+
+def test_save_figures():
+    """Test file naming when saving figures."""
+    import matplotlib.pylab as plt
+    from mayavi import mlab
+    examples_dir = tempfile.mkdtemp()
+    gallery_conf = {
+        'examples_dirs': examples_dir,
+        'plot_gallery': True,
+        'find_mayavi_figures': True,
+    }
+    mlab.test_plot3d()
+    plt.plot(1, 1)
+    fig_list = sg.save_figures(examples_dir + '/image{0}.png', 0, gallery_conf)
+    assert_equal(len(fig_list), 2)
+    assert fig_list[0].endswith('image1.png')
+    assert fig_list[1].endswith('image2.png')
+    for fig in fig_list:
+        os.remove(fig)
+    mlab.test_plot3d()
+    plt.plot(1, 1)
+    fig_list = sg.save_figures(examples_dir + '/image{0}.png', 2, gallery_conf)
+    assert_equal(len(fig_list), 2)
+    assert fig_list[0].endswith('image3.png')
+    assert fig_list[1].endswith('image4.png')
+    plt.close('all')
+    for fig in fig_list:
+        os.remove(fig)
+    os.rmdir(examples_dir)


### PR DESCRIPTION
I noticed that when you build tutorials like this https://circle-artifacts.com/gh/mne-tools/mne-python/645/artifacts/0/home/ubuntu/mne-python/doc/_build/html/auto_tutorials/plot_source_localization_basics.html, function ``save_figures`` gets called multiple times (notice the duplicates of the mayavi figure). Therefore the fix in https://github.com/sphinx-gallery/sphinx-gallery/pull/116 alone won't work. I tried this locally on couple of my examples and tutorials and it seems to fix the issue.