### PR TITLE
Update travis to drop ubuntu 12 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,25 +3,33 @@ sudo: false
 addons:
   apt:
     packages:
-    - python-numpy
-    - python-matplotlib
-    - python-scipy
-    - python-pip
-    - python-coverage
     - xvfb # For mayavi headless
 
 virtualenv:
         system_site_packages: true
 
-env:
-    matrix:
-        - DISTRIB="ubuntu" PYTHON_VERSION="2.7"
-        # This environment tests the oldest supported anaconda env
-        - DISTRIB="conda" PYTHON_VERSION="2.6"
-        # This environment tests is for mayavi
-        - DISTRIB="conda" PYTHON_VERSION="2.7"
-        # This environment tests the newest supported anaconda env
-        - DISTRIB="conda" PYTHON_VERSION="3.4"
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: DISTRIB="ubuntu 14" PYTHON_VERSION="2.7"
+      addons:
+        apt:
+          packages:
+            - python-numpy
+            - python-matplotlib
+            - python-scipy
+            - python-pip
+            - python-coverage
+            - cython
+            - python-pandas
+    # This environment tests is for mayavi
+    - os: linux
+      env: DISTRIB="conda" PYTHON_VERSION="2.7"
+    # This environment tests the newest supported anaconda env
+    - os: linux
+      env: DISTRIB="conda" PYTHON_VERSION="3.4"
 
 before_install:
     - if [ "$DISTRIB" == "conda" ]; then
@@ -46,11 +54,8 @@ install:
         fi;
       fi;
     - pip install -r requirements.txt
-    # This will build pandas as a dependency in ubuntu 12.04
-    - if [ "$DISTRIB" == "ubuntu" ]; then pip install seaborn; fi;
+    - if [ "$DISTRIB" == "ubuntu 14" ]; then pip install seaborn; fi;
 
-    # Seaborn does not support python 2.6 thus is not available in conda
-    - if [ "$PYTHON_VERSION" == "2.6" ]; then pip install seaborn; fi;
     - python setup.py install
 
 # To test the mayavi environment follow the instructions at

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Change Log
 git master
 ----------
 
+
 Developer changes
 '''''''''''''''''
 * Support on the fly theme change for local builds of the
@@ -13,6 +14,9 @@ Developer changes
   usage example.::
 
     $ make html theme=rtd
+
+* Test Sphinx Gallery support on Ubuntu 14 packages, drop Ubuntu 12
+  support. Drop support for Python 2.6 in the conda environment
 
 
 v0.1.4


### PR DESCRIPTION
while working on #151, I hit again the problem of tests not passing on ubuntu. Problem is the seaborn support and requirement for pandas cython for pandas.
I have created a more descriptive test matrix, which loads ubuntu 12 and 14. Ubuntu 14 does not have seaborn either but the pandas version is updated enough to work with seaborn.
After few tests I can't get ubuntu 12 to work without upgrading all python packages with pip.

Travis still claims ubuntu 14 is a test feature and builds on it take longer. That is the reason of the container matrix. All test on conda are ubuntu 12 containers and for ubuntu 14 specific packages the environment is different.