### PR TITLE
[CSS] Code link tooltip is left aligned with code

### DIFF
--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -209,7 +209,6 @@ a.sphx-glr-code-links[tooltip]:hover:before{
     display: inline-block;
     text-align: center;
     text-indent: 0;
-    margin-left: -5em;
+    margin-left: 0; /* Use zero to avoid overlapping with sidebar */
     margin-top: 1.2em;
 }
-


### PR DESCRIPTION
This is a tiny backport of a CSS needed for Sphinx-Gallery not to collapse this Scikit-learn website theme.

Code link tooltips used to be shifted to the left to give the impression
they are centered with the link one hovers the mouse. Nevertheless this
floating tooltip collides with the sidebar in the Scikit-learn
documentation.

As a general goal our CSS shall not collide with other projects
templates. Thus this tooltip shall be contained with the codeblock
where the links are.