### PR TITLE
[MRG] Fix :orphan: sphinx-directive multiple calls

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -117,8 +117,6 @@ def generate_gallery_rst(app):
         for workdir in [examples_dir, gallery_dir, mod_examples_dir]:
             if not os.path.exists(workdir):
                 os.makedirs(workdir)
-        # we create an index.rst with all examples
-        fhindex = open(os.path.join(gallery_dir, 'index.rst'), 'w')
         # Here we don't use an os.walk, but we recurse only twice: flat is
         # better than nested.
         this_fhindex, this_computation_times = \
@@ -132,7 +130,10 @@ def generate_gallery_rst(app):
 
         computation_times += this_computation_times
 
-        fhindex.write(this_fhindex)
+        # we create an index.rst with all examples
+        fhindex = open(os.path.join(gallery_dir, 'index.rst'), 'w')
+        # :orphan: to suppress "not included in TOCTREE" sphinx warnings
+        fhindex.write(":orphan:\n\n" + this_fhindex)
         for directory in sorted(os.listdir(examples_dir)):
             if os.path.isdir(os.path.join(examples_dir, directory)):
                 src_dir = os.path.join(examples_dir, directory)

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -381,10 +381,8 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
         print(80 * '_')
         return "", []  # because string is an expected return type
 
-    # suppress "not included in TOCTREE" sphinx warnings
-    fhindex = ":orphan:\n\n"
     with open(os.path.join(src_dir, 'README.txt')) as fid:
-        fhindex += fid.read()
+        fhindex = fid.read()
     # Add empty lines to avoid bug in issue #165
     fhindex += "\n\n"
 


### PR DESCRIPTION
PR #187 introduced the use of the `orphan` sphinx directive to avoid the warnings of the gallery examples not being in any toctree. This directive has to be called once per rst file and not before every section, otherwise `:orphan:` is presented in the html file. This PR fixes that behaviour