### PR TITLE
Fix py37 changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ matrix:
     - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="3.6"
     - os: linux
+      dist: trusty
       python: 'nightly'
   allow_failures:
     - python: "nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,13 @@ matrix:
       env: DISTRIB="conda" PYTHON_VERSION="3.4"
     - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="3.5"
+    - os: linux
+      env: DISTRIB="conda" PYTHON_VERSION="3.6"
+    - os: linux
+      python: 'nightly'
+  allow_failures:
+    - python: "nightly"
+
 before_install:
     - if [ "$DISTRIB" == "conda" ]; then
          wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;


### PR DESCRIPTION
python/cpython#46 or bpo-29463 added docstring as a property to the module class that comes out of AST (so the free strings no longer appear an the first element in the parsed files).

