### PR TITLE
Revert "Enforce UTF8 encoding in backreferences"

### DIFF
--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -11,7 +11,7 @@ Parses example file code in order to keep track of used functions
 from __future__ import print_function
 import ast
 import os
-import codecs
+
 
 # Try Python 2 first, otherwise load from Python 3
 try:
@@ -130,8 +130,7 @@ def identify_names(code):
 
 def scan_used_functions(example_file, gallery_conf):
     """save variables so we can later add links to the documentation"""
-    example_code_obj = identify_names(
-        codecs.open(example_file, encoding='utf-8').read())
+    example_code_obj = identify_names(open(example_file).read())
     if example_code_obj:
         codeobj_fname = example_file[:-3] + '_codeobj.pickle'
         with open(codeobj_fname, 'wb') as fid:


### PR DESCRIPTION
Reverts sphinx-gallery/sphinx-gallery#257.
In python 2 the codeblocks are not being properly recognized to embed the documentation links.