### PR TITLE
Reset matplotlib using rc_file_defaults, not rcdefaults.

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -521,7 +521,7 @@ def clean_modules():
             del sys.modules[module]
 
     # Reset Matplotlib to default
-    plt.rcdefaults()
+    matplotlib.rc_file_defaults()
 
 
 def generate_file_rst(fname, target_dir, src_dir, gallery_conf):


### PR DESCRIPTION
rcdefaults() restores the internal defaults of matplotlib.
rc_file_defaults() restores to whatever was loaded when matplotlib was
first imported, which includes settings from the user's matplotlibrc,
and can be different.

Before this PR, the first item generated by the gallery uses the user's
matplotlibrc whereas all others uses the internal default one.

Alternatively, you may decide that s-g should always ignore the user's
matplotlibrc (although it would still be nice to provide some way to
customize the defaults), in which case a call to rcdefaults() should be
added before the first example is generated (for example, it the call
could just happen before every example rather than after every example).