### PR TITLE
[MRG] Remove nonfunctional text2string function

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -83,7 +83,7 @@ from .downloads import CODE_DOWNLOAD
 from .py_source_parser import (get_docstring_and_rest,
                                split_code_and_text_blocks)
 
-from .notebook import jupyter_notebook, text2string, save_notebook
+from .notebook import jupyter_notebook, save_notebook
 
 try:
     basestring
@@ -589,7 +589,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
                 example_rst += codestr2rst(bcontent) + '\n'
 
         else:
-            example_rst += text2string(bcontent) + '\n'
+            example_rst += bcontent + '\n\n'
 
     clean_modules()
 

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -19,14 +19,6 @@ import sys
 from .py_source_parser import split_code_and_text_blocks
 
 
-def text2string(content):
-    """Returns a string without the extra triple quotes"""
-    try:
-        return ast.literal_eval(content) + '\n'
-    except Exception:
-        return content + '\n'
-
-
 def jupyter_notebook_skeleton():
     """Returns a dictionary with the elements of a Jupyter notebook"""
     py_version = sys.version_info
@@ -170,7 +162,7 @@ def fill_notebook(work_notebook, script_blocks):
         if blabel == 'code':
             add_code_cell(work_notebook, bcontent)
         else:
-            add_markdown_cell(work_notebook, text2string(bcontent))
+            add_markdown_cell(work_notebook, bcontent + '\n')
 
 
 def save_notebook(work_notebook, write_file):


### PR DESCRIPTION
`text2string()` uses `ast.literal_eval()` but `ast` is never imported in the file. So the try-except block is catching a `NameError`?