### PR TITLE
[MRG] Drop styling of codelinks tooltip use title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Change Log
 git master
 ----------
 
+New features
+''''''''''''
+
+* Drop styling in codelinks tooltip. Replaced for title attribute which is managed by the browser.
+
 v0.1.7
 ------
 

--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -190,25 +190,3 @@ p.sphx-glr-signature a.reference.external {
   margin-left: auto;
   display: table;
 }
-
-a.sphx-glr-code-links:hover{
-    text-decoration: none;
-}
-
-a.sphx-glr-code-links[tooltip]:hover:before{
-    background: rgba(0,0,0,.8);
-    border-radius: 5px;
-    color: white;
-    content: attr(tooltip);
-    padding: 5px 15px;
-    position: absolute;
-    z-index: 98;
-    width: 16em;
-    word-break: normal;
-    white-space: normal;
-    display: inline-block;
-    text-align: center;
-    text-indent: 0;
-    margin-left: 0; /* Use zero to avoid overlapping with sidebar */
-    margin-top: 1.2em;
-}

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -359,8 +359,7 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
                                                     gallery_dir))
 
     # patterns for replacement
-    link_pattern = ('<a href="%s" class="sphx-glr-code-links" '
-                    'tooltip="Link to documentation for %s">%s</a>')
+    link_pattern = ('<a href="%s" title="View documentation for %s">%s</a>')
     orig_pattern = '<span class="n">%s</span>'
     period = '<span class="o">.</span>'
 


### PR DESCRIPTION
Following the recommendation done on https://github.com/scikit-learn/scikit-learn/pull/7986#issuecomment-265322148, this PR simplifies the tooltips for code links

Currently the tooltip appears immediately after hovering the link and with message "Link to". It is visually uniform in firefox and chromium.
![before](https://cloud.githubusercontent.com/assets/713451/21137861/ca60ac62-c12b-11e6-811f-41bf6b2462f4.png)

This changes uses title and lets the browser handle this popup which appears after a few seconds of hovering over the link. It also changes "link to"->"View"
Thus in firefox it is similar to the previous one but without the like break
![firefox](https://cloud.githubusercontent.com/assets/713451/21137945/264a3b60-c12c-11e6-895f-8306fb098d10.png)
And in chromium is a different style
![chromium](https://cloud.githubusercontent.com/assets/713451/21137947/2888484a-c12c-11e6-94bc-99abbd9d1611.png)

