### PR TITLE
cached conda gives problems in new Circle CI Builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,8 +4,6 @@ machine:
     PATH: "/home/ubuntu/miniconda/envs/circleenv/bin:/home/ubuntu/miniconda/bin:$PATH"
 
 dependencies:
-  cache_directories:
-    - "~/miniconda"
   pre:
     # Disable pyenv (no cleaner way provided by CircleCI as it prepends pyenv version to PATH)
     - rm -rf ~/.pyenv


### PR DESCRIPTION
Shamelessly copy from MNE-python Circle CI script not to install conda again