### PR TITLE
[MRG] download zip files path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,10 @@ Getting Started to Sphinx-Gallery
     :target: http://sphinx-gallery.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
+.. image::     https://ci.appveyor.com/api/projects/status/github/sphinx-gallery/sphinx-gallery?branch=master&svg=true
+    :target: https://ci.appveyor.com/project/Titan-C/sphinx-gallery/history
+
+
 
 A Sphinx extension that builds an HTML version of any Python
 script and puts it into an examples gallery.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,3 +40,6 @@ test_script:
   - sphinx-build -D plot_gallery=0 -b html -d _build\doctrees . _build\html
   # make html
   - sphinx-build -b html -d _build\doctrees . _build\html
+
+artifacts:
+  - path: doc\_build\html

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -136,8 +136,6 @@ def scan_used_functions(example_file, gallery_conf):
     return backrefs
 
 
-# XXX This figure:: uses a forward slash even on Windows, but the op.join's
-# elsewhere will use backslashes...
 THUMBNAIL_TEMPLATE = """
 .. raw:: html
 
@@ -165,6 +163,10 @@ def _thumbnail_div(full_dir, fname, snippet, is_backref=False):
     """Generates RST to place a thumbnail in a gallery"""
     thumb = os.path.join(full_dir, 'images', 'thumb',
                          'sphx_glr_%s_thumb.png' % fname[:-3])
+
+    # Inside rst files forward slash defines paths
+    thumb = thumb.replace(os.sep, "/")
+
     ref_name = os.path.join(full_dir, fname).replace(os.path.sep, '_')
 
     template = BACKREF_THUMBNAIL_TEMPLATE if is_backref else THUMBNAIL_TEMPLATE

--- a/sphinx_gallery/downloads.py
+++ b/sphinx_gallery/downloads.py
@@ -110,8 +110,11 @@ def generate_zipfiles(gallery_dir):
     py_zipfile = python_zip(listdir, gallery_dir)
     jy_zipfile = python_zip(listdir, gallery_dir, ".ipynb")
 
+    def rst_path(filepath):
+        return filepath.replace(os.sep, '/')
+
     dw_rst = CODE_ZIP_DOWNLOAD.format(os.path.basename(py_zipfile),
-                                      py_zipfile,
+                                      rst_path(py_zipfile),
                                       os.path.basename(jy_zipfile),
-                                      jy_zipfile)
+                                      rst_path(jy_zipfile))
     return dw_rst

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -305,16 +305,18 @@ def figure_rst(figure_list, sources_dir):
         number of figures saved
     """
 
-    figure_list = [os.path.relpath(figure_path, sources_dir)
-                   for figure_path in figure_list]
+    figure_paths = [os.path.relpath(figure_path, sources_dir)
+                    for figure_path in figure_list]
+    figure_paths = [figure_name.replace(os.sep, '/').lstrip('/')
+                    for figure_name in figure_list]
     images_rst = ""
-    if len(figure_list) == 1:
-        figure_name = figure_list[0]
-        images_rst = SINGLE_IMAGE % figure_name.lstrip('/')
-    elif len(figure_list) > 1:
+    if len(figure_paths) == 1:
+        figure_name = figure_paths[0]
+        images_rst = SINGLE_IMAGE % figure_name
+    elif len(figure_paths) > 1:
         images_rst = HLIST_HEADER
-        for figure_name in figure_list:
-            images_rst += HLIST_IMAGE_TEMPLATE % figure_name.lstrip('/')
+        for figure_name in figure_paths:
+            images_rst += HLIST_IMAGE_TEMPLATE % figure_name
 
     return images_rst, len(figure_list)
 
@@ -429,7 +431,7 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
 .. toctree::
    :hidden:
 
-   /%s/%s\n""" % (build_target_dir, fname[:-3])
+   /%s\n""" % os.path.join(build_target_dir, fname[:-3]).replace(os.sep, '/')
         entries_text.append((amount_of_code, this_entry))
 
     # sort to have the smallest entries in the beginning

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -22,14 +22,14 @@ def test_thumbnail_div():
 
 .. only:: html
 
-    .. figure:: /fake_dir{0}images{0}thumb{0}sphx_glr_test_file_thumb.png
+    .. figure:: /fake_dir/images/thumb/sphx_glr_test_file_thumb.png
 
         :ref:`sphx_glr_fake_dir_test_file.py`
 
 .. raw:: html
 
     </div>
-""".format(os.sep)
+"""
 
     assert_equal(html_div, reference)
 
@@ -47,7 +47,7 @@ def test_backref_thumbnail_div():
 
 .. only:: html
 
-    .. figure:: /fake_dir{0}images{0}thumb{0}sphx_glr_test_file_thumb.png
+    .. figure:: /fake_dir/images/thumb/sphx_glr_test_file_thumb.png
 
         :ref:`sphx_glr_fake_dir_test_file.py`
 
@@ -58,7 +58,7 @@ def test_backref_thumbnail_div():
 .. only:: not html
 
     * :ref:`sphx_glr_fake_dir_test_file.py`
-""".format(os.sep)
+"""
 
     assert_equal(html_div, reference)
 
@@ -88,6 +88,6 @@ identify_names
             {'name': 'identify_names',
              'module': 'sphinx_gallery.back_references',
              'module_short': 'sphinx_gallery.back_references'}
-        }
+    }
 
     assert_equal(expected, res)


### PR DESCRIPTION
Closes #183, now downloadable zip files are available and there are no missing gallery examples in the toctree
- Uses forward slashes only inside rst files
- AppVeyor captures artifacts of html build