### PR TITLE
[MRG] Add Python 3.5 for AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   global:
     PYTHON: "C:\\conda"
     MINICONDA_VERSION: "latest"
-    CONDA_DEPENDENCIES: "numpy seaborn matplotlib mayavi sphinx pillow nose coverage"
+    CONDA_DEPENDENCIES: "numpy seaborn matplotlib sphinx pillow nose coverage"
 
   matrix:
     - PYTHON_VERSION: "2.7"
@@ -23,6 +23,8 @@ install:
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "activate test"
+    # mayavi only compatible with Python 2.7
+    - 'IF "%PYTHON_VERSION%"=="2.7" ( conda install mayavi )'
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,8 @@ environment:
   matrix:
     - PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
+    - PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "64"
 
 platform:
     -x64


### PR DESCRIPTION
This PR is just to make sure this is working as expected. I'll merge it once AppVeyor comes back green and I'll double check that Python 3.5 is used.