### PR TITLE
Sphinx themes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,17 @@ Change Log
 git master
 ----------
 
+Developer changes
+'''''''''''''''''
+* Support on the fly theme change for local builds of the
+  Sphinx-Gallery docs. Passing to the make target the variable `theme`
+  builds the docs with the new theme. All sphinx themes are availible
+  plus read the docs online theme under the value `rtd` as shown in this
+  usage example.::
+
+    $ make html theme=rtd
+
+
 v0.1.4
 ------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Developer changes
 '''''''''''''''''
 * Support on the fly theme change for local builds of the
   Sphinx-Gallery docs. Passing to the make target the variable `theme`
-  builds the docs with the new theme. All sphinx themes are availible
+  builds the docs with the new theme. All sphinx themes are available
   plus read the docs online theme under the value `rtd` as shown in this
   usage example.::
 
@@ -33,12 +33,12 @@ New features
 Bug Fixes
 '''''''''
 * When seaborn is imported in a example the plot style preferences are
-  tranfered to plots executed aftewards. The CI is set up such that
+  transferred to plots executed afterwards. The CI is set up such that
   users can follow how to get the compatible versions of
   mayavi-pandas-seaborn and nomkl in a conda environment to have all
   the features available.
 * Fix math conversion from example rst to Jupyter notebook text for
-  inline math and multiline equations
+  inline math and multi-line equations
 
 v0.1.3
 ------
@@ -82,7 +82,7 @@ Bug Fixes
 '''''''''
 
 * Restore the html-noplot functionality
-* Gallery CSS now implictly enforces thumbnails width
+* Gallery CSS now implicitly enforces thumbnails width
 
 v0.1.0
 ------

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -21,9 +21,15 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
 .PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
 
+# Theme variable default
+theme = default
+
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"
+	@echo "             can include the sphinx theme to rendered with variable"
+	@echo "     theme=[default,rtd,alabaster,sphinxdoc,scrolls,agogo,"
+	@echo "            traditional,nature,haiku,pyramid,bizstyle]"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
 	@echo "  pickle     to make pickle files"
@@ -45,6 +51,7 @@ help:
 	@echo "  pseudoxml  to make pseudoxml-XML files for display purposes"
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
+
 clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf auto_examples/
@@ -53,16 +60,19 @@ clean:
 	rm -rf generated/*
 	rm -rf modules/generated/*
 
+html-noplot: export SPHX_GLR_THEME = $(theme)
 html-noplot:
 	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
+html_abort_on_example_error: export SPHX_GLR_THEME = $(theme)
 html_abort_on_example_error:
 	$(SPHINXBUILD) -D abort_on_example_error=1 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
+html: export SPHX_GLR_THEME = $(theme)
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -113,7 +113,21 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+
+# The theme is set by the make target
+html_theme = os.environ.get('SPHX_GLR_THEME', 'default')
+
+# on_rtd is whether we are on readthedocs.org, this line of code grabbed
+# from docs.readthedocs.org
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+# only import rtd theme and set it if want to build docs locally
+if not on_rtd and html_theme == 'rtd':
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+# otherwise, readthedocs.org uses their theme by default, so no need to
+# specify it
 
 
 def setup(app):


### PR DESCRIPTION
In response to the discussion in https://github.com/sphinx-gallery/sphinx-gallery/pull/145#issuecomment-247575808

Here I propose to change the html theme passing an extra variable to the make target. In this case on can build locally the read the docs theme by using

```bash
make html theme=rtd
```

Also all sphinx themes become available. Thus to change to nature theme is as simple as
```bash
make html theme=nature
```

If one does not pass the `theme=value` instruction the `classic` default is taken.
