### PR TITLE
[NO MRG - WIP] Improved use of relative paths

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,6 @@ with-doctest=1
 doctest-extension=rst
 
 [build_sphinx]
-source-dir = docs/
-build-dir  = docs/_build
+source-dir = doc/
+build-dir  = doc_build
 all_files  = 1

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -165,6 +165,7 @@ def write_backreferences(seen_backrefs, gallery_conf,
     """Writes down back reference files, which include a thumbnail list
     of examples using a certain module"""
     example_file = os.path.join(target_dir, fname)
+    target_path_name = os.path.relpath(target_dir, gallery_conf['src_dir'])
     backrefs = scan_used_functions(example_file, gallery_conf)
     for backref in backrefs:
         include_path = os.path.join(gallery_conf['mod_example_dir'],
@@ -175,6 +176,6 @@ def write_backreferences(seen_backrefs, gallery_conf,
                 heading = '\n\nExamples using ``%s``' % backref
                 ex_file.write(heading + '\n')
                 ex_file.write('^' * len(heading) + '\n')
-            ex_file.write(_thumbnail_div(target_dir, fname, snippet,
+            ex_file.write(_thumbnail_div(target_path_name, fname, snippet,
                                          is_backref=True))
             seen_backrefs.add(backref)

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -432,9 +432,5 @@ def embed_code_links(app, exception):
 
     gallery_conf = app.config.sphinx_gallery_conf
 
-    gallery_dirs = gallery_conf['gallery_dirs']
-    if not isinstance(gallery_dirs, list):
-        gallery_dirs = [gallery_dirs]
-
-    for gallery_dir in gallery_dirs:
+    for gallery_dir in gallery_conf['gallery_dirs']:
         _embed_code_links(app, gallery_conf, gallery_dir)

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -341,8 +341,8 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
                   "Error:\n".format(this_module))
             print(e.args)
 
-    html_gallery_dir = os.path.abspath(os.path.join(app.builder.outdir,
-                                                    gallery_dir))
+    gallery_path = os.path.relpath(gallery_dir, app.builder.srcdir)
+    html_gallery_dir = os.path.join(app.builder.outdir, gallery_path)
 
     # patterns for replacement
     link_pattern = ('<a href="%s" class="sphx-glr-code-links" '

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -61,14 +61,14 @@ def clean_gallery_out(build_dir):
                 os.remove(os.path.join(build_image_dir, filename))
 
 
-def build_paths(gallery_conf_dirs, srcdir):
+def build_paths(gallery_conf, path_name, srcdir):
 
-    if not isinstance(gallery_conf_dirs, list):
-        gallery_conf_dirs = [gallery_conf_dirs]
+    if not isinstance(gallery_conf[path_name], list):
+        gallery_conf[path_name] = [gallery_conf[path_name]]
 
-    gallery_conf_dirs = [os.path.join(srcdir, work_dir)
-                         for work_dir in gallery_conf_dirs]
-    return gallery_conf_dirs
+    gallery_conf[path_name] = [os.path.join(srcdir, work_dir)
+                               for work_dir in gallery_conf[path_name]]
+    return gallery_conf[path_name]
 
 
 def generate_gallery_rst(app):
@@ -95,13 +95,13 @@ def generate_gallery_rst(app):
     clean_gallery_out(app.builder.outdir)
 
     examples_dirs = build_paths(
-        gallery_conf['examples_dirs'], app.builder.srcdir)
+        gallery_conf, 'examples_dirs', app.builder.srcdir)
     gallery_dirs = build_paths(
-        gallery_conf['gallery_dirs'], app.builder.srcdir)
+        gallery_conf, 'gallery_dirs', app.builder.srcdir)
     mod_examples_dir = os.path.join(
         app.builder.srcdir, gallery_conf['mod_example_dir'])
     gallery_conf['mod_example_dir'] = mod_examples_dir
-
+    gallery_conf['src_dir'] = app.builder.srcdir
     seen_backrefs = set()
 
     computation_times = []
@@ -176,7 +176,8 @@ def sumarize_failing_examples(app, exception):
 
     gallery_conf = app.config.sphinx_gallery_conf
     failing_examples = set(gallery_conf['failing_examples'])
-    expected_failing_examples = set(gallery_conf['expected_failing_examples'])
+    expected_failing_examples = set(build_paths(
+        gallery_conf, 'expected_failing_examples', app.builder.srcdir))
     print(failing_examples)
 
     examples_expected_to_fail = failing_examples.intersection(

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -357,11 +357,14 @@ def save_figures(image_path, fig_count, gallery_conf):
     images_rst = ""
     if len(figure_list) == 1:
         figure_name = figure_list[0]
-        images_rst = SINGLE_IMAGE % figure_name.lstrip('/')
+        fig_rst_path = os.path.relpath(figure_name, gallery_conf['src_dir'])
+        images_rst = SINGLE_IMAGE % fig_rst_path.lstrip('/')
     elif len(figure_list) > 1:
         images_rst = HLIST_HEADER
         for figure_name in figure_list:
-            images_rst += HLIST_IMAGE_TEMPLATE % figure_name.lstrip('/')
+            fig_rst_path = os.path.relpath(
+                figure_name, gallery_conf['src_dir'])
+            images_rst += HLIST_IMAGE_TEMPLATE % fig_rst_path.lstrip('/')
 
     return figure_list, images_rst
 
@@ -459,6 +462,7 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
                       if fname.endswith('.py')]
     entries_text = []
     computation_times = []
+    target_path_name = os.path.relpath(target_dir, gallery_conf['src_dir'])
     for fname in sorted_listdir:
         amount_of_code, time_elapsed = \
             generate_file_rst(fname, target_dir, src_dir, gallery_conf)
@@ -467,7 +471,7 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
         intro = extract_intro(new_fname)
         write_backreferences(seen_backrefs, gallery_conf,
                              target_dir, fname, intro)
-        this_entry = _thumbnail_div(target_dir, fname, intro) + """
+        this_entry = _thumbnail_div(target_path_name, fname, intro) + """
 
 .. toctree::
    :hidden:
@@ -607,7 +611,8 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
     image_fname = 'sphx_glr_' + base_image_name + '_{0:03}.png'
     image_path_template = os.path.join(image_dir, image_fname)
 
-    ref_fname = example_file.replace(os.path.sep, '_')
+    file_target = os.path.relpath(example_file, gallery_conf['src_dir'])
+    ref_fname = file_target.replace(os.path.sep, '_')
     example_rst = """\n\n.. _sphx_glr_{0}:\n\n""".format(ref_fname)
     example_nb = Notebook(fname, target_dir)
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -137,6 +137,7 @@ def build_test_configuration(**kwargs):
 
     gallery_conf = copy.deepcopy(gen_gallery.DEFAULT_GALLERY_CONF)
     gallery_conf.update(examples_dir=tempfile.mkdtemp(),
+                        src_dir='',
                         gallery_dir=tempfile.mkdtemp())
     gallery_conf.update(kwargs)
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -236,19 +236,19 @@ def test_thumbnail_number():
         assert_equal(thumbnail_number, 2)
 
 
-def test_save_figures():
+def test_save_figures_mayavi():
     """Test file naming when saving figures. Requires mayavi."""
     try:
         from mayavi import mlab
     except ImportError:
         raise nose.SkipTest('Mayavi not installed')
     mlab.options.offscreen = True
-    examples_dir = tempfile.mkdtemp()
 
-    gallery_conf = {'find_mayavi_figures': True}
+    gallery_conf = build_test_configuration(find_mayavi_figures=True)
+
     mlab.test_plot3d()
     plt.plot(1, 1)
-    fname_template = os.path.join(examples_dir, 'image{0}.png')
+    fname_template = os.path.join(gallery_conf['examples_dir'], 'image{0}.png')
     fig_list, _ = sg.save_figures(fname_template, 0, gallery_conf)
     assert_equal(len(fig_list), 2)
     assert fig_list[0].endswith('image1.png')
@@ -261,7 +261,7 @@ def test_save_figures():
     assert fig_list[0].endswith('image3.png')
     assert fig_list[1].endswith('image4.png')
 
-    shutil.rmtree(examples_dir)
+    shutil.rmtree(gallery_conf['examples_dir'])
 
 
 def test_zip_notebooks():


### PR DESCRIPTION
This aims to fix in a broader sense issues #40 #50 #115 #119 #120 

The issue is that, sphinx-gallery (sphinx way of work) relies on relative paths within the documentation to resolve correctly the back reference links and thumbnail images from arbitrary location in the documentation source.

If one is to build the documentation not inside the doc source using the `make html` command one runs into problems. PR #119 addresses this issue by changing directory during build. But this solution neglects the link embedding in the final html.

This should not be merged before #97 
