### PR TITLE
[MRG] Build gallery when example has SyntaxError

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -320,5 +320,5 @@ sphinx_gallery_conf = {
     'examples_dirs': examples_dirs,
     'gallery_dirs': gallery_dirs,
     'find_mayavi_figures': find_mayavi_figures,
-    'expected_failing_examples': ['../examples/plot_raise.py']
+    'expected_failing_examples': ['../examples/plot_raise.py', '../examples/plot_syntaxerror.py']
 }

--- a/examples/plot_syntaxerror.py
+++ b/examples/plot_syntaxerror.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""
+Example with SyntaxError
+========================
+
+Sphinx-Gallery uses Python's AST parser, thus you need to have written
+valid python code for Sphinx-Gallery to parse it. If your script has a
+SyntaxError you'll be presented the traceback and the original code.
+
+"""
+# Code source: Óscar Nájera
+# License: BSD 3 clause
+
+Invalid Python code

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -97,7 +97,10 @@ def identify_names(code):
     e.HelloWorld HelloWorld d d
     """
     finder = NameFinder()
-    finder.visit(ast.parse(code))
+    try:
+        finder.visit(ast.parse(code))
+    except SyntaxError:
+        return {}
 
     example_code_obj = {}
     for name, full_name in finder.get_mapping():

--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -11,6 +11,13 @@ import ast
 import re
 from textwrap import dedent
 
+SYNTAX_ERROR_DOCSTRING = """
+SyntaxError
+===========
+
+Example script with invalid Python syntax
+"""
+
 
 def get_docstring_and_rest(filename):
     """Separate `filename` content between docstring and the rest
@@ -27,12 +34,16 @@ def get_docstring_and_rest(filename):
     # can't use codecs.open(filename, 'r', 'utf-8') here b/c ast doesn't
     # seem to work with unicode strings in Python2.7
     # "SyntaxError: encoding declaration in Unicode string"
-    with open(filename, 'rb') as f:
-        content = f.read()
+    with open(filename, 'rb') as fid:
+        content = fid.read()
     # change from Windows format to UNIX for uniformity
     content = content.replace(b'\r\n', b'\n')
 
-    node = ast.parse(content)
+    try:
+        node = ast.parse(content)
+    except SyntaxError:
+        return SYNTAX_ERROR_DOCSTRING, content.decode('utf-8')
+
     if not isinstance(node, ast.Module):
         raise TypeError("This function only supports modules. "
                         "You provided {0}".format(node.__class__.__name__))


### PR DESCRIPTION
As reported in #126 if an example has a SyntaxError gallery build
breaks. This provides the necessary changes to continue build and
raise an error at the end on the summary of errors