### PR TITLE
WIP: Fix link error to sphinx file

### DIFF
--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -232,7 +232,7 @@ class SphinxDocLinkResolver(object):
                 fname_idx = value[cobj['name']][0]
 
         if fname_idx is not None:
-            fname = self._searchindex['filenames'][fname_idx] + '.html'
+            fname = os.path.splitext(self._searchindex['filenames'][fname_idx])[0] + '.html'
 
             if self._is_windows:
                 fname = fname.replace('/', '\\')


### PR DESCRIPTION
Using the bleeding-edge (updated today) version of Sphinx, it looks like files that were originally:
```
_build/html/generated/mne.pick_types.rst.html
```
Are now put in:
```
_build/html/generated/mne.pick_types.html
```
The fix here just strips the `.rst` before appending the `.html`, but will probably only work on latest `sphinx`. Is this a bug that should be fixed by `sphinx-gallery`, or did Sphinx do something they shouldn't have done by changing the filename?