### PR TITLE
MRG: Fix warning

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -39,7 +39,7 @@ DEFAULT_GALLERY_CONF = {
     'doc_module': (),
     'reference_url': {},
     # build options
-    'plot_gallery': True,
+    'plot_gallery': 'True',  # can be unicode, this avoids sphinx warning
     'download_all_examples': True,
     'abort_on_example_error': False,
     'failing_examples': {},

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -38,8 +38,12 @@ DEFAULT_GALLERY_CONF = {
     'backreferences_dir': None,
     'doc_module': (),
     'reference_url': {},
-    # build options
-    'plot_gallery': 'True',  # can be unicode, this avoids sphinx warning
+    # Build options
+    # -------------
+    # We use a string for 'plot_gallery' rather than simply the Python boolean
+    # `True` as it avoids a warning about unicode when controlling this value
+    # via the command line switches of sphinx-build
+    'plot_gallery': 'True',
     'download_all_examples': True,
     'abort_on_example_error': False,
     'failing_examples': {},


### PR DESCRIPTION
Without this change, I always get this warning:
```
WARNING: The config value `plot_gallery' has type `unicode', defaults to `bool'.
```
I don't love this fix. I assume only bool values should be allowed, but there is an `eval` later in the code that looks like it's meant to accommodate string values, so this might actually be a correct workaround.