### PR TITLE
Allow and use https links where possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
       env: DISTRIB="conda" PYTHON_VERSION="3.5"
 before_install:
     - if [ "$DISTRIB" == "conda" ]; then
-         wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+         wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
          chmod +x miniconda.sh;
          ./miniconda.sh -b;
          export PATH=/home/travis/miniconda2/bin:$PATH;

--- a/README.rst
+++ b/README.rst
@@ -25,12 +25,12 @@ Who uses Sphinx-Gallery
 
 * `Sphinx-Gallery <https://sphinx-gallery.readthedocs.io/en/latest/auto_examples/index.html>`_
 * `Scikit-learn <http://scikit-learn.org/dev/auto_examples/index.html>`_
-* `Nilearn <http://nilearn.github.io/auto_examples/index.html>`_
-* `MNE-python <http://www.martinos.org/mne/stable/auto_examples/index.html>`_
-* `PyStruct <http://pystruct.github.io/auto_examples/index.html>`_
+* `Nilearn <https://nilearn.github.io/auto_examples/index.html>`_
+* `MNE-python <https://www.martinos.org/mne/stable/auto_examples/index.html>`_
+* `PyStruct <https://pystruct.github.io/auto_examples/index.html>`_
 * `GIMLi <http://www.pygimli.org/_examples_auto/index.html>`_
-* `Nestle <http://kbarbary.github.io/nestle/examples/index.html>`_
-* `pyRiemann <http://pythonhosted.org/pyriemann/auto_examples/index.html>`_
+* `Nestle <https://kbarbary.github.io/nestle/examples/index.html>`_
+* `pyRiemann <https://pythonhosted.org/pyriemann/auto_examples/index.html>`_
 * `scikit-image <http://scikit-image.org/docs/dev/auto_examples/>`_
 * `Astropy <http://docs.astropy.org/en/stable/generated/examples/index.html>`_
 * `SunPy <http://docs.sunpy.org/en/stable/generated/gallery/index.html>`_

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ dependencies:
     # Disable pyenv (no cleaner way provided by CircleCI as it prepends pyenv version to PATH)
     - rm -rf ~/.pyenv
     - rm -rf ~/virtualenvs
-    - wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O ~/miniconda.sh
+    - wget -q https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O ~/miniconda.sh
     - chmod +x ~/miniconda.sh
     - ~/miniconda.sh -b -p /home/ubuntu/miniconda
     - conda update --yes --quiet conda

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -107,8 +107,8 @@ dictionary within your Sphinx ``conf.py`` file :
                 'sphinx_gallery': None,
 
                 # External python modules use their documentation websites
-                'matplotlib': 'http://matplotlib.org',
-                'numpy': 'http://docs.scipy.org/doc/numpy-1.9.1'}
+                'matplotlib': 'https://matplotlib.org',
+                'numpy': 'https://docs.scipy.org/doc/numpy-1.9.1'}
         }
 
 

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -89,7 +89,7 @@ code snippets within the gallery appear like this
 .. raw:: html
 
     <div class="highlight-python"><div class="highlight"><pre>
-    <span class="n">y</span> <span class="o">=</span> <a href="http://docs.scipy.org/doc/numpy-1.9.1/reference/generated/numpy.sin.html#numpy.sin"><span class="n">np</span><span class="o">.</span><span class="n">sin</span></a><span class="p">(</span><span class="n">x</span><span class="p">)</span>
+    <span class="n">y</span> <span class="o">=</span> <a href="https://docs.scipy.org/doc/numpy-1.9.1/reference/generated/numpy.sin.html#numpy.sin"><span class="n">np</span><span class="o">.</span><span class="n">sin</span></a><span class="p">(</span><span class="n">x</span><span class="p">)</span>
     </pre></div>
     </div>
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -294,9 +294,9 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/{.major}'.format(sys.version_info), None),
-    'numpy': ('http://docs.scipy.org/doc/numpy/', None),
-    'scipy': ('http://docs.scipy.org/doc/scipy/reference', None),
-    'matplotlib': ('http://matplotlib.org/', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
+    'matplotlib': ('https://matplotlib.org/', None),
 }
 
 examples_dirs = ['../examples', '../tutorials']
@@ -321,8 +321,8 @@ sphinx_gallery_conf = {
     'doc_module': ('sphinx_gallery', 'numpy'),
     'reference_url': {
         'sphinx_gallery': None,
-        'matplotlib': 'http://matplotlib.org',
-        'numpy': 'http://docs.scipy.org/doc/numpy-1.9.1'},
+        'matplotlib': 'https://matplotlib.org',
+        'numpy': 'https://docs.scipy.org/doc/numpy-1.9.1'},
     'examples_dirs': examples_dirs,
     'gallery_dirs': gallery_dirs,
     'find_mayavi_figures': find_mayavi_figures,

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -198,16 +198,17 @@ class SphinxDocLinkResolver(object):
 
         self.extra_modules_test = extra_modules_test
         self._page_cache = {}
-        if doc_url.startswith('http://'):
+        if doc_url.startswith(('http://', 'https://')):
             if relative:
                 raise ValueError('Relative links are only supported for local '
-                                 'URLs (doc_url cannot start with "http://)"')
+                                 'URLs (doc_url cannot be absolute)')
             searchindex_url = doc_url + '/' + searchindex
         else:
             searchindex_url = os.path.join(doc_url, searchindex)
 
         # detect if we are using relative links on a Windows system
-        if os.name.lower() == 'nt' and not doc_url.startswith('http://'):
+        if (os.name.lower() == 'nt' and
+                not doc_url.startswith(('http://', 'https://'))):
             if not relative:
                 raise ValueError('You have to use relative=True for the local'
                                  ' package on a Windows system.')

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -22,8 +22,10 @@ except ImportError:
 try:
     import urllib2 as urllib_request
     from urllib2 import HTTPError, URLError
+    import urlparse as urllib_parse
 except ImportError:
     import urllib.request as urllib_request
+    import urllib.parse as urllib_parse
     from urllib.error import HTTPError, URLError
 
 from io import StringIO
@@ -35,8 +37,8 @@ logger = sphinx_compatibility.getLogger('sphinx-gallery')
 
 
 def _get_data(url):
-    """Helper function to get data over http or from a local file"""
-    if url.startswith('http://'):
+    """Helper function to get data over http(s) or from a local file"""
+    if urllib_parse.urlparse(url).scheme in ('http', 'https'):
         resp = urllib_request.urlopen(url)
         encoding = resp.headers.get('content-encoding', 'plain')
         data = resp.read()

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -17,13 +17,13 @@ import sys
 # Try Python 2 first, otherwise load from Python 3
 try:
     import cPickle as pickle
-    import urllib2 as urllib
-    from urllib2 import HTTPError, URLError
 except ImportError:
     import pickle
-    import urllib.request
-    import urllib.error
-    import urllib.parse
+try:
+    import urllib2 as urllib_request
+    from urllib2 import HTTPError, URLError
+except ImportError:
+    import urllib.request as urllib_request
     from urllib.error import HTTPError, URLError
 
 from io import StringIO
@@ -37,13 +37,8 @@ logger = sphinx_compatibility.getLogger('sphinx-gallery')
 def _get_data(url):
     """Helper function to get data over http or from a local file"""
     if url.startswith('http://'):
-        # Try Python 2, use Python 3 on exception
-        try:
-            resp = urllib.urlopen(url)
-            encoding = resp.headers.dict.get('content-encoding', 'plain')
-        except AttributeError:
-            resp = urllib.request.urlopen(url)
-            encoding = resp.headers.get('content-encoding', 'plain')
+        resp = urllib_request.urlopen(url)
+        encoding = resp.headers.get('content-encoding', 'plain')
         data = resp.read()
         if encoding == 'plain':
             data = data.decode('utf-8')

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -55,7 +55,7 @@ def clean_gallery_out(build_dir):
     #  the docs, the number of images in the directory grows.
     #
     # This question has been asked on the sphinx development list, but there
-    #  was no response: http://osdir.com/ml/sphinx-dev/2011-02/msg00123.html
+    #  was no response: https://git.net/ml/sphinx-dev/2011-02/msg00123.html
     #
     # The following is a hack that prevents this behavior by clearing the
     #  image build directory from gallery images each time the docs are built.


### PR DESCRIPTION
Check for both `http:` and `https:` where necessary, and then use secure links in as many places as possible.