### PR TITLE
[MRG] CSS: add a CSS class to links in code

### DIFF
--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -151,3 +151,25 @@ p.sphx-glr-signature a.reference.external {
   padding: 3px;
   font-size: 75%;
 }
+
+a.sphx-glr-code-links:hover{
+    text-decoration: none;
+}
+
+a.sphx-glr-code-links[title]:hover:before{
+    background: rgba(0,0,0,.8);
+    border-radius: 5px;
+    color: white;
+    content: attr(title);
+    padding: 5px 15px;
+    position: absolute;
+    z-index: 98;
+    width: 15.5em;
+    word-break: normal;
+    display: inline-block;
+    text-align: center;
+    text-indent: 0;
+    margin-left: -5em;
+    margin-top: 1.2em;
+}
+

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -345,7 +345,8 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
                                                     gallery_dir))
 
     # patterns for replacement
-    link_pattern = '<a href="%s" class="sphx-glr-code-links">%s</a>'
+    link_pattern = ('<a href="%s" class="sphx-glr-code-links" '
+       'title="Link to documentation for %s">%s</a>')
     orig_pattern = '<span class="n">%s</span>'
     period = '<span class="o">.</span>'
 
@@ -382,7 +383,9 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
                         parts = name.split('.')
                         name_html = period.join(orig_pattern % part
                                                 for part in parts)
-                        str_repl[name_html] = link_pattern % (link, name_html)
+                        str_repl[name_html] = link_pattern % (link,
+                            '%s.%s' % (cobj['module'], cobj['name']),
+                            name_html)
                 # do the replacement in the html file
 
                 # ensure greediness

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -345,7 +345,7 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
                                                     gallery_dir))
 
     # patterns for replacement
-    link_pattern = '<a href="%s">%s</a>'
+    link_pattern = '<a href="%s" class="sphx-glr-code-links">%s</a>'
     orig_pattern = '<span class="n">%s</span>'
     period = '<span class="o">.</span>'
 


### PR DESCRIPTION
The goal is to enable downstream to style the doc-resolv links in code examples specially.