### PR TITLE
[MRG] Fix embedded missing link

### DIFF
--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -414,9 +414,8 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
 
             # ensure greediness
             names = sorted(str_repl, key=len, reverse=True)
-            expr = re.compile(r'(?<!\.)\b' +  # don't follow . or word
-                              '|'.join(re.escape(name)
-                                       for name in names))
+            regex_str = '|'.join(re.escape(name) for name in names)
+            regex = re.compile(regex_str)
 
             def substitute_link(match):
                 return str_repl[match.group()]
@@ -427,7 +426,7 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
                 with open(full_fname, 'wb') as fid:
                     for line in lines_in:
                         line = line.decode('utf-8')
-                        line = expr.sub(substitute_link, line)
+                        line = regex.sub(substitute_link, line)
                         fid.write(line.encode('utf-8'))
 
 


### PR DESCRIPTION
Fixes part of https://github.com/sphinx-gallery/sphinx-gallery/issues/113. The regular expression was not matching for the first (i.e. also the longest) name.

I have to say I don't understand why the regex `'r(?<!\.)\b` was here ... but I double-check that on sphinx-gallery examples, it does add a link for the longest name.

For example this adds a link to `np.linspace` in this [example](http://sphinx-gallery.readthedocs.io/en/stable/auto_examples/plot_exp.html#sphx-glr-auto-examples-plot-exp-py) and a link to `np.random.RandomState` in this [example](http://sphinx-gallery.readthedocs.io/en/latest/auto_examples/plot_seaborn.html#sphx-glr-auto-examples-plot-seaborn-py).

Obviously adding a test would be good, but I have already spent too much time on this to my liking ...