### PR TITLE
Add link from documentation to Github

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -12,7 +12,7 @@ gallery of examples from any set of Python scripts.
 It is extracted from the scikit-learn project and aims to be an
 independent general purpose extension.
 
-For the project on Github `Sphinx-Gallery <https://github.com/sphinx-gallery/sphinx-gallery>`_
+The code of the project is on Github: `Sphinx-Gallery <https://github.com/sphinx-gallery/sphinx-gallery>`_
 
 Why Sphinx-Gallery?
 -------------------
@@ -75,7 +75,7 @@ Contents:
    tutorials/index
    auto_mayavi_examples/index
    changes
-   Fork the project on Github <https://github.com/sphinx-gallery/sphinx-gallery>
+   Fork sphinx-gallery on Github <https://github.com/sphinx-gallery/sphinx-gallery>
 
 
 Indices and tables

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -12,6 +12,8 @@ gallery of examples from any set of Python scripts.
 It is extracted from the scikit-learn project and aims to be an
 independent general purpose extension.
 
+For the project on Github `Sphinx-Gallery <https://github.com/sphinx-gallery/sphinx-gallery>`_
+
 Why Sphinx-Gallery?
 -------------------
 
@@ -73,6 +75,7 @@ Contents:
    tutorials/index
    auto_mayavi_examples/index
    changes
+   Fork the project on Github <https://github.com/sphinx-gallery/sphinx-gallery>
 
 
 Indices and tables


### PR DESCRIPTION
Fix #159 
- Include a link to the Github repository in the main page of documentation.
- Include a link in the table of contents