### PR TITLE
Push the docs from Circle CI into github

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -36,6 +36,5 @@ deployment:
   staging:
     branch:
       - master
-      - push_doc
     commands:
         - ./docs_deploy.sh rtd_html

--- a/circle.yml
+++ b/circle.yml
@@ -38,5 +38,4 @@ deployment:
       - master
       - push_doc
     commands:
-        - touch rtd_html/.nojekyll
         - ./docs_deploy.sh rtd_html

--- a/circle.yml
+++ b/circle.yml
@@ -31,3 +31,12 @@ general:
     - "doc/_build/html"
     - "rtd_html"
     - "alabaster_html"
+
+deployment:
+  staging:
+    branch:
+      - master
+      - push_doc
+    commands:
+        - touch rtd_html/.nojekyll
+        - ./docs_deploy.sh rtd_html

--- a/docs_deploy.sh
+++ b/docs_deploy.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# ideas used from https://gist.github.com/motemen/8595451
+
+# abort the script if there is a non-zero error
+set -e
+
+# show where we are on the machine
+pwd
+
+siteSource="$1"
+
+if [ ! -d "$siteSource" ]
+then
+    echo "Usage: $0 <site source dir>"
+    exit 1
+fi
+
+# now lets setup the docs repo so we can update them with the current build
+git config --global user.email "Circle CI" > /dev/null 2>&1
+git config --global user.name "bot@try.out" > /dev/null 2>&1
+git clone git@github.com:sphinx-gallery/sphinx-gallery.github.io.git
+cd sphinx-gallery.github.io/
+
+# copy over or recompile the new site
+git rm -rf .
+cp -a "../${siteSource}/." .
+
+# stage any changes and new files
+git add -A
+# now commit
+git commit --allow-empty -m "Update the docs from master"
+# and push, but send any output to /dev/null to hide anything sensitive
+git push --force --quiet origin master > /dev/null 2>&1
+
+# go back to where we started
+cd ..
+
+echo "Finished Deployment!"

--- a/docs_deploy.sh
+++ b/docs_deploy.sh
@@ -24,6 +24,8 @@ cd sphinx-gallery.github.io/
 # copy over or recompile the new site
 git rm -rf .
 cp -a "../${siteSource}/." .
+# github nojekyll
+touch .nojekyll
 
 # stage any changes and new files
 git add -A


### PR DESCRIPTION
Read the docs has built our docs for a long time, and it has some limitations. For example we can not build the examples gallery for mayavi. And with PR #244, we need to have the jupyter notebooks on a github repository to use binder.

This PR builds the documentation on CircleCI and if succesful it pushed the results to github pages.
Now the build address is 
https://sphinx-gallery.github.io
For the moment it will only build master branch. 
I image we can slowly move towards this website and drop readthedocs.