### PR TITLE
ENH: Improve markdown conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+*.orig
 
 # Translations
 *.mo
@@ -50,6 +51,7 @@ coverage.xml
 # Sphinx documentation
 doc/_build/
 doc/auto_examples
+doc/auto_mayavi_examples
 doc/tutorials/
 doc/modules/generated
 

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -11,10 +11,12 @@ Class that holds the Jupyter notebook information
 # License: 3-clause BSD
 
 from __future__ import division, absolute_import, print_function
+from functools import partial
 import json
 import os
 import re
 import sys
+
 
 def ipy_notebook_skeleton():
     """Returns a dictionary with the elements of a Jupyter notebook"""
@@ -46,6 +48,14 @@ def ipy_notebook_skeleton():
     return notebook_skeleton
 
 
+def directive_fun(match, directive):
+    """Helper to fill in directives"""
+    directive_to_alert = dict(note="info", warning="danger")
+    return ('<div class="alert alert-{0}"><h4>{1}</h4><p>{2}</p></div>'
+            ''.format(directive_to_alert[directive], directive.capitalize(),
+                      match.group(1).strip()))
+
+
 def rst2md(text):
     """Converts the RST text from the examples docstrigs and comments
     into markdown text for the Jupyter notebooks"""
@@ -60,6 +70,29 @@ def rst2md(text):
                   text)
     inline_math = re.compile(r':math:`(.+?)`', re.DOTALL)
     text = re.sub(inline_math, r'$\1$', text)
+
+    directives = ('warning', 'note')
+    for directive in directives:
+        directive_re = re.compile(r'^\.\. %s::((?:.+)?(?:\n+^  .+)*)'
+                                  % directive, flags=re.M)
+        text = re.sub(directive_re,
+                      partial(directive_fun, directive=directive), text)
+
+    links = re.compile(r'^ *\.\. _.*:.*$\n', flags=re.M)
+    text = re.sub(links, '', text)
+
+    refs = re.compile(r':ref:`')
+    text = re.sub(refs, '`', text)
+
+    contents = re.compile(r'^\s*\.\. contents::.*$(\n +:\S+: *$)*\n',
+                          flags=re.M)
+    text = re.sub(contents, '', text)
+
+    images = re.compile(
+        r'^\.\. image::(.*$)(\n *:alt:(.*$))?[\n +:\S+:.*$]*', flags=re.M)
+    text = re.sub(
+        images, lambda match: '![{1}]({0})\n'.format(
+            match.group(1).strip(), (match.group(3) or '').strip()), text)
 
     return text
 

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -52,8 +52,8 @@ def directive_fun(match, directive):
     """Helper to fill in directives"""
     directive_to_alert = dict(note="info", warning="danger")
     return ('<div class="alert alert-{0}"><h4>{1}</h4><p>{2}</p></div>'
-            ''.format(directive_to_alert[directive], directive.capitalize(),
-                      match.group(1).strip()))
+            .format(directive_to_alert[directive], directive.capitalize(),
+                    match.group(1).strip()))
 
 
 def rst2md(text):
@@ -89,10 +89,11 @@ def rst2md(text):
     text = re.sub(contents, '', text)
 
     images = re.compile(
-        r'^\.\. image::(.*$)(\n *:alt:(.*$))?[\n +:\S+:.*$]*', flags=re.M)
+        r'^\.\. image::(.*$)(?:\n *:alt:(.*$)\n)?(?: +:\S+:.*$\n)*',
+        flags=re.M)
     text = re.sub(
         images, lambda match: '![{1}]({0})\n'.format(
-            match.group(1).strip(), (match.group(3) or '').strip()), text)
+            match.group(1).strip(), (match.group(2) or '').strip()), text)
 
     return text
 

--- a/sphinx_gallery/tests/test_notebook.py
+++ b/sphinx_gallery/tests/test_notebook.py
@@ -26,3 +26,43 @@ def test_latex_conversion():
 \begin{align}\mathcal{H} &= 0 \\
    \mathcal{G} &= D\end{align}"""
     assert_equal(align_eq_jmd, rst2md(align_eq))
+
+
+def test_convert():
+    """Test ReST conversion"""
+    rst = """hello
+
+.. contents::
+    :local:
+
+This is :math:`some` math :math:`stuff`.
+
+.. note::
+    Interpolation is a linear operation that can be performed also on
+    Raw and Epochs objects.
+
+.. warning::
+    Go away
+
+For more details on interpolation see the page :ref:`channel_interpolation`.
+.. _foo: bar
+
+.. image:: foobar
+  :alt: me
+  :whatever: you
+"""
+
+    markdown = """hello
+
+This is $some$ math $stuff$.
+
+<div class="alert alert-info"><h4>Note</h4><p>Interpolation is a linear operation that can be performed also on
+    Raw and Epochs objects.</p></div>
+
+<div class="alert alert-danger"><h4>Warning</h4><p>Go away</p></div>
+
+For more details on interpolation see the page `channel_interpolation`.
+
+![me](foobar)
+"""  # noqa
+    assert_equal(rst2md(rst), markdown)

--- a/tutorials/plot_notebook.py
+++ b/tutorials/plot_notebook.py
@@ -99,3 +99,16 @@ print('Some output from Python')
 # code directly will see the plots; this is not necessary for creating the docs
 
 plt.show()
+
+############################################################################
+# You can also include :math:`math` inline, or as separate equations:
+#
+# .. math::
+#
+#    \exp(j\pi) = -1
+#
+# You can also insert images:
+#
+# .. image:: http://www.sphinx-doc.org/en/stable/_static/sphinxheader.png
+#    :alt: Sphinx header
+#


### PR DESCRIPTION
Closes #141.

1. Removes some of the offending residual restructuredtext directives:
    ![screenshot from 2016-08-30 13-04-42](https://cloud.githubusercontent.com/assets/2365790/18099012/acd6b842-6eb2-11e6-92fb-a863ff0d40d1.png)

2. Adds warning/note boxes:
    ![screenshot from 2016-08-30 13-05-00](https://cloud.githubusercontent.com/assets/2365790/18099020/b5d762ca-6eb2-11e6-9162-9f83fd5f16d0.png)

3. Adds image support:
    ![screenshot from 2016-08-30 13-05-31](https://cloud.githubusercontent.com/assets/2365790/18099024/ba42d380-6eb2-11e6-8811-a401101426a6.png)

4. Corrects problem with greedy regex for inline math.

Ready for review/merge from my end.