### PR TITLE
Fix for when sys.argv is used in examples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,13 @@ New features
   `#233 <https://github.com/sphinx-gallery/sphinx-gallery/pull/233>`_ and
   `#234 <https://github.com/sphinx-gallery/sphinx-gallery/pull/234>`_
 
+Bug Fixes
+'''''''''
+
+* Reset ``sys.argv`` before running each example. See
+  `#252 <https://github.com/sphinx-gallery/sphinx-gallery/pull/252>`_
+  for more details.
+
 v0.1.11
 -------
 

--- a/examples/plot_sys_argv.py
+++ b/examples/plot_sys_argv.py
@@ -1,0 +1,14 @@
+"""
+Using ``sys.argv`` in examples
+
+Note that your example will be run by sphinx-gallery without arguments.
+"""
+
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(description='Toy parser')
+parser.add_argument('--option', default='default',
+                    help='a dummy optional argument')
+print('sys.argv:', sys.argv)
+print('parsed args:', parser.parse_args())

--- a/examples/plot_sys_argv.py
+++ b/examples/plot_sys_argv.py
@@ -1,5 +1,6 @@
 """
 Using ``sys.argv`` in examples
+==============================
 
 Note that your example will be run by sphinx-gallery without arguments.
 """

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -568,7 +568,9 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
 
     argv_orig = sys.argv[:]
     if block_vars['execute_script']:
-        print('Executing file %s' % src_file)
+        # We want to run the example without arguments. See
+        # https://github.com/sphinx-gallery/sphinx-gallery/pull/252
+        # for more details.
         sys.argv[0] = src_file
         sys.argv[1:] = []
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -565,6 +565,13 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
     time_elapsed = 0
     block_vars = {'execute_script': execute_script, 'fig_count': 0,
                   'image_path': image_path_template, 'src_file': src_file}
+
+    argv_orig = sys.argv[:]
+    if block_vars['execute_script']:
+        print('Executing file %s' % src_file)
+        sys.argv[0] = src_file
+        sys.argv[1:] = []
+
     for blabel, bcontent in script_blocks:
         if blabel == 'code':
             code_output, rtime = execute_code_block(src_file, bcontent,
@@ -586,6 +593,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
         else:
             example_rst += bcontent + '\n\n'
 
+    sys.argv = argv_orig
     clean_modules()
 
     # Writes md5 checksum if example has build correctly


### PR DESCRIPTION
Fix #251.

The fix is not the nicest one (maybe changing `sys.argv` inside a `try` clause and changing it back in `except` would make it a bit better) but it works ...