### PR TITLE
[MRG] MAINT simplify .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,6 @@ install:
         source activate testenv;
         if [ "$PYTHON_VERSION" == "2.7" ]; then
           conda install --yes mayavi;
-          conda upgrade --yes --all;
-          pip install --upgrade pyface;
         fi;
       fi;
     - pip install -r requirements.txt


### PR DESCRIPTION
now that mayavi 4.5 is available through conda, we do not need the work-around of installing a newer pyface with pip.

Just making sure that the CI pass before merging this one.