### PR TITLE
[MRG] Notebook inline math

### DIFF
--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -55,7 +55,8 @@ def rst2md(text):
 
     math_eq = re.compile(r'^\.\. math::((?:.+)?(?:\n+^  .+)*)', flags=re.M)
     text = re.sub(math_eq,
-                  lambda match: r'$${0}$$'.format(match.group(1).strip()),
+                  lambda match: r'\begin{{align}}{0}\end{{align}}'.format(
+                      match.group(1).strip()),
                   text)
     inline_math = re.compile(r':math:`(.+?)`', re.DOTALL)
     text = re.sub(inline_math, r'$\1$', text)

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -57,7 +57,7 @@ def rst2md(text):
     text = re.sub(math_eq,
                   lambda match: r'$${0}$$'.format(match.group(1).strip()),
                   text)
-    inline_math = re.compile(r':math:`(.+)`')
+    inline_math = re.compile(r':math:`(.+?)`')
     text = re.sub(inline_math, r'$\1$', text)
 
     return text

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -57,7 +57,7 @@ def rst2md(text):
     text = re.sub(math_eq,
                   lambda match: r'$${0}$$'.format(match.group(1).strip()),
                   text)
-    inline_math = re.compile(r':math:`(.+?)`')
+    inline_math = re.compile(r':math:`(.+?)`', re.DOTALL)
     text = re.sub(inline_math, r'$\1$', text)
 
     return text

--- a/sphinx_gallery/tests/test_notebook.py
+++ b/sphinx_gallery/tests/test_notebook.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Author: Óscar Nájera
+# License: 3-clause BSD
+r"""
+Testing the Jupyter notebook parser
+"""
+
+from __future__ import division, absolute_import, print_function
+import re
+from nose.tools import assert_equal, assert_false, assert_true
+from sphinx_gallery.notebook import rst2md
+
+
+def test_latex_conversion():
+    """Latex parsing from rst into Jupyter Markdown"""
+    double_inline_rst = r":math:`T<0` and :math:`U>0`"
+    double_inline_jmd = r"$T<0$ and $U>0$"
+    assert_equal(double_inline_jmd, rst2md(double_inline_rst))
+
+    align_eq = r"""
+.. math::
+   \mathcal{H} &= 0 \\
+   \mathcal{G} &= D"""
+
+    align_eq_jmd = r"""
+\begin{align}\mathcal{H} &= 0 \\
+   \mathcal{G} &= D\end{align}"""
+    assert_equal(align_eq_jmd, rst2md(align_eq))


### PR DESCRIPTION
If inline math appears multiple times in the same line it would be joined in the same block. The non-greedy regex fixes that.
If inline math spans over multiple lines, it would not be parsed. The re.DOTALL fixes that

- [x] Extend test to cover this.

For discussion. The example `plot_quantum.py` uses heavily latex. I noticed the previous bugs from it. It also uses a multiline math that to be rendered correctly in the jupyter notebook it requires to be wrapped with:
```latex
\begin{align}
\end{align}
```
Should I make this the default for the rst syntax:
```rst
.. math: some latex
```