### PR TITLE
Seaborn enviroment clean up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
     packages:
     - python-numpy
     - python-matplotlib
+    - python-scipy
     - python-pip
     - python-coverage
     - xvfb # For mayavi headless
@@ -32,17 +33,24 @@ before_install:
       fi
 
 install:
+    # force no mkl because mayavi requires old version of numpy
+    # which then crashes with pandas and seaborn
     - if [ "$DISTRIB" == "conda" ]; then
-        conda create --yes -n testenv python=$PYTHON_VERSION pip numpy
-        setuptools matplotlib pillow sphinx nose coverage;
+        conda create --yes -n testenv python=$PYTHON_VERSION pip nomkl numpy
+        setuptools matplotlib pillow sphinx nose coverage seaborn;
         source activate testenv;
         if [ "$PYTHON_VERSION" == "2.7" ]; then
-          conda install --yes --quiet mayavi;
+          conda install --yes mayavi;
           conda upgrade --yes --all;
           pip install --upgrade pyface;
         fi;
       fi;
     - pip install -r requirements.txt
+    # This will build pandas as a dependency in ubuntu 12.04
+    - if [ "$DISTRIB" == "ubuntu" ]; then pip install seaborn; fi;
+
+    # Seaborn does not support python 2.6 thus is not available in conda
+    - if [ "$PYTHON_VERSION" == "2.6" ]; then pip install seaborn; fi;
     - python setup.py install
 
 # To test the mayavi environmen follow the instructions at

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,18 @@ Change Log
 git master
 ----------
 
+New features
+''''''''''''
+* Enhanced CSS for download buttons
+
+Bug Fixes
+'''''''''
+* When seaborn is imported in a example the plot style preferences are
+  tranfered to plots executed aftewards. The CI is set up such that
+  users can follow how to get the compatible versions of
+  mayavi-pandas-seaborn and nomkl in a conda environment to have all
+  the features available.
+
 v0.1.3
 ------
 

--- a/examples/plot_seaborn.py
+++ b/examples/plot_seaborn.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+r"""
+Using Seaborn
+=============
+
+A example from their website
+
+"""
+# Author: Michael Waskom
+# License: BSD 3 clause
+
+from __future__ import division, absolute_import, print_function
+
+import seaborn as sns
+import matplotlib.pyplot as plt
+sns.set(style="white")
+
+df = sns.load_dataset("iris")
+
+g = sns.PairGrid(df, diag_sharey=False)
+g.map_lower(sns.kdeplot, cmap="Blues_d")
+g.map_upper(plt.scatter)
+g.map_diag(sns.kdeplot, lw=3)

--- a/examples/plot_seaborn.py
+++ b/examples/plot_seaborn.py
@@ -1,23 +1,29 @@
 # -*- coding: utf-8 -*-
 r"""
-Using Seaborn
-=============
+Seaborn example
+===============
 
-A example from their website
-
+Preview the capture of seaborn styles in plots
 """
 # Author: Michael Waskom
 # License: BSD 3 clause
 
 from __future__ import division, absolute_import, print_function
 
+
+import numpy as np
 import seaborn as sns
-import matplotlib.pyplot as plt
-sns.set(style="white")
 
-df = sns.load_dataset("iris")
+# Enforce the use of default set style
+#sns.set(style="darkgrid", palette="Set2")
 
-g = sns.PairGrid(df, diag_sharey=False)
-g.map_lower(sns.kdeplot, cmap="Blues_d")
-g.map_upper(plt.scatter)
-g.map_diag(sns.kdeplot, lw=3)
+# Create a noisy periodic dataset
+sines = []
+rs = np.random.RandomState(8)
+for _ in range(15):
+    x = np.linspace(0, 30 / 2, 30)
+    y = np.sin(x) + rs.normal(0, 1.5) + rs.normal(0, .3, 30)
+    sines.append(y)
+
+# Plot the average over replicates with bootstrap resamples
+sns.tsplot(sines, err_style="boot_traces", n_boot=500)

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -642,6 +642,14 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
             example_rst += text2string(bcontent) + '\n'
             example_nb.add_markdown_cell(text2string(bcontent))
 
+    # Unload seaborn after all examples run
+    if 'seaborn' in sys.modules:
+        sys.modules['seaborn'].reset_defaults()
+        sys.modules['seaborn'].reset_orig()
+
+    # Reset Matplotlib to default
+    plt.rcdefaults()
+
     # Writes md5 checksum if example has build correctly
     # not failed and was initially meant to run(no-plot shall not cache md5sum)
     if block_vars['execute_script']:

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -93,6 +93,10 @@ class Tee(object):
         self.file1.flush()
         self.file2.flush()
 
+    # When called from a local terminal seaborn needs it in Python3
+    def isatty(self):
+        self.file1.isatty()
+
 
 class MixedEncodingStringIO(StringIO):
     """Helper when both ASCII and unicode strings will be written"""

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -646,10 +646,12 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
             example_rst += text2string(bcontent) + '\n'
             example_nb.add_markdown_cell(text2string(bcontent))
 
-    # Unload seaborn after all examples run
+    # Horrible code to 'unload' seaborn, so that it resets
+    # its default when is load
+    # Python does not support unloading of modules
+    # https://bugs.python.org/issue9072
     if 'seaborn' in sys.modules:
-        sys.modules['seaborn'].reset_defaults()
-        sys.modules['seaborn'].reset_orig()
+        del sys.modules['seaborn']
 
     # Reset Matplotlib to default
     plt.rcdefaults()

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -565,6 +565,24 @@ def execute_code_block(code_block, example_globals,
     return code_output, time_elapsed
 
 
+def clean_modules():
+    """Remove "unload" seaborn from the name space
+
+    After a script is executed it can load a variety of setting that one
+    does not want to influence in other examples in the gallery."""
+
+    # Horrible code to 'unload' seaborn, so that it resets
+    # its default when is load
+    # Python does not support unloading of modules
+    # https://bugs.python.org/issue9072
+    for module in list(sys.modules.keys()):
+        if 'seaborn' in module:
+            del sys.modules[module]
+
+    # Reset Matplotlib to default
+    plt.rcdefaults()
+
+
 def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
     """Generate the rst file for a given example.
 
@@ -646,15 +664,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
             example_rst += text2string(bcontent) + '\n'
             example_nb.add_markdown_cell(text2string(bcontent))
 
-    # Horrible code to 'unload' seaborn, so that it resets
-    # its default when is load
-    # Python does not support unloading of modules
-    # https://bugs.python.org/issue9072
-    if 'seaborn' in sys.modules:
-        del sys.modules['seaborn']
-
-    # Reset Matplotlib to default
-    plt.rcdefaults()
+    clean_modules()
 
     # Writes md5 checksum if example has build correctly
     # not failed and was initially meant to run(no-plot shall not cache md5sum)

--- a/tutorials/plot_seaborn_notebook.py
+++ b/tutorials/plot_seaborn_notebook.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+r"""
+A notebook seaborn test
+=======================
+
+Just to have examples in the gallery of notebooks
+"""
+# Author: Michael Waskom
+# License: BSD 3 clause
+
+from __future__ import division, absolute_import, print_function
+import numpy as np
+from scipy.stats import kendalltau
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+sns.set(style="ticks")
+
+rs = np.random.RandomState(11)
+x = rs.gamma(2, size=1000)
+y = -.5 * x + rs.normal(size=1000)
+
+sns.jointplot(x, y, kind="hex", stat_func=kendalltau, color="#4CB391")
+
+###############################################################################
+# A new block in the notebook to have different styles
+#
+sns.set(style="whitegrid", palette="pastel", color_codes=True)
+
+# Load the example tips dataset
+tips = sns.load_dataset("tips")
+
+# Draw a nested violinplot and split the violins for easier comparison
+sns.violinplot(x="day", y="total_bill", hue="sex", data=tips, split=True,
+               inner="quart", palette={"Male": "b", "Female": "y"})
+sns.despine(left=True)


### PR DESCRIPTION
If seaborn is loaded in one example, examples afterward keep using its plotting style. This patch clears its presence. I'm still looking for different way to sandbox the python execution.

I'm also getting errors in python3 on the seaborn script.