### PR TITLE
Include a reference for each gallery subsection

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -284,9 +284,12 @@ def save_thumbnail(image_path_template, src_file, file_conf, gallery_conf):
 def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
     """Generate the gallery reStructuredText for an example directory"""
 
+    fhindex = """\n\n.. _sphx_glr_{0}:\n\n""".format(
+        target_dir.replace(os.path.sep, '_'))
+
     with codecs.open(os.path.join(src_dir, 'README.txt'), 'r',
                      encoding='utf-8') as fid:
-        fhindex = fid.read()
+        fhindex += fid.read()
     # Add empty lines to avoid bug in issue #165
     fhindex += "\n\n"
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -284,8 +284,9 @@ def save_thumbnail(image_path_template, src_file, file_conf, gallery_conf):
 def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
     """Generate the gallery reStructuredText for an example directory"""
 
+    head_ref = os.path.relpath(target_dir, gallery_conf['src_dir'])
     fhindex = """\n\n.. _sphx_glr_{0}:\n\n""".format(
-        target_dir.replace(os.path.sep, '_'))
+        head_ref.replace(os.path.sep, '_'))
 
     with codecs.open(os.path.join(src_dir, 'README.txt'), 'r',
                      encoding='utf-8') as fid:


### PR DESCRIPTION
When describing a gallery subsection or the main gallery one writes
in the README.txt file which supports RestructuredText syntax and one
should put references for the headings.

But because one can forget an the seems to be no conflict in Sphinx if a
header has to references Sphinx-Gallery prepends an automatically
generated label for each subsection

Fix #127
