### PR TITLE
[MRG] Better path handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,14 @@ Change Log
 git master
 ----------
 
-New features
-''''''''''''
-
 * Drop styling in codelinks tooltip. Replaced for title attribute which is managed by the browser.
+
+Bug Fixes
+'''''''''
+
+* Sphinx-Gallery can now build by directly calling sphinx-build from
+  any path, no explicit need to run the Makefile from the sources
+  directory.
 
 v0.1.7
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change Log
 git master
 ----------
 
+New features
+''''''''''''
+
 * Drop styling in codelinks tooltip. Replaced for title attribute which is managed by the browser.
 
 Bug Fixes
@@ -11,7 +14,8 @@ Bug Fixes
 
 * Sphinx-Gallery can now build by directly calling sphinx-build from
   any path, no explicit need to run the Makefile from the sources
-  directory.
+  directory. See `#190 <https://github.com/sphinx-gallery/sphinx-gallery/pull/190>`_ 
+  for more details.
 
 v0.1.7
 ------

--- a/circle.yml
+++ b/circle.yml
@@ -23,11 +23,11 @@ dependencies:
 test:
   override:
     - python setup.py build_sphinx
+    - export SPHX_GLR_THEME=rtd; sphinx-build doc rtd_html
     - export SPHX_GLR_THEME=alabaster; sphinx-build doc alabaster_html
-    - cd doc; make html theme=rtd
 
 general:
   artifacts:
-    - "doc_build/html"
-    - "alabaster_html"
     - "doc/_build/html"
+    - "rtd_html"
+    - "alabaster_html"

--- a/circle.yml
+++ b/circle.yml
@@ -22,8 +22,12 @@ dependencies:
 
 test:
   override:
+    - python setup.py build_sphinx
+    - export SPHX_GLR_THEME=alabaster; sphinx-build doc alabaster_html
     - cd doc; make html theme=rtd
 
 general:
   artifacts:
+    - "doc_build/html"
+    - "alabaster_html"
     - "doc/_build/html"

--- a/circle.yml
+++ b/circle.yml
@@ -23,8 +23,8 @@ dependencies:
 test:
   override:
     - python setup.py build_sphinx
-    - export SPHX_GLR_THEME=rtd; sphinx-build doc rtd_html
-    - export SPHX_GLR_THEME=alabaster; sphinx-build doc alabaster_html
+    - SPHX_GLR_THEME=rtd sphinx-build doc rtd_html
+    - SPHX_GLR_THEME=alabaster sphinx-build doc alabaster_html
 
 general:
   artifacts:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -57,8 +57,7 @@ clean:
 	rm -rf auto_examples/
 	rm -rf auto_mayavi_examples/
 	rm -rf tutorials/
-	rm -rf generated/*
-	rm -rf modules/generated/*
+	rm -rf modules/
 
 html-noplot: export SPHX_GLR_THEME = $(theme)
 html-noplot:

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,6 @@ with-doctest=1
 doctest-extension=rst
 
 [build_sphinx]
-source-dir = docs/
-build-dir  = docs/_build
+source-dir = doc/
+build-dir  = doc_build
 all_files  = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,5 +8,5 @@ doctest-extension=rst
 
 [build_sphinx]
 source-dir = doc/
-build-dir  = doc_build
+build-dir  = doc/_build
 all_files  = 1

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -176,9 +176,11 @@ def write_backreferences(seen_backrefs, gallery_conf,
     """Writes down back reference files, which include a thumbnail list
     of examples using a certain module"""
     example_file = os.path.join(target_dir, fname)
+    build_target_dir = os.path.relpath(target_dir, gallery_conf['src_dir'])
     backrefs = scan_used_functions(example_file, gallery_conf)
     for backref in backrefs:
-        include_path = os.path.join(gallery_conf['mod_example_dir'],
+        include_path = os.path.join(gallery_conf['src_dir'],
+                                    gallery_conf['mod_example_dir'],
                                     '%s.examples' % backref)
         seen = backref in seen_backrefs
         with open(include_path, 'a' if seen else 'w') as ex_file:
@@ -186,6 +188,6 @@ def write_backreferences(seen_backrefs, gallery_conf,
                 heading = '\n\nExamples using ``%s``' % backref
                 ex_file.write(heading + '\n')
                 ex_file.write('^' * len(heading) + '\n')
-            ex_file.write(_thumbnail_div(target_dir, fname, snippet,
+            ex_file.write(_thumbnail_div(build_target_dir, fname, snippet,
                                          is_backref=True))
             seen_backrefs.add(backref)

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -333,16 +333,17 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
     # Add resolvers for the packages for which we want to show links
     doc_resolvers = {}
 
+    src_gallery_dir = os.path.join(app.builder.srcdir, gallery_dir)
     for this_module, url in gallery_conf['reference_url'].items():
         try:
             if url is None:
                 doc_resolvers[this_module] = SphinxDocLinkResolver(
                     app.builder.outdir,
-                    gallery_dir,
+                    src_gallery_dir,
                     relative=True)
             else:
                 doc_resolvers[this_module] = SphinxDocLinkResolver(url,
-                                                                   gallery_dir)
+                                                                   src_gallery_dir)
 
         except HTTPError as e:
             print("The following HTTP Error has occurred:\n")
@@ -373,7 +374,7 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
     for dirpath, fname in iterator:
         full_fname = os.path.join(html_gallery_dir, dirpath, fname)
         subpath = dirpath[len(html_gallery_dir) + 1:]
-        pickle_fname = os.path.join(gallery_dir, subpath,
+        pickle_fname = os.path.join(src_gallery_dir, subpath,
                                     fname[:-5] + '_codeobj.pickle')
 
         if os.path.exists(pickle_fname):

--- a/sphinx_gallery/downloads.py
+++ b/sphinx_gallery/downloads.py
@@ -55,14 +55,14 @@ def python_zip(file_list, gallery_path, extension='.py'):
         zip file name, written as `target_dir_{python,jupyter}.zip`
         depending on the extension
     """
-    zipname = gallery_path.replace(os.path.sep, '_')
+    zipname = os.path.basename(gallery_path)
     zipname += '_python' if extension == '.py' else '_jupyter'
     zipname = os.path.join(gallery_path, zipname + '.zip')
 
     zipf = zipfile.ZipFile(zipname, mode='w')
     for fname in file_list:
         file_src = os.path.splitext(fname)[0] + extension
-        zipf.write(file_src)
+        zipf.write(file_src, os.path.relpath(file_src, gallery_path))
     zipf.close()
 
     return zipname

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -86,6 +86,7 @@ def generate_gallery_rst(app):
         abort_on_example_error=app.builder.config.abort_on_example_error)
 
     # this assures I can call the config in other places
+    gallery_conf['src_dir'] = app.builder.srcdir
     app.config.sphinx_gallery_conf = gallery_conf
     app.config.html_static_path.append(glr_path_static())
 
@@ -99,20 +100,15 @@ def generate_gallery_rst(app):
     if not isinstance(gallery_dirs, list):
         gallery_dirs = [gallery_dirs]
 
-    mod_examples_dir = os.path.relpath(gallery_conf['mod_example_dir'],
-                                       app.builder.srcdir)
+    mod_examples_dir = os.path.join(
+        app.builder.srcdir, gallery_conf['mod_example_dir'])
     seen_backrefs = set()
 
     computation_times = []
 
-    # cd to the appropriate directory regardless of sphinx configuration
-    working_dir = os.getcwd()
-    os.chdir(app.builder.srcdir)
     for examples_dir, gallery_dir in zip(examples_dirs, gallery_dirs):
-        examples_dir = os.path.relpath(examples_dir,
-                                       app.builder.srcdir)
-        gallery_dir = os.path.relpath(gallery_dir,
-                                      app.builder.srcdir)
+        examples_dir = os.path.join(app.builder.srcdir, examples_dir)
+        gallery_dir = os.path.join(app.builder.srcdir, gallery_dir)
 
         for workdir in [examples_dir, gallery_dir, mod_examples_dir]:
             if not os.path.exists(workdir):
@@ -149,9 +145,6 @@ def generate_gallery_rst(app):
 
         fhindex.write(SPHX_GLR_SIG)
         fhindex.flush()
-
-    # Back to initial directory
-    os.chdir(working_dir)
 
     if gallery_conf['plot_gallery']:
         print("Computation time summary:")
@@ -191,32 +184,33 @@ def sumarize_failing_examples(app, exception):
         return
 
     gallery_conf = app.config.sphinx_gallery_conf
-    failing_examples = set([os.path.normpath(path) for path in
-                            gallery_conf['failing_examples']])
-    expected_failing_examples = set([os.path.normpath(path) for path in
+    failing_examples = gallery_conf['failing_examples']
+
+    expected_failing_examples = set([os.path.normpath(os.path.join(app.srcdir, path))
+                                     for path in
                                      gallery_conf['expected_failing_examples']])
 
-    examples_expected_to_fail = failing_examples.intersection(
+    examples_expected_to_fail = set(failing_examples.keys()).intersection(
         expected_failing_examples)
     expected_fail_msg = []
     if examples_expected_to_fail:
-        expected_fail_msg.append("Examples failing as expected:")
+        expected_fail_msg.append("\n\nExamples failing as expected:")
         for fail_example in examples_expected_to_fail:
             expected_fail_msg.append(fail_example + ' failed leaving traceback:\n' +
-                                     gallery_conf['failing_examples'][fail_example] + '\n')
+                                     failing_examples[fail_example] + '\n')
         print("\n".join(expected_fail_msg))
 
-    examples_not_expected_to_fail = failing_examples.difference(
+    examples_not_expected_to_fail = set(failing_examples.keys()).difference(
         expected_failing_examples)
     fail_msgs = []
     if examples_not_expected_to_fail:
         fail_msgs.append("Unexpected failing examples:")
         for fail_example in examples_not_expected_to_fail:
             fail_msgs.append(fail_example + ' failed leaving traceback:\n' +
-                             gallery_conf['failing_examples'][fail_example] + '\n')
+                             failing_examples[fail_example] + '\n')
 
     examples_not_expected_to_pass = expected_failing_examples.difference(
-        failing_examples)
+        failing_examples.keys())
     if examples_not_expected_to_pass:
         fail_msgs.append("Examples expected to fail, but not failling:\n" +
                          "Please remove these examples from\n" +

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -84,9 +84,9 @@ def generate_gallery_rst(app):
     gallery_conf.update(plot_gallery=plot_gallery)
     gallery_conf.update(
         abort_on_example_error=app.builder.config.abort_on_example_error)
+    gallery_conf['src_dir'] = app.builder.srcdir
 
     # this assures I can call the config in other places
-    gallery_conf['src_dir'] = app.builder.srcdir
     app.config.sphinx_gallery_conf = gallery_conf
     app.config.html_static_path.append(glr_path_static())
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -184,33 +184,32 @@ def sumarize_failing_examples(app, exception):
         return
 
     gallery_conf = app.config.sphinx_gallery_conf
-    failing_examples = gallery_conf['failing_examples']
-
+    failing_examples = set(gallery_conf['failing_examples'].keys())
     expected_failing_examples = set([os.path.normpath(os.path.join(app.srcdir, path))
                                      for path in
                                      gallery_conf['expected_failing_examples']])
 
-    examples_expected_to_fail = set(failing_examples.keys()).intersection(
+    examples_expected_to_fail = failing_examples.intersection(
         expected_failing_examples)
     expected_fail_msg = []
     if examples_expected_to_fail:
         expected_fail_msg.append("\n\nExamples failing as expected:")
         for fail_example in examples_expected_to_fail:
             expected_fail_msg.append(fail_example + ' failed leaving traceback:\n' +
-                                     failing_examples[fail_example] + '\n')
+                                     gallery_conf['failing_examples'][fail_example] + '\n')
         print("\n".join(expected_fail_msg))
 
-    examples_not_expected_to_fail = set(failing_examples.keys()).difference(
+    examples_not_expected_to_fail = failing_examples.difference(
         expected_failing_examples)
     fail_msgs = []
     if examples_not_expected_to_fail:
         fail_msgs.append("Unexpected failing examples:")
         for fail_example in examples_not_expected_to_fail:
             fail_msgs.append(fail_example + ' failed leaving traceback:\n' +
-                             failing_examples[fail_example] + '\n')
+                             gallery_conf['failing_examples'][fail_example] + '\n')
 
     examples_not_expected_to_pass = expected_failing_examples.difference(
-        failing_examples.keys())
+        failing_examples)
     if examples_not_expected_to_pass:
         fail_msgs.append("Examples expected to fail, but not failling:\n" +
                          "Please remove these examples from\n" +

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -243,15 +243,14 @@ def save_figures(image_path, fig_count, gallery_conf):
 
     Returns
     -------
-    figure_list : list of str
-        strings containing the full path to each figure
     images_rst : str
         rst code to embed the images in the document
+    fig_num : int
+        number of figures saved
     """
     figure_list = []
 
-    fig_numbers = plt.get_fignums()
-    for fig_num in fig_numbers:
+    for fig_num in plt.get_fignums():
         # Set the fig_num figure as the current figure as we can't
         # save a figure that's not the current figure.
         fig = plt.figure(fig_num)
@@ -282,8 +281,32 @@ def save_figures(image_path, fig_count, gallery_conf):
             figure_list.append(current_fig)
         mlab.close(all=True)
 
-    # Depending on whether we have one or more figures, we're using a
-    # horizontal list or a single rst call to 'image'.
+    return figure_rst(figure_list, gallery_conf['src_dir'])
+
+
+def figure_rst(figure_list, sources_dir):
+    """Given a list of paths to figures generate the corresponding rst
+
+    Depending on whether we have one or more figures, we use a
+    single rst call to 'image' or a horizontal list.
+
+    Parameters
+    ----------
+    figure_list : list of str
+        Strings are the figures' absolute paths
+    sources_dir : str
+        absolute path of Sphinx documentation sources
+
+    Returns
+    -------
+    images_rst : str
+        rst code to embed the images in the document
+    fig_num : int
+        number of figures saved
+    """
+
+    figure_list = [os.path.relpath(figure_path, sources_dir)
+                   for figure_path in figure_list]
     images_rst = ""
     if len(figure_list) == 1:
         figure_name = figure_list[0]
@@ -293,7 +316,7 @@ def save_figures(image_path, fig_count, gallery_conf):
         for figure_name in figure_list:
             images_rst += HLIST_IMAGE_TEMPLATE % figure_name.lstrip('/')
 
-    return figure_list, images_rst
+    return images_rst, len(figure_list)
 
 
 def scale_image(in_fname, out_fname, max_width, max_height):
@@ -394,6 +417,7 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
                       if fname.endswith('.py')]
     entries_text = []
     computation_times = []
+    build_target_dir = os.path.relpath(target_dir, gallery_conf['src_dir'])
     for fname in sorted_listdir:
         amount_of_code, time_elapsed = \
             generate_file_rst(fname, target_dir, src_dir, gallery_conf)
@@ -402,12 +426,12 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
         intro = extract_intro(new_fname)
         write_backreferences(seen_backrefs, gallery_conf,
                              target_dir, fname, intro)
-        this_entry = _thumbnail_div(target_dir, fname, intro) + """
+        this_entry = _thumbnail_div(build_target_dir, fname, intro) + """
 
 .. toctree::
    :hidden:
 
-   /%s/%s\n""" % (target_dir, fname[:-3])
+   /%s/%s\n""" % (build_target_dir, fname[:-3])
         entries_text.append((amount_of_code, this_entry))
 
     # sort to have the smallest entries in the beginning
@@ -460,9 +484,8 @@ def execute_code_block(code_block, example_globals,
         if my_stdout:
             stdout = CODE_OUTPUT.format(indent(my_stdout, u' ' * 4))
         os.chdir(cwd)
-        fig_list, images_rst = save_figures(
-            block_vars['image_path'], block_vars['fig_count'], gallery_conf)
-        fig_num = len(fig_list)
+        images_rst, fig_num = save_figures(block_vars['image_path'],
+                                           block_vars['fig_count'], gallery_conf)
 
     except Exception:
         formatted_exception = traceback.format_exc()
@@ -523,7 +546,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
         seconds required to run the script
     """
 
-    src_file = os.path.join(src_dir, fname)
+    src_file = os.path.normpath(os.path.join(src_dir, fname))
     example_file = os.path.join(target_dir, fname)
     shutil.copyfile(src_file, example_file)
     script_blocks = split_code_and_text_blocks(src_file)
@@ -540,9 +563,11 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
 
     base_image_name = os.path.splitext(fname)[0]
     image_fname = 'sphx_glr_' + base_image_name + '_{0:03}.png'
+    build_image_dir = os.path.relpath(image_dir, gallery_conf['src_dir'])
     image_path_template = os.path.join(image_dir, image_fname)
 
-    ref_fname = example_file.replace(os.path.sep, '_')
+    ref_fname = os.path.relpath(example_file, gallery_conf['src_dir'])
+    ref_fname = ref_fname.replace(os.path.sep, '_')
     example_rst = """\n\n.. _sphx_glr_{0}:\n\n""".format(ref_fname)
 
     filename_pattern = gallery_conf.get('filename_pattern')


### PR DESCRIPTION
This replaces #133 
As brought back to life by #186, Sphinx-Gallery does not handle the cases when the documentation structure is in a different place than the location of the makefile and the conf.py files.

This PR aims to fix that and preceding issues stated in  #40 #50 #115 #119 #120

For test completeness I know build in circle CI the documentation in various location, with different commands a different themes.

As can be seen from the build logs(https://circleci.com/gh/Titan-C/sphinx-gallery/12?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link). The examples are run only on the first build, later builds can take advantage of the cached files as they are referenced in the same locations and the output to the described location. For review. This are the 3 builds

* alabaster theme: https://12-26191147-gh.circle-artifacts.com/0/home/ubuntu/sphinx-gallery/alabaster_html/index.html
* classic theme: https://12-26191147-gh.circle-artifacts.com/0/home/ubuntu/sphinx-gallery/doc_build/html/tutorials/index.html
* read the docs theme: https://12-26191147-gh.circle-artifacts.com/0/home/ubuntu/sphinx-gallery/doc/_build/html/advanced_configuration.html#establishing-local-references-to-examples

Since it is possible I have missed cases where links/images/references/etc are not well resolved, the links above point to different places of the documentation I have checked, but please help me explore. And even better tell me if we can elaborate a way to test on this.

There is an issue with circle ci and the cached conda installation that is addressed in #189 