### PR TITLE
Add the ability to optionally include images in a gallery that were saved to disk

### DIFF
--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -243,14 +243,14 @@ def test_save_figures():
     mlab.test_plot3d()
     plt.plot(1, 1)
     fname_template = os.path.join(gallery_conf['gallery_dir'], 'image{0}.png')
-    image_rst, fig_num = sg.save_figures(fname_template, 0, gallery_conf)
+    image_rst, fig_num = sg.save_figures(fname_template, '', 0, gallery_conf)
     assert_equal(fig_num, 2)
     assert '/image1.png' in image_rst
     assert '/image2.png' in image_rst
 
     mlab.test_plot3d()
     plt.plot(1, 1)
-    image_rst, fig_num = sg.save_figures(fname_template, 2, gallery_conf)
+    image_rst, fig_num = sg.save_figures(fname_template, '', 2, gallery_conf)
     assert_equal(fig_num, 2)
     assert '/image2.png' not in image_rst
     assert '/image3.png' in image_rst


### PR DESCRIPTION
This resolves #206. I'll add documentation and a test for this feature and the new configuration option if this approach is copacetic.

This change makes it so that we can include images in a gallery for code that does not save image via pyplot or mayavi. It's enabled via a new configuration option `find_saved_figures`, which defaults to `False`.

If it's `True`, we inspect the directory containing the example script (i.e. the directory where the script was being run) for png images. If we find any, we move them to the output directory for the gallery and give them names following the template used for pyplot figures.

I've had to modify the API of the internal `save_figures` function slightly. As far as I can tell this function only has consumers inside of `sphinx-gallery` so it should be ok to change the API, but please let me know if that's incorrect.

There are a couple things that could be improved:

* Search for png images that already exist before running the script so we can find the list of images created *just* by the script
* Search for images that aren't in png format or somehow allow users to specify the image format.