### PR TITLE
[MRG] CSS: improve rendering of download buttons

### DIFF
--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -111,6 +111,7 @@ div.sphx-glr-footer {
 div.sphx-glr-download {
   display: inline-block;
   margin: 1em auto 1ex 2ex;
+  vertical-align: middle;
 }
 
 div.sphx-glr-download a {

--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -140,6 +140,12 @@ div.sphx-glr-download a {
     }
 }
 
+@media (min-width: 40em) {
+    div.sphx-glr-download a {
+	min-width: 16em;
+    }
+}
+
 
 div.sphx-glr-download code.download {
   display: inline-block;

--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -128,6 +128,11 @@ div.sphx-glr-download a {
   text-align: center;
 }
 
+/* The last child of a download button is the file name */
+div.sphx-glr-download a span:last-child {
+    font-size: smaller;
+}
+
 @media (min-width: 20em) {
     div.sphx-glr-download a {
 	min-width: 10em;

--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -130,6 +130,7 @@ div.sphx-glr-download a {
 
 div.sphx-glr-download code.download {
   display: inline-block;
+  white-space: normal;
 }
 
 div.sphx-glr-download a:hover {
@@ -150,18 +151,15 @@ ul.sphx-glr-horizontal img {
   height: auto !important;
 }
 
-p.sphx-glr-signature {
-  text-align: right;
-  margin-left: auto;
-  display: table;
-}
-
 p.sphx-glr-signature a.reference.external {
   -moz-border-radius: 5px;
   -webkit-border-radius: 5px;
   border-radius: 5px;
   padding: 3px;
   font-size: 75%;
+  text-align: right;
+  margin-left: auto;
+  display: table;
 }
 
 a.sphx-glr-code-links:hover{

--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -103,6 +103,11 @@ thumbnail with its default link Background color */
 blockquote.sphx-glr-script-out {
   margin-left: 0pt;
 }
+
+div.sphx-glr-footer {
+    text-align: center;
+}
+
 div.sphx-glr-download {
   display: inline-block;
   margin: 1em auto 1ex 2ex;
@@ -115,11 +120,13 @@ div.sphx-glr-download a {
   border: 1px solid #c2c22d;
   color: #000;
   display: inline-block;
+  /* Not valid in old browser, hence we keep the line above to override */
+  display: table-caption;
   font-weight: bold;
-  max-width: 45ex;
   padding: 1ex;
   text-align: center;
 }
+
 
 div.sphx-glr-download code.download {
   display: inline-block;
@@ -143,8 +150,13 @@ ul.sphx-glr-horizontal img {
   height: auto !important;
 }
 
+p.sphx-glr-signature {
+  text-align: right;
+  margin-left: auto;
+  display: table;
+}
+
 p.sphx-glr-signature a.reference.external {
-  background-color: #EBECED;
   -moz-border-radius: 5px;
   -webkit-border-radius: 5px;
   border-radius: 5px;

--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -150,6 +150,11 @@ div.sphx-glr-download a {
 div.sphx-glr-download code.download {
   display: inline-block;
   white-space: normal;
+  word-break: normal;
+  overflow-wrap: break-word;
+  /* border and background are given by the enclosing 'a' */
+  border: none;
+  background: none;
 }
 
 div.sphx-glr-download a:hover {

--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -127,6 +127,18 @@ div.sphx-glr-download a {
   text-align: center;
 }
 
+@media (min-width: 20em) {
+    div.sphx-glr-download a {
+	min-width: 10em;
+    }
+}
+
+@media (min-width: 30em) {
+    div.sphx-glr-download a {
+	min-width: 13em;
+    }
+}
+
 
 div.sphx-glr-download code.download {
   display: inline-block;

--- a/sphinx_gallery/downloads.py
+++ b/sphinx_gallery/downloads.py
@@ -13,20 +13,24 @@ import os
 import zipfile
 
 CODE_DOWNLOAD = """
-\n.. container:: sphx-glr-download
+\n.. container:: sphx-glr-footer
 
-    :download:`Download Python source code: {0} <{0}>`\n
+\n  .. container:: sphx-glr-download
 
-\n.. container:: sphx-glr-download
+     :download:`Download Python source code: {0} <{0}>`\n
 
-    :download:`Download Jupyter notebook: {1} <{1}>`\n"""
+\n  .. container:: sphx-glr-download
+
+     :download:`Download Jupyter notebook: {1} <{1}>`\n"""
 
 CODE_ZIP_DOWNLOAD = """
-\n.. container:: sphx-glr-download
+\n.. container:: sphx-glr-footer
+
+\n  .. container:: sphx-glr-download
 
     :download:`Download all examples in Python source code: {0} </{1}>`\n
 
-\n.. container:: sphx-glr-download
+\n  .. container:: sphx-glr-download
 
     :download:`Download all examples in Jupyter notebook files: {2} </{3}>`\n"""
 

--- a/sphinx_gallery/downloads.py
+++ b/sphinx_gallery/downloads.py
@@ -32,7 +32,7 @@ CODE_ZIP_DOWNLOAD = """
 
 \n  .. container:: sphx-glr-download
 
-    :download:`Download all examples in Jupyter notebook files: {2} </{3}>`\n"""
+    :download:`Download all examples in Jupyter notebooks: {2} </{3}>`\n"""
 
 
 def python_zip(file_list, gallery_path, extension='.py'):


### PR DESCRIPTION
This PR:

* Fixes the overflow visible in the download buttons (as discussed in https://github.com/scikit-learn/scikit-learn/pull/7354#issuecomment-246689940)

* Centers the buttons correctly

* Make the sphinx-gallery signature slightly less visible (let's not annoy downstream users)

Before, in sphinx-gallery's documentation:

![image](https://cloud.githubusercontent.com/assets/208217/18550236/0cc44b3c-7b53-11e6-8870-eddac36c7ab9.png)

After:

![image](https://cloud.githubusercontent.com/assets/208217/18550192/df186876-7b52-11e6-976c-e235246140f6.png)

Before in scipy-lectures
![image](https://cloud.githubusercontent.com/assets/208217/18550320/83f024ec-7b53-11e6-860c-dda162295215.png)

After:
![image](https://cloud.githubusercontent.com/assets/208217/18550347/a52982e8-7b53-11e6-8ad3-bf2581ec6e20.png)
