### PR TITLE
Warn the user to set the Agg backend

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,11 @@ git master
 
 Bug Fixes
 '''''''''
-* Sphinx-Gallery now reminds the user to set the Agg backend in their
-  Sphinx configuration in case they are loading any other backend.
+* Sphinx-Gallery now raises an exception if the matplotlib bakend can
+  not be set to ``'agg'``. This can happen for example if
+  matplotlib.pyplot is imported in conf.py. See `#157
+  <https://github.com/sphinx-gallery/sphinx-gallery/pull/157>`_ for
+  more details.
 
 v0.1.5
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Change Log
 git master
 ----------
 
+Bug Fixes
+'''''''''
+* Sphinx-Gallery now reminds the user to set the Agg backend in their
+  Sphinx configuration in case they are loading any other backend.
+
 v0.1.5
 ------
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -55,23 +55,25 @@ except ImportError:
 
 from io import StringIO
 
-mpl_backend_msg = """
-
-Sphinx-Gallery relies on the matplotlib Agg backend to render figures
-and write them to files. You are currently using the {} backend.
-Sphinx-Gallery will terminate the build now, because changing backends
-is not well supported by matplotlib. We advise you to move
-sphinx_gallery imports before any matplotlib-dependent import. Moving
-sphinx_gallery imports at the top of your conf.py file should fix this
-issue.\n\n"""
-
 try:
     # make sure that the Agg backend is set before importing any
     # matplotlib
     import matplotlib
-    matplotlib.use('Agg')
-    if matplotlib.get_backend() != 'agg':
-        raise ValueError(mpl_backend_msg.format(matplotlib.get_backend()))
+    matplotlib.use('agg')
+    matplotlib_backend = matplotlib.get_backend()
+
+    if matplotlib_backend != 'agg':
+        mpl_backend_msg = (
+            "Sphinx-Gallery relies on the matplotlib 'agg' backend to "
+            "render figures and write them to files. You are "
+            "currently using the {} backend. Sphinx-Gallery will "
+            "terminate the build now, because changing backends is "
+            "not well supported by matplotlib. We advise you to move "
+            "sphinx_gallery imports before any matplotlib-dependent "
+            "import. Moving sphinx_gallery imports at the top of "
+            "your conf.py file should fix this issue")
+
+        raise ValueError(mpl_backend_msg.format(matplotlib_backend))
 
     import matplotlib.pyplot as plt
 except ImportError:

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -55,11 +55,24 @@ except ImportError:
 
 from io import StringIO
 
+mpl_backend_msg = """
+
+Sphinx-Gallery relies on the matplotlib Agg backend to render figures
+and write them to files. You are currently using the {} backend.
+Sphinx-Gallery will terminate the build now, because changing backends
+is not well supported by matplotlib. We advise you to move
+sphinx_gallery imports before any matplotlib-dependent import. Moving
+sphinx_gallery imports at the top of your conf.py file should fix this
+issue.\n\n"""
+
 try:
     # make sure that the Agg backend is set before importing any
     # matplotlib
     import matplotlib
     matplotlib.use('Agg')
+    if matplotlib.get_backend() != 'agg':
+        raise ValueError(mpl_backend_msg.format(matplotlib.get_backend()))
+
     import matplotlib.pyplot as plt
 except ImportError:
     # this script can be imported by nosetest to find tests to run: we should


### PR DESCRIPTION
closes #153 

This includes an additional warning message when loading the Agg backend if matplotlib has loaded any other backend before. 
