### PR TITLE
ENH: make it possible to also specify abort_on_example_error in the sphinx_gallery_conf

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ New features
 * Print aggregated and sorted list of computation times of all examples
   in the console during the build.
 * For examples that create multiple figures, set the thumbnail image.
-
+* The ``abort_on_example_error`` option can now be specified in
+  ``sphinx_gallery_conf`` (although the build option takes precedence over the
+  ``sphinx_gallery_conf`` option).
 
 v0.1.2
 ------

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -279,6 +279,9 @@ by including in your ``Makefile``::
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 Remember that for ``Makefile`` white space is significant and the indentation are tabs
-and not spaces
+and not spaces.
+
+Alternatively, you can also instead add the ``abort_on_example_error`` option to
+the ``sphinx_gallery_conf`` inside your ``conf.py`` configuration file.
 
 .. _regular expressions: https://docs.python.org/2/library/re.html

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -57,8 +57,19 @@ def generate_gallery_rst(app):
 
     gallery_conf.update(app.config.sphinx_gallery_conf)
     gallery_conf.update(plot_gallery=plot_gallery)
-    gallery_conf.update(
-        abort_on_example_error=app.builder.config.abort_on_example_error)
+
+    # If abort_on_example_error was specified in the sphinx_gallery_conf, we
+    # only override it if it was explicitly set in the build config. If it was
+    # not explicitly specified, it will be None, otherwise it will be
+    # True/False.
+    if app.builder.config.abort_on_example_error is None:
+        if 'abort_on_example_error' in gallery_conf:
+            pass  # use the value from sphinx_gallery_conf
+        else:
+            gallery_conf['abort_on_example_error'] = False
+    else:
+        gallery_conf['abort_on_example_error'] = \
+            app.builder.config.abort_on_example_error
 
     # this assures I can call the config in other places
     app.config.sphinx_gallery_conf = gallery_conf
@@ -156,7 +167,11 @@ gallery_conf = {
 def setup(app):
     """Setup sphinx-gallery sphinx extension"""
     app.add_config_value('plot_gallery', True, 'html')
-    app.add_config_value('abort_on_example_error', False, 'html')
+
+    # We set the default abort_on_example_error to None here so that we can
+    # determine later if the option was explicitly set to False or True.
+    app.add_config_value('abort_on_example_error', None, 'html')
+
     app.add_config_value('sphinx_gallery_conf', gallery_conf, 'html')
     app.add_stylesheet('gallery.css')
 


### PR DESCRIPTION
With these changes, it is possible to specify ``abort_on_example_error`` inside the normal ``sphinx_gallery_conf`` options.