### PR TITLE
Fix backreferences.identify_names when module is used without attribute

### DIFF
--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -103,7 +103,13 @@ def identify_names(code):
     for name, full_name in finder.get_mapping():
         # name is as written in file (e.g. np.asarray)
         # full_name includes resolved import path (e.g. numpy.asarray)
-        module, attribute = full_name.rsplit('.', 1)
+        splitted = full_name.rsplit('.', 1)
+        if len(splitted) == 1:
+            # module without attribute. This is not useful for
+            # backreferences
+            continue
+
+        module, attribute = splitted
         # get shortened module name
         module_short = get_short_module_name(module, attribute)
         cobj = {'name': attribute, 'module': module,

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -60,3 +60,33 @@ def test_backref_thumbnail_div():
 """
 
     assert_equal(html_div, reference)
+
+
+def test_identify_names():
+    code_str = """
+import os
+os
+
+os.path.join
+
+import sphinx_gallery.back_references as br
+br.identify_names
+
+from sphinx_gallery.back_references import identify_names
+identify_names
+"""
+    res = sg.identify_names(code_str)
+    expected = {
+        'os.path.join':
+            {'name': 'join', 'module': 'os.path', 'module_short': 'os.path'},
+        'br.identify_names':
+            {'name': 'identify_names',
+             'module': 'sphinx_gallery.back_references',
+             'module_short': 'sphinx_gallery.back_references'},
+        'identify_names':
+            {'name': 'identify_names',
+             'module': 'sphinx_gallery.back_references',
+             'module_short': 'sphinx_gallery.back_references'}
+        }
+
+    assert_equal(expected, res)


### PR DESCRIPTION
Fix #172.

My guess is that backreferences are not used for modules so I excluded modules without attributes from `scan_used_functions`.

Edit: Close #149 as well.