### PR TITLE
[WIP] Expose examples sortkey

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -300,7 +300,7 @@ intersphinx_mapping = {
     'matplotlib': ('https://matplotlib.org/', None),
 }
 
-from sphinx_gallery.sorting import ExplicitOrder
+from sphinx_gallery.sorting import ExplicitOrder, amount_of_code
 examples_dirs = ['../examples', '../tutorials']
 gallery_dirs = ['auto_examples', 'tutorials']
 
@@ -330,6 +330,7 @@ sphinx_gallery_conf = {
     'subsection_order': ExplicitOrder(['../examples/sin_func',
                                        '../examples/no_output',
                                        '../tutorials/seaborn']),
+    'within_subsection_order': amount_of_code,
     'find_mayavi_figures': find_mayavi_figures,
     'expected_failing_examples': ['../examples/no_output/plot_raise.py',
                                   '../examples/no_output/plot_syntaxerror.py']

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -32,6 +32,7 @@ DEFAULT_GALLERY_CONF = {
     'filename_pattern': re.escape(os.sep) + 'plot',
     'examples_dirs': os.path.join('..', 'examples'),
     'subsection_order': None,
+    'within_subsection_order': None,
     'gallery_dirs': 'auto_examples',
     'backreferences_dir': None,
     'doc_module': (),

--- a/sphinx_gallery/sorting.py
+++ b/sphinx_gallery/sorting.py
@@ -13,6 +13,8 @@ from __future__ import division, absolute_import, print_function
 import os
 import types
 
+from .py_source_parser import split_code_and_text_blocks
+
 
 class ExplicitOrder(object):
     """Sorting key for all galleries subsections
@@ -46,3 +48,23 @@ class ExplicitOrder(object):
             raise ValueError('If you use an explicit folder ordering, you '
                              'must specify all folders. Explicit order not '
                              'found for {}'.format(item))
+
+
+def amount_of_code(src_dir):
+    """Sort examples in src_dir by amount of code """
+    def sort_files(filename):
+        src_file = os.path.normpath(os.path.join(src_dir, filename))
+        file_conf, script_blocks = split_code_and_text_blocks(src_file)
+        amount_of_code = sum([len(bcontent)
+                              for blabel, bcontent, lineno in script_blocks
+                              if blabel == 'code'])
+        return amount_of_code
+    return sort_files
+
+
+def file_size(src_dir):
+    """Sort examples in src_dir by file size"""
+    def sort_files(filename):
+        src_file = os.path.normpath(os.path.join(src_dir, filename))
+        return os.stat(src_file).st_size
+    return sort_files


### PR DESCRIPTION
This is my proposal for #275 
Here I directly expose a sortkey for ordering the examples within each subsection. 
Default is for the moment case sensitive alphabetic ordering, which uses the `None` keyword. Functions for amount of code or file size are also provided.
Needs the documentation. Feel free to take over this PR.