### PR TITLE
Ensure shortened module path points to expected object.

### DIFF
--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -76,12 +76,23 @@ class NameFinder(ast.NodeVisitor):
 
 def get_short_module_name(module_name, obj_name):
     """ Get the shortest possible module name """
+    scope = {}
+    try:
+        # Find out what the real object is supposed to be.
+        exec('from %s import %s' % (module_name, obj_name), scope, scope)
+        real_obj = scope[obj_name]
+    except Exception:
+        return module_name
+
     parts = module_name.split('.')
     short_name = module_name
     for i in range(len(parts) - 1, 0, -1):
         short_name = '.'.join(parts[:i])
+        scope = {}
         try:
-            exec('from %s import %s' % (short_name, obj_name))
+            exec('from %s import %s' % (short_name, obj_name), scope, scope)
+            # Ensure shortened object is the same as what we expect.
+            assert real_obj is scope[obj_name]
         except Exception:  # libraries can throw all sorts of exceptions...
             # get the last working module name
             short_name = '.'.join(parts[:(i + 1)])


### PR DESCRIPTION
For example, `matplotlib.pyplot.figure` can be shortened to `matplotlib.figure`, but the former is a function (that is used a lot) while the latter is a module (which is generally used much less).