### PR TITLE
STYLE: tighter and pretty download buttons

### DIFF
--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -103,16 +103,28 @@ thumbnail with its default link Background color */
 blockquote.sphx-glr-script-out {
   margin-left: 0pt;
 }
-.sphx-glr-download {
+div.sphx-glr-download {
+  display: inline-block;
+  margin: 1em auto 1ex 2ex;
+}
+
+div.sphx-glr-download a {
   background-color: #ffc;
   border: 1px solid #c2c22d;
   border-radius: 4px;
-  margin: 1em auto 1ex auto;
+  background-image: linear-gradient(to bottom, #FFC, #d5d57e);
   max-width: 45ex;
   padding: 1ex;
+  text-align: center;
+  color: #000;
+  font-weight: bold;
 }
-.sphx-glr-download a {
-  color: #4b4600;
+
+div.sphx-glr-download a:hover {
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.1), 0 1px 5px rgba(0,0,0,.25);
+    text-decoration: none;
+  background-image: none;
+    background-color: #d5d57e;
 }
 
 ul.sphx-glr-horizontal {

--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -121,10 +121,10 @@ div.sphx-glr-download a {
 }
 
 div.sphx-glr-download a:hover {
-    box-shadow: inset 0 1px 0 rgba(255,255,255,.1), 0 1px 5px rgba(0,0,0,.25);
-    text-decoration: none;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.1), 0 1px 5px rgba(0,0,0,.25);
+  text-decoration: none;
   background-image: none;
-    background-color: #d5d57e;
+  background-color: #d5d57e;
 }
 
 ul.sphx-glr-horizontal {

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -108,10 +108,10 @@ CODE_DOWNLOAD = """**Total running time of the script:**
 ({0:.0f} minutes {1:.3f} seconds)\n\n
 \n.. container:: sphx-glr-download
 
-    **Download Python source code:** :download:`{2} <{2}>`\n
+    :download:`Download Python source code: {2} <{2}>`\n
 \n.. container:: sphx-glr-download
 
-    **Download IPython notebook:** :download:`{3} <{3}>`\n"""
+    :download:`Download IPython notebook: {3} <{3}>`\n"""
 
 # The following strings are used when we have several pictures: we use
 # an html div tag that our CSS uses to turn the lists into horizontal


### PR DESCRIPTION
This is a small style change to make the download buttons of the examples take less vertical space while still being more visible.

I am attaching a screenshot of the new style:
![tighter_download](https://cloud.githubusercontent.com/assets/208217/17448545/c6de6ce2-5b09-11e6-9d7c-4b58cd416347.png)
