### PR TITLE
ENH: Cleaner output

### DIFF
--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -364,7 +364,7 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
     orig_pattern = '<span class="n">%s</span>'
     period = '<span class="o">.</span>'
 
-    # This could
+    # This could be turned into a generator if necessary, but should be okay
     flat = [[dirpath, filename]
             for dirpath, _, filenames in os.walk(html_gallery_dir)
             for filename in filenames]

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -11,6 +11,8 @@ import re
 import shelve
 import sys
 
+from sphinx.util.console import fuchsia
+
 # Try Python 2 first, otherwise load from Python 3
 try:
     import cPickle as pickle
@@ -358,71 +360,75 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
 
     # patterns for replacement
     link_pattern = ('<a href="%s" class="sphx-glr-code-links" '
-       'tooltip="Link to documentation for %s">%s</a>')
+                    'tooltip="Link to documentation for %s">%s</a>')
     orig_pattern = '<span class="n">%s</span>'
     period = '<span class="o">.</span>'
 
-    for dirpath, _, filenames in os.walk(html_gallery_dir):
-        for fname in filenames:
-            print('\tprocessing: %s' % fname)
-            full_fname = os.path.join(html_gallery_dir, dirpath, fname)
-            subpath = dirpath[len(html_gallery_dir) + 1:]
-            pickle_fname = os.path.join(gallery_dir, subpath,
-                                        fname[:-5] + '_codeobj.pickle')
+    # This could
+    flat = [[dirpath, filename]
+            for dirpath, _, filenames in os.walk(html_gallery_dir)
+            for filename in filenames]
+    iterator = app.status_iterator(
+        flat, os.path.basename(html_gallery_dir), colorfunc=fuchsia,
+        length=len(flat), stringify_func=lambda x: os.path.basename(x[1]))
+    for dirpath, fname in iterator:
+        full_fname = os.path.join(html_gallery_dir, dirpath, fname)
+        subpath = dirpath[len(html_gallery_dir) + 1:]
+        pickle_fname = os.path.join(gallery_dir, subpath,
+                                    fname[:-5] + '_codeobj.pickle')
 
-            if os.path.exists(pickle_fname):
-                # we have a pickle file with the objects to embed links for
-                with open(pickle_fname, 'rb') as fid:
-                    example_code_obj = pickle.load(fid)
-                fid.close()
-                str_repl = {}
-                # generate replacement strings with the links
-                for name, cobj in example_code_obj.items():
-                    this_module = cobj['module'].split('.')[0]
+        if os.path.exists(pickle_fname):
+            # we have a pickle file with the objects to embed links for
+            with open(pickle_fname, 'rb') as fid:
+                example_code_obj = pickle.load(fid)
+            fid.close()
+            str_repl = {}
+            # generate replacement strings with the links
+            for name, cobj in example_code_obj.items():
+                this_module = cobj['module'].split('.')[0]
 
-                    if this_module not in doc_resolvers:
-                        continue
+                if this_module not in doc_resolvers:
+                    continue
 
-                    try:
-                        link = doc_resolvers[this_module].resolve(cobj,
-                                                                  full_fname)
-                    except (HTTPError, URLError) as e:
-                        if isinstance(e, HTTPError):
-                            extra = e.code
-                        else:
-                            extra = e.reason
-                        print("\t\tError resolving %s.%s: %r (%s)"
-                              % (cobj['module'], cobj['name'], e, extra))
-                        continue
+                try:
+                    link = doc_resolvers[this_module].resolve(cobj,
+                                                              full_fname)
+                except (HTTPError, URLError) as e:
+                    if isinstance(e, HTTPError):
+                        extra = e.code
+                    else:
+                        extra = e.reason
+                    print("\n\t\tError resolving %s.%s: %r (%s)"
+                          % (cobj['module'], cobj['name'], e, extra))
+                    continue
 
-                    if link is not None:
-                        parts = name.split('.')
-                        name_html = period.join(orig_pattern % part
-                                                for part in parts)
-                        full_function_name = '%s.%s' % (
-                            cobj['module'], cobj['name'])
-                        str_repl[name_html] = link_pattern % (
-                            link, full_function_name, name_html)
-                # do the replacement in the html file
+                if link is not None:
+                    parts = name.split('.')
+                    name_html = period.join(orig_pattern % part
+                                            for part in parts)
+                    full_function_name = '%s.%s' % (
+                        cobj['module'], cobj['name'])
+                    str_repl[name_html] = link_pattern % (
+                        link, full_function_name, name_html)
+            # do the replacement in the html file
 
-                # ensure greediness
-                names = sorted(str_repl, key=len, reverse=True)
-                expr = re.compile(r'(?<!\.)\b' +  # don't follow . or word
-                                  '|'.join(re.escape(name)
-                                           for name in names))
+            # ensure greediness
+            names = sorted(str_repl, key=len, reverse=True)
+            expr = re.compile(r'(?<!\.)\b' +  # don't follow . or word
+                              '|'.join(re.escape(name)
+                                       for name in names))
 
-                def substitute_link(match):
-                    return str_repl[match.group()]
+            def substitute_link(match):
+                return str_repl[match.group()]
 
-                if len(str_repl) > 0:
-                    with open(full_fname, 'rb') as fid:
-                        lines_in = fid.readlines()
-                    with open(full_fname, 'wb') as fid:
-                        for line in lines_in:
-                            line = line.decode('utf-8')
-                            line = expr.sub(substitute_link, line)
-                            fid.write(line.encode('utf-8'))
-    print('[done]')
+            if len(str_repl) > 0:
+                with open(full_fname, 'rb') as fid:
+                    lines_in = fid.readlines()
+                with open(full_fname, 'wb') as fid:
+                    for line in lines_in:
+                        line = line.decode('utf-8')
+                        line = expr.sub(substitute_link, line)
+                        fid.write(line.encode('utf-8'))
 
 
 def embed_code_links(app, exception):

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -73,6 +73,7 @@ def generate_gallery_rst(app):
     Start the sphinx-gallery configuration and recursively scan the examples
     directories in order to populate the examples gallery
     """
+    print('Generating gallery')
     try:
         plot_gallery = eval(app.builder.config.plot_gallery)
     except TypeError:
@@ -126,7 +127,8 @@ def generate_gallery_rst(app):
         if this_fhindex == "":
             raise FileNotFoundError("Main example directory {0} does not "
                                     "have a README.txt file. Please write "
-                                    "one to introduce your gallery.".format(examples_dir))
+                                    "one to introduce your gallery."
+                                    .format(examples_dir))
 
         computation_times += this_computation_times
 
@@ -151,12 +153,13 @@ def generate_gallery_rst(app):
     # Back to initial directory
     os.chdir(working_dir)
 
-    print("Computation time summary:")
-    for time_elapsed, fname in sorted(computation_times)[::-1]:
-        if time_elapsed is not None:
-            print("\t- %s : %.2g sec" % (fname, time_elapsed))
-        else:
-            print("\t- %s : not run" % fname)
+    if gallery_conf['plot_gallery']:
+        print("Computation time summary:")
+        for time_elapsed, fname in sorted(computation_times)[::-1]:
+            if time_elapsed is not None:
+                print("\t- %s : %.2g sec" % (fname, time_elapsed))
+            else:
+                print("\t- %s : not run" % fname)
 
 
 def touch_empty_backreferences(app, what, name, obj, options, lines):

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -381,7 +381,10 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
         print(80 * '_')
         return "", []  # because string is an expected return type
 
-    fhindex = open(os.path.join(src_dir, 'README.txt')).read()
+    # suppress "not included in TOCTREE" sphinx warnings
+    fhindex = ":orphan:\n\n"
+    with open(os.path.join(src_dir, 'README.txt')) as fid:
+        fhindex += fid.read()
     # Add empty lines to avoid bug in issue #165
     fhindex += "\n\n"
 
@@ -564,7 +567,8 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
     time_elapsed = 0
     block_vars = {'execute_script': execute_script, 'fig_count': 0,
                   'image_path': image_path_template, 'src_file': src_file}
-    print('Executing file %s' % src_file)
+    if block_vars['execute_script']:
+        print('Executing file %s' % src_file)
     for blabel, bcontent in script_blocks:
         if blabel == 'code':
             code_output, rtime = execute_code_block(bcontent,
@@ -610,6 +614,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
         example_rst += SPHX_GLR_SIG
         f.write(example_rst)
 
-    print("{0} ran in : {1:.2g} seconds\n".format(src_file, time_elapsed))
+    if block_vars['execute_script']:
+        print("{0} ran in : {1:.2g} seconds\n".format(src_file, time_elapsed))
 
     return amount_of_code, time_elapsed


### PR DESCRIPTION
This does two things:

1. Suppresses output when doing `plot_gallery=False` saying it took 0 seconds to run a bunch of examples that didn't run. It's not very informative, and it makes the sphinx output very long, thus making things like checking for good sphink markup, bad links, etc. harder (what `plot_gallery=False` is mostly used for, I assume).

2. Uses `app.status_iterator` for the last stage of processing where code is embedded. Instead of having tens or hundreds of lines, now the output looks like the rest of sphinx, e.g.:
    ```
    auto_examples[100%] plot_left_cerebellum_volume_source.html
    auto_tutorials[100%] plot_ica_from_raw.html
    ```