### PR TITLE
MRG: Dont close figures until end of script

### DIFF
--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -127,6 +127,8 @@ def scan_used_functions(example_file, gallery_conf):
     return backrefs
 
 
+# XXX This figure:: uses a forward slash even on Windows, but the op.join's
+# elsewhere will use backslashes...
 THUMBNAIL_TEMPLATE = """
 .. raw:: html
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -177,7 +177,7 @@ def get_docstring_and_rest(filename):
     with open(filename, 'rb') as f:
         content = f.read()
     # change from Windows format to UNIX for uniformity
-    content = content.replace('\r\n', '\n')
+    content = content.replace(b'\r\n', b'\n')
 
     node = ast.parse(content)
     if not isinstance(node, ast.Module):

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -176,6 +176,8 @@ def get_docstring_and_rest(filename):
     # "SyntaxError: encoding declaration in Unicode string"
     with open(filename, 'rb') as f:
         content = f.read()
+    # change from Windows format to UNIX for uniformity
+    content = content.replace('\r\n', '\n')
 
     node = ast.parse(content)
     if not isinstance(node, ast.Module):
@@ -561,10 +563,10 @@ def execute_code_block(code_block, example_globals,
     except Exception:
         formatted_exception = traceback.format_exc()
 
-        fail_example_warning = 80 * '_' + '\n' + \
-            '%s failed to execute correctly:' % src_file + \
+        fail_example_warning = '\n' + 80 * '_' + '\n' + \
+            '%s failed to execute correctly:' % src_file + '\n' + \
             formatted_exception + 80 * '_' + '\n'
-        warnings.warn(fail_example_warning)
+        warnings.warn(fail_example_warning, stacklevel=3)
 
         fig_num = 0
         images_rst = codestr2rst(formatted_exception, lang='pytb')
@@ -615,6 +617,7 @@ def clean_modules(gallery_conf):
     if gallery_conf.get('find_mayavi_figures', False):
         from mayavi import mlab
         mlab.close(all=True)
+        assert len(mlab.get_engine().scenes) == 0
 
 
 def generate_file_rst(fname, target_dir, src_dir, gallery_conf):

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -5,6 +5,7 @@
 Testing the rst files generator
 """
 from __future__ import division, absolute_import, print_function
+import os
 import sphinx_gallery.backreferences as sg
 from nose.tools import assert_equal
 
@@ -14,21 +15,21 @@ def test_thumbnail_div():
 
     html_div = sg._thumbnail_div('fake_dir', 'test_file.py', 'test formating')
 
-    reference = """
+    reference = r"""
 .. raw:: html
 
     <div class="sphx-glr-thumbcontainer" tooltip="test formating">
 
 .. only:: html
 
-    .. figure:: /fake_dir/images/thumb/sphx_glr_test_file_thumb.png
+    .. figure:: /fake_dir{0}images{0}thumb{0}sphx_glr_test_file_thumb.png
 
         :ref:`sphx_glr_fake_dir_test_file.py`
 
 .. raw:: html
 
     </div>
-"""
+""".format(os.sep)
 
     assert_equal(html_div, reference)
 
@@ -46,7 +47,7 @@ def test_backref_thumbnail_div():
 
 .. only:: html
 
-    .. figure:: /fake_dir/images/thumb/sphx_glr_test_file_thumb.png
+    .. figure:: /fake_dir{0}images{0}thumb{0}sphx_glr_test_file_thumb.png
 
         :ref:`sphx_glr_fake_dir_test_file.py`
 
@@ -57,6 +58,6 @@ def test_backref_thumbnail_div():
 .. only:: not html
 
     * :ref:`sphx_glr_fake_dir_test_file.py`
-"""
+""".format(os.sep)
 
     assert_equal(html_div, reference)

--- a/sphinx_gallery/tests/test_docs_resolv.py
+++ b/sphinx_gallery/tests/test_docs_resolv.py
@@ -6,6 +6,7 @@ Testing the rst files generator
 """
 from __future__ import division, absolute_import, print_function
 import sphinx_gallery.docs_resolv as sg
+import os
 import tempfile
 import sys
 from nose.tools import assert_equal
@@ -16,14 +17,20 @@ def test_shelve():
     retrieved after file is deleted"""
     test_string = 'test information'
     tmp_cache = tempfile.mkdtemp()
-    with tempfile.NamedTemporaryFile('w') as fid:
+    # Don't use context manager for NamedTemporaryFile here:
+    # "Whether the name can be used to open the file a second time, while the
+    # named temporary file is still open, varies across platforms (it can be
+    # so used on Unix; it cannot on Windows NT or later)
+    with tempfile.NamedTemporaryFile('w', delete=False) as fid:
         fid.write(test_string)
-        fid.seek(0)
 
+    try:
         # recovers data from temporary file and caches it in the shelve
         file_data = sg.get_data(fid.name, tmp_cache)
         # tests recovered data matches
         assert_equal(file_data, test_string)
+    finally:
+        os.remove(fid.name)
 
     # test if cached data is available after temporary file has vanished
     assert_equal(sg.get_data(fid.name, tmp_cache), test_string)

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -265,7 +265,7 @@ def test_ipy_notebook():
                 example_nb.add_markdown_cell(sg.text2string(bcontent))
 
         example_nb.save_file()
-        with open(f.name, 'rb') as f:
+        with open(f.name, 'r') as f:
             assert_equal(json.load(f), example_nb.work_notebook)
     finally:
         os.remove(f.name)


### PR DESCRIPTION
Sometimes it is necessary to have figures that are not closed within a given code-block. This modifies the gallery behavior to leave the figures open until the script is done. This is useful e.g. when creating a figure in one code block, and querying some parameter from it later. Our particular use case came from creating a Mayavi figure in one code block, and needing to get the viewport transformation from it in another code-block.