### PR TITLE
[MRG] Script downloads

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ git master
 New features
 ''''''''''''
 * Enhanced CSS for download buttons
+* Download buttons at the end of each section in the gallery to
+  download all scripts or Jupyter notebooks together in a zip file.
 
 Bug Fixes
 '''''''''

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,10 @@ New features
 ''''''''''''
 * Enhanced CSS for download buttons
 * Download buttons at the end of each section in the gallery to
-  download all scripts or Jupyter notebooks together in a zip file.
+  download all python scripts or Jupyter notebooks together in a zip
+  file. New config variable `download_section_examples` to toggle this
+  effect. Activated by default
+
 
 Bug Fixes
 '''''''''

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,10 +7,10 @@ git master
 New features
 ''''''''''''
 * Enhanced CSS for download buttons
-* Download buttons at the end of each section in the gallery to
-  download all python scripts or Jupyter notebooks together in a zip
-  file. New config variable `download_section_examples` to toggle this
-  effect. Activated by default
+* Download buttons at the end of the gallery to download all python
+  scripts or Jupyter notebooks together in a zip file. New config
+  variable `download_all_examples` to toggle this effect. Activated by
+  default
 
 
 Bug Fixes

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ It is extracted from the scikit-learn project and aims to be an
 independent general purpose extension.
 
 Who uses Sphinx-Gallery
------------------------
+=======================
 
 * `Sphinx-Gallery <http://sphinx-gallery.readthedocs.io/en/latest/auto_examples/index.html>`_
 * `Scikit-learn <http://scikit-learn.org/dev/auto_examples/index.html>`_

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -21,3 +21,16 @@ its reference
 ``:ref:`sphx_glr_auto_examples_plot_gallery_version.py```. The image
 it generated has the name ``sphx_glr_plot_gallery_version_thumb.png``
 and its thumbnail is ``sphx_glr_plot_gallery_version_thumb.png``
+
+Disable joint download of all gallery scripts
+---------------------------------------------
+
+By default Sphinx-Gallery prepares zip files of all python scripts and
+all Jupyter notebooks for each gallery section and makes them
+available for download at the end of each section. To disable this
+behavior add to the configuration dictionary in your ``conf.py`` file
+
+.. code-block:: python
+
+    sphinx_gallery_conf = {
+	'download_section_examples'  : False}

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -13,3 +13,4 @@ Sphinx-Gallery API Reference
    backreferences
    gen_rst
    docs_resolv
+   downloads

--- a/sphinx_gallery/downloads.py
+++ b/sphinx_gallery/downloads.py
@@ -37,9 +37,9 @@ def python_zip(file_list, gallery_path, extension='.py'):
 
     Parameters
     ----------
-    file_list : list of str
+    file_list : list of strings
         Holds all the file names to be included in zip file
-    gallery_path : str
+    gallery_path : string
         path to where the zipfile is stored
     extension : str
         '.py' or '.ipynb' In order to deal with downloads of python
@@ -48,9 +48,10 @@ def python_zip(file_list, gallery_path, extension='.py'):
         variable while generating the zip file
     Returns
     -------
-    str : zip file name, written as `target_dir_{python,jupyter}.zip`
+    zipname : string
+        zip file name, written as `target_dir_{python,jupyter}.zip`
         depending on the extension
-"""
+    """
     zipname = gallery_path.replace(os.path.sep, '_')
     zipname += '_python' if extension == '.py' else '_jupyter'
     zipname = os.path.join(gallery_path, zipname + '.zip')
@@ -65,7 +66,17 @@ def python_zip(file_list, gallery_path, extension='.py'):
 
 
 def list_downloadable_sources(target_dir):
-    """Returns a list of python source files is target_dir"""
+    """Returns a list of python source files is target_dir
+
+    Parameters
+    ----------
+    target_dir : string
+        path to the directory where python source file are
+    Returns
+    -------
+    list
+        list of paths to all Python source files in `target_dir`
+    """
     return [os.path.join(target_dir, fname)
             for fname in os.listdir(target_dir)
             if fname.endswith('.py')]
@@ -78,12 +89,12 @@ def generate_zipfiles(gallery_dir):
 
     Parameters
     ----------
-    gallery_dir : str
+    gallery_dir : string
         path of the gallery to collect downloadable sources
 
     Return
     ------
-    download_rst: str
+    download_rst: string
         RestructuredText to include download buttons to the generated files
     """
 

--- a/sphinx_gallery/downloads.py
+++ b/sphinx_gallery/downloads.py
@@ -12,15 +12,14 @@ from __future__ import absolute_import, division, print_function
 import os
 import zipfile
 
-CODE_DOWNLOAD = """**Total running time of the script:**
-({0:.0f} minutes {1:.3f} seconds)\n\n
+CODE_DOWNLOAD = """
 \n.. container:: sphx-glr-download
 
-    :download:`Download Python source code: {2} <{2}>`\n
+    :download:`Download Python source code: {0} <{0}>`\n
 
 \n.. container:: sphx-glr-download
 
-    :download:`Download Jupyter notebook: {3} <{3}>`\n"""
+    :download:`Download Jupyter notebook: {1} <{1}>`\n"""
 
 CODE_ZIP_DOWNLOAD = """
 \n.. container:: sphx-glr-download

--- a/sphinx_gallery/downloads.py
+++ b/sphinx_gallery/downloads.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+r"""
+Utilities for downloadable items
+================================
+
+"""
+# Author: Óscar Nájera
+# License: 3-clause BSD
+
+from __future__ import absolute_import, division, print_function
+
+import os
+import zipfile
+
+CODE_DOWNLOAD = """**Total running time of the script:**
+({0:.0f} minutes {1:.3f} seconds)\n\n
+\n.. container:: sphx-glr-download
+
+    :download:`Download Python source code: {2} <{2}>`\n
+
+\n.. container:: sphx-glr-download
+
+    :download:`Download Jupyter notebook: {3} <{3}>`\n"""
+
+CODE_ZIP_DOWNLOAD = """
+\n.. container:: sphx-glr-download
+
+    :download:`Download all examples in Python source code: {0} </{1}>`\n
+
+\n.. container:: sphx-glr-download
+
+    :download:`Download all examples in Jupyter notebook files: {2} </{3}>`\n"""
+
+
+def python_zip(file_list, gallery_path, extension='.py'):
+    """Stores all files in file_list into an zip file
+
+    Parameters
+    ----------
+    file_list : list of str
+        Holds all the file names to be included in zip file
+    gallery_path : str
+        path to where the zipfile is stored
+    extension : str
+        '.py' or '.ipynb' In order to deal with downloads of python
+        sources and jupyter notebooks the file extension from files in
+        file_list will be removed and replace with the value of this
+        variable while generating the zip file
+    Returns
+    -------
+    str : zip file name, written as `target_dir_{python,jupyter}.zip`
+        depending on the extension
+"""
+    zipname = gallery_path.replace(os.path.sep, '_')
+    zipname += '_python' if extension == '.py' else '_jupyter'
+    zipname = os.path.join(gallery_path, zipname + '.zip')
+
+    zipf = zipfile.ZipFile(zipname, mode='w')
+    for fname in file_list:
+        file_src = os.path.splitext(fname)[0] + extension
+        zipf.write(file_src)
+    zipf.close()
+
+    return zipname
+
+
+def list_downloadable_sources(target_dir):
+    """Returns a list of python source files is target_dir"""
+    return [os.path.join(target_dir, fname)
+            for fname in os.listdir(target_dir)
+            if fname.endswith('.py')]
+
+
+def generate_zipfiles(gallery_dir):
+    """
+    Collects all Python source files and Jupyter notebooks in
+    gallery_dir and makes zipfiles of them
+
+    Parameters
+    ----------
+    gallery_dir : str
+        path of the gallery to collect downloadable sources
+
+    Return
+    ------
+    download_rst: str
+        RestructuredText to include download buttons to the generated files
+    """
+
+    listdir = list_downloadable_sources(gallery_dir)
+    for directory in sorted(os.listdir(gallery_dir)):
+        if os.path.isdir(os.path.join(gallery_dir, directory)):
+            target_dir = os.path.join(gallery_dir, directory)
+            listdir.extend(list_downloadable_sources(target_dir))
+
+    py_zipfile = python_zip(listdir, gallery_dir)
+    jy_zipfile = python_zip(listdir, gallery_dir, ".ipynb")
+
+    dw_rst = CODE_ZIP_DOWNLOAD.format(os.path.basename(py_zipfile),
+                                      py_zipfile,
+                                      os.path.basename(jy_zipfile),
+                                      jy_zipfile)
+    return dw_rst

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -29,7 +29,7 @@ DEFAULT_GALLERY_CONF = {
     'reference_url': {},
     # build options
     'plot_gallery': True,
-    'download_section_examples': True,
+    'download_all_examples': True,
     'abort_on_example_error': False,
     'failing_examples': {},
     'expected_failing_examples': set(),
@@ -131,7 +131,7 @@ def generate_gallery_rst(app):
                 fhindex.write(this_fhindex)
                 computation_times += this_computation_times
 
-        if gallery_conf['download_section_examples']:
+        if gallery_conf['download_all_examples']:
             download_fhindex = generate_zipfiles(gallery_dir)
             fhindex.write(download_fhindex)
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -28,6 +28,7 @@ DEFAULT_GALLERY_CONF = {
     'reference_url': {},
     # build options
     'plot_gallery': True,
+    'download_section_examples': True,
     'abort_on_example_error': False,
     'failing_examples': {},
     'expected_failing_examples': set(),

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -18,6 +18,7 @@ import os
 from . import glr_path_static
 from .gen_rst import generate_dir_rst, SPHX_GLR_SIG
 from .docs_resolv import embed_code_links
+from .downloads import generate_zipfiles
 
 DEFAULT_GALLERY_CONF = {
     'filename_pattern': re.escape(os.sep) + 'plot',
@@ -129,6 +130,10 @@ def generate_gallery_rst(app):
                                      seen_backrefs)
                 fhindex.write(this_fhindex)
                 computation_times += this_computation_times
+
+        if gallery_conf['download_section_examples']:
+            download_fhindex = generate_zipfiles(gallery_dir)
+            fhindex.write(download_fhindex)
 
         fhindex.write(SPHX_GLR_SIG)
         fhindex.flush()

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -26,7 +26,8 @@ import subprocess
 import sys
 import traceback
 import warnings
-import zipfile
+
+from .downloads import CODE_DOWNLOAD
 
 
 # Try Python 2 first, otherwise load from Python 3
@@ -109,24 +110,6 @@ class MixedEncodingStringIO(StringIO):
 
 
 ###############################################################################
-CODE_DOWNLOAD = """**Total running time of the script:**
-({0:.0f} minutes {1:.3f} seconds)\n\n
-\n.. container:: sphx-glr-download
-
-    :download:`Download Python source code: {2} <{2}>`\n
-
-\n.. container:: sphx-glr-download
-
-    :download:`Download Jupyter notebook: {3} <{3}>`\n"""
-
-CODE_ZIP_DOWNLOAD = """
-\n.. container:: sphx-glr-download
-
-    :download:`Download all examples in Python source code: {0} </{1}>`\n
-
-\n.. container:: sphx-glr-download
-
-    :download:`Download all examples in Jupyter notebook files: {2} </{3}>`\n"""
 # The following strings are used when we have several pictures: we use
 # an html div tag that our CSS uses to turn the lists into horizontal
 # lists.
@@ -458,41 +441,6 @@ def save_thumbnail(image_path_template, src_file, gallery_conf):
         scale_image(default_thumb_file, thumb_file, 200, 140)
 
 
-def python_zip(file_list, src_path, zipfile_path, extension='.py'):
-    """Stores all files in file_list into an zip file
-
-    Parameters
-    ----------
-    file_list : list of str
-        Hold all the file names to be included in zip file
-    src_path : str
-        path to where the examples are located
-    zipfile_path : str
-        path to where the zipfile is stored
-    extension : str
-        '.py' or '.ipynb' In order to deal with downloads of python
-        sources and jupyter notebooks the file extension from files in
-        file_list will be removed and replace with the value of this
-        variable while generating the zip file
-    Returns
-    -------
-    str : zip file name, written as `target_dir_{python,jupyter}.zip`
-        depending on the extension
-"""
-    zipname = src_path.replace(os.path.sep, '_')
-    zipname+= '_python' if extension == '.py' else '_jupyter'
-    zipname = os.path.join(zipfile_path, zipname + '.zip')
-
-    zipf = zipfile.ZipFile(zipname, mode='w')
-    for fname in file_list:
-        file_src = os.path.splitext(fname)[0] + extension
-        example_file = os.path.join(src_path, file_src)
-        zipf.write(example_file, arcname=file_src)
-    zipf.close()
-
-    return zipname
-
-
 def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
     """Generate the gallery reStructuredText for an example directory"""
     if not os.path.exists(os.path.join(src_dir, 'README.txt')):
@@ -536,16 +484,6 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
     # clear at the end of the section
     fhindex += """.. raw:: html\n
     <div style='clear:both'></div>\n\n"""
-
-
-    if gallery_conf['download_section_examples']:
-        py_zipfile = python_zip(sorted_listdir, target_dir, target_dir)
-        jy_zipfile = python_zip(sorted_listdir, target_dir, target_dir, ".ipynb")
-
-        fhindex += CODE_ZIP_DOWNLOAD.format(os.path.basename(py_zipfile),
-                                            py_zipfile,
-                                            os.path.basename(jy_zipfile),
-                                            jy_zipfile)
 
     return fhindex, computation_times
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -538,13 +538,14 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
     <div style='clear:both'></div>\n\n"""
 
 
-    py_zipfile = python_zip(sorted_listdir, target_dir, target_dir)
-    jy_zipfile = python_zip(sorted_listdir, target_dir, target_dir, ".ipynb")
+    if gallery_conf['download_section_examples']:
+        py_zipfile = python_zip(sorted_listdir, target_dir, target_dir)
+        jy_zipfile = python_zip(sorted_listdir, target_dir, target_dir, ".ipynb")
 
-    fhindex += CODE_ZIP_DOWNLOAD.format(os.path.basename(py_zipfile),
-                                        py_zipfile,
-                                        os.path.basename(jy_zipfile),
-                                        jy_zipfile)
+        fhindex += CODE_ZIP_DOWNLOAD.format(os.path.basename(py_zipfile),
+                                            py_zipfile,
+                                            os.path.basename(jy_zipfile),
+                                            jy_zipfile)
 
     return fhindex, computation_times
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -458,16 +458,17 @@ def save_thumbnail(image_path_template, src_file, gallery_conf):
         scale_image(default_thumb_file, thumb_file, 200, 140)
 
 
-def python_zip(file_list, target_dir, extension='.py'):
+def python_zip(file_list, src_path, zipfile_path, extension='.py'):
     """Stores all files in file_list into an zip file
 
     Parameters
     ----------
     file_list : list of str
         Hold all the file names to be included in zip file
-    target_dir : str
-        name path of the directory where examples are being stored for
-        download in the gallery
+    src_path : str
+        path to where the examples are located
+    zipfile_path : str
+        path to where the zipfile is stored
     extension : str
         '.py' or '.ipynb' In order to deal with downloads of python
         sources and jupyter notebooks the file extension from files in
@@ -479,12 +480,12 @@ def python_zip(file_list, target_dir, extension='.py'):
         depending on the extension
 """
     zipname = '_python' if extension == '.py' else '_jupyter'
-    zipname = target_dir + zipname + '.zip'
+    zipname = os.path.join(zipfile_path, zipname + '.zip')
 
     zipf = zipfile.ZipFile(zipname, mode='w')
     for fname in file_list:
         file_src = os.path.splitext(fname)[0] + extension
-        example_file = os.path.join(target_dir, file_src)
+        example_file = os.path.join(src_path, file_src)
         zipf.write(example_file, arcname=file_src)
     zipf.close()
 
@@ -535,8 +536,8 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
 
     fhindex += CODE_ZIP_DOWNLOAD.format(target_dir)
 
-    python_zip(sorted_listdir, target_dir)
-    python_zip(sorted_listdir, target_dir, ".ipynb")
+    python_zip(sorted_listdir, target_dir, target_dir)
+    python_zip(sorted_listdir, target_dir, target_dir, ".ipynb")
 
     return fhindex, computation_times
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -26,6 +26,7 @@ import subprocess
 import sys
 import traceback
 import warnings
+import zipfile
 
 
 # Try Python 2 first, otherwise load from Python 3
@@ -113,10 +114,19 @@ CODE_DOWNLOAD = """**Total running time of the script:**
 \n.. container:: sphx-glr-download
 
     :download:`Download Python source code: {2} <{2}>`\n
+
 \n.. container:: sphx-glr-download
 
     :download:`Download Jupyter notebook: {3} <{3}>`\n"""
 
+CODE_ZIP_DOWNLOAD = """
+\n.. container:: sphx-glr-download
+
+    :download:`Download all examples in Python source code: {0}_python </{0}_python.zip>`\n
+
+\n.. container:: sphx-glr-download
+
+    :download:`Download all examples in Jupyter notebook files: {0}_jupyter </{0}_jupyter.zip>`\n"""
 # The following strings are used when we have several pictures: we use
 # an html div tag that our CSS uses to turn the lists into horizontal
 # lists.
@@ -448,6 +458,19 @@ def save_thumbnail(image_path_template, src_file, gallery_conf):
         scale_image(default_thumb_file, thumb_file, 200, 140)
 
 
+def python_zip(file_list, target_dir, extension='.py'):
+
+    zipname = '_python' if extension == '.py' else '_jupyter'
+    zipname = target_dir + zipname + '.zip'
+
+    zipf = zipfile.ZipFile(zipname, mode='w')
+    for fname in file_list:
+        file_src = os.path.splitext(fname)[0] + extension
+        example_file = os.path.join(target_dir, file_src)
+        zipf.write(example_file, arcname=file_src)
+    zipf.close()
+
+
 def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
     """Generate the gallery reStructuredText for an example directory"""
     if not os.path.exists(os.path.join(src_dir, 'README.txt')):
@@ -459,6 +482,7 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
         return "", []  # because string is an expected return type
 
     fhindex = open(os.path.join(src_dir, 'README.txt')).read()
+
     if not os.path.exists(target_dir):
         os.makedirs(target_dir)
     sorted_listdir = [fname for fname in sorted(os.listdir(src_dir))
@@ -490,6 +514,11 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
     # clear at the end of the section
     fhindex += """.. raw:: html\n
     <div style='clear:both'></div>\n\n"""
+
+    fhindex += CODE_ZIP_DOWNLOAD.format(target_dir)
+
+    python_zip(sorted_listdir, target_dir)
+    python_zip(sorted_listdir, target_dir, ".ipynb")
 
     return fhindex, computation_times
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -672,8 +672,10 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
     example_nb.save_file()
     with codecs.open(os.path.join(target_dir, base_image_name + '.rst'),
                      mode='w', encoding='utf-8') as f:
-        example_rst += CODE_DOWNLOAD.format(time_m, time_s, fname,
-                                            example_nb.file_name)
+        example_rst += "**Total running time of the script:**" \
+                       " ({0: .0f} minutes {1: .3f} seconds)\n\n".format(
+                           time_m, time_s)
+        example_rst += CODE_DOWNLOAD.format(fname, example_nb.file_name)
         example_rst += SPHX_GLR_SIG
         f.write(example_rst)
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -459,7 +459,25 @@ def save_thumbnail(image_path_template, src_file, gallery_conf):
 
 
 def python_zip(file_list, target_dir, extension='.py'):
+    """Stores all files in file_list into an zip file
 
+    Parameters
+    ----------
+    file_list : list of str
+        Hold all the file names to be included in zip file
+    target_dir : str
+        name path of the directory where examples are being stored for
+        download in the gallery
+    extension : str
+        '.py' or '.ipynb' In order to deal with downloads of python
+        sources and jupyter notebooks the file extension from files in
+        file_list will be removed and replace with the value of this
+        variable while generating the zip file
+    Returns
+    -------
+    None : zip file is written as `target_dir_{python,jupyter}.zip`
+        depending on the extension
+"""
     zipname = '_python' if extension == '.py' else '_jupyter'
     zipname = target_dir + zipname + '.zip'
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -122,11 +122,11 @@ CODE_DOWNLOAD = """**Total running time of the script:**
 CODE_ZIP_DOWNLOAD = """
 \n.. container:: sphx-glr-download
 
-    :download:`Download all examples in Python source code: {0}_python </{0}_python.zip>`\n
+    :download:`Download all examples in Python source code: {0} </{1}>`\n
 
 \n.. container:: sphx-glr-download
 
-    :download:`Download all examples in Jupyter notebook files: {0}_jupyter </{0}_jupyter.zip>`\n"""
+    :download:`Download all examples in Jupyter notebook files: {2} </{3}>`\n"""
 # The following strings are used when we have several pictures: we use
 # an html div tag that our CSS uses to turn the lists into horizontal
 # lists.
@@ -476,10 +476,11 @@ def python_zip(file_list, src_path, zipfile_path, extension='.py'):
         variable while generating the zip file
     Returns
     -------
-    None : zip file is written as `target_dir_{python,jupyter}.zip`
+    str : zip file name, written as `target_dir_{python,jupyter}.zip`
         depending on the extension
 """
-    zipname = '_python' if extension == '.py' else '_jupyter'
+    zipname = src_path.replace(os.path.sep, '_')
+    zipname+= '_python' if extension == '.py' else '_jupyter'
     zipname = os.path.join(zipfile_path, zipname + '.zip')
 
     zipf = zipfile.ZipFile(zipname, mode='w')
@@ -488,6 +489,8 @@ def python_zip(file_list, src_path, zipfile_path, extension='.py'):
         example_file = os.path.join(src_path, file_src)
         zipf.write(example_file, arcname=file_src)
     zipf.close()
+
+    return zipname
 
 
 def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
@@ -534,10 +537,14 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
     fhindex += """.. raw:: html\n
     <div style='clear:both'></div>\n\n"""
 
-    fhindex += CODE_ZIP_DOWNLOAD.format(target_dir)
 
-    python_zip(sorted_listdir, target_dir, target_dir)
-    python_zip(sorted_listdir, target_dir, target_dir, ".ipynb")
+    py_zipfile = python_zip(sorted_listdir, target_dir, target_dir)
+    jy_zipfile = python_zip(sorted_listdir, target_dir, target_dir, ".ipynb")
+
+    fhindex += CODE_ZIP_DOWNLOAD.format(os.path.basename(py_zipfile),
+                                        py_zipfile,
+                                        os.path.basename(jy_zipfile),
+                                        jy_zipfile)
 
     return fhindex, computation_times
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -15,6 +15,7 @@ import re
 import os
 import nose
 import shutil
+import zipfile
 from nose.tools import assert_equal, assert_false, assert_true
 
 import sphinx_gallery.gen_rst as sg
@@ -259,6 +260,22 @@ def test_save_figures():
     assert fig_list[1].endswith('image4.png')
 
     shutil.rmtree(examples_dir)
+
+
+def test_zip_notebooks():
+    """Test generated zipfiles are not corrupt"""
+    gallery_conf = build_test_configuration(examples_dir='examples')
+    examples = [fname
+                for fname in sorted(os.listdir(gallery_conf['examples_dir']))
+                if fname.endswith('.py')]
+    sg.python_zip(examples, gallery_conf['examples_dir'],
+                  gallery_conf['gallery_dir'])
+    zipfilename = os.path.join(gallery_conf['gallery_dir'], "_python.zip")
+    zipf = zipfile.ZipFile(zipfilename)
+    check = zipf.testzip()
+    if check:
+        raise OSError("Bad file in zipfile: {0}".format(check))
+
 
 # TODO: test that broken thumbnail does appear when needed
 # TODO: test that examples are not executed twice

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -268,10 +268,9 @@ def test_zip_notebooks():
     examples = [fname
                 for fname in sorted(os.listdir(gallery_conf['examples_dir']))
                 if fname.endswith('.py')]
-    sg.python_zip(examples, gallery_conf['examples_dir'],
+    zipfilepath = sg.python_zip(examples, gallery_conf['examples_dir'],
                   gallery_conf['gallery_dir'])
-    zipfilename = os.path.join(gallery_conf['gallery_dir'], "_python.zip")
-    zipf = zipfile.ZipFile(zipfilename)
+    zipf = zipfile.ZipFile(zipfilepath)
     check = zipf.testzip()
     if check:
         raise OSError("Bad file in zipfile: {0}".format(check))

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -21,6 +21,7 @@ from nose.tools import assert_equal, assert_false, assert_true
 import sphinx_gallery.gen_rst as sg
 from sphinx_gallery import gen_gallery
 from sphinx_gallery import notebook
+from sphinx_gallery import downloads
 import matplotlib.pylab as plt  # Import gen_rst first to enable 'Agg' backend.
 
 CONTENT = [
@@ -265,11 +266,9 @@ def test_save_figures():
 def test_zip_notebooks():
     """Test generated zipfiles are not corrupt"""
     gallery_conf = build_test_configuration(examples_dir='examples')
-    examples = [fname
-                for fname in sorted(os.listdir(gallery_conf['examples_dir']))
-                if fname.endswith('.py')]
-    zipfilepath = sg.python_zip(examples, gallery_conf['examples_dir'],
-                  gallery_conf['gallery_dir'])
+    examples = downloads.list_downloadable_sources(
+        gallery_conf['examples_dir'])
+    zipfilepath = downloads.python_zip(examples, gallery_conf['gallery_dir'])
     zipf = zipfile.ZipFile(zipfilepath)
     check = zipf.testzip()
     if check:


### PR DESCRIPTION
To answer #128 I propose this to download all example files per section in python and Jupyter notebooks

I'm still unsure of the presentation. If the download should be in the yellow boxes we use in the files or a simpler plain text. Also if it would be at the start of the example section or at the end.

![spectacle d10639](https://cloud.githubusercontent.com/assets/713451/16716119/a22ec0ec-46f3-11e6-8e27-016be288bab7.png)
