### PR TITLE
Don't error when input directory is the same as the output directory

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -546,7 +546,10 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
 
     src_file = os.path.normpath(os.path.join(src_dir, fname))
     example_file = os.path.join(target_dir, fname)
-    shutil.copyfile(src_file, example_file)
+    try:
+        shutil.copyfile(src_file, example_file)
+    except shutil.SameFileError:
+        pass
     script_blocks = split_code_and_text_blocks(src_file)
     amount_of_code = sum([len(bcontent)
                           for blabel, bcontent in script_blocks


### PR DESCRIPTION
In my project, I'd like to have:

```
sphinx_gallery_conf = {
    'examples_dirs': 'cookbook',
    'gallery_dirs': 'cookbook',
}
```

This almost works right now except for the error raised by the block modified in this pull request. Since the error is harmless in this situation, let's just catch the exception and ignore it.