### PR TITLE
MRG: Allow sorting subsection files

### DIFF
--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -18,6 +18,7 @@ file:
 - ``examples_dirs`` and ``gallery_dirs`` (:ref:`multiple_galleries_config`)
 - ``filename_pattern`` (:ref:`build_pattern`)
 - ``subsection_order`` (:ref:`sub_gallery_order`)
+- ``within_subsection_order`` (:ref:`within_gallery_order`)
 - ``reference_url`` (:ref:`link_to_documentation`)
 - ``backreferences_dir`` and ``doc_module`` (:ref:`references_to_examples`)
 - ``default_thumb_file`` (:ref:`custom_default_thumb`)
@@ -140,6 +141,29 @@ the converse does not hold.
 
 If you so desire you can implement your own sorting key. It will be
 provided the relative paths to `conf.py` of each sub gallery folder.
+
+
+.. _within_gallery_order:
+
+Sorting gallery examples
+========================
+
+Within a given gallery (sub)section, the example files by default are ordered
+by the amount of code, i.e. :class:`sphinx_gallery.sorting.AmountOfCodeSortKey`
+as::
+
+    from sphinx_gallery.sorting import AmountOfCodeSortKey
+    sphinx_gallery_conf = {
+        ...
+        'within_subsection_order': AmountOfCodeSortKey,
+    }
+
+However, other options exist that can be instantiated for use with
+``within_subsection_order``:
+
+- :class:`sphinx_gallery.sorting.FileSizeSortKey` to sort by file size.
+- :class:`sphinx_gallery.sorting.FileNameSortKey` to sort by file name.
+- :class:`sphinx_gallery.sorting.ExampleTitleSortKey` to sort by example title.
 
 
 .. _link_to_documentation:

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -148,19 +148,23 @@ provided the relative paths to `conf.py` of each sub gallery folder.
 Sorting gallery examples
 ========================
 
-Within a given gallery (sub)section, the example files by default are ordered
-by the amount of code, i.e. :class:`sphinx_gallery.sorting.AmountOfCodeSortKey`
-as::
+Within a given gallery (sub)section, the example files are ordered by
+using the standard :func:`sorted` function with the ``key`` argument by default
+set to
+:class:`NumberOfCodeLinesSortKey(src_dir) <sphinx_gallery.sorting.NumberOfCodeLinesSortKey>`,
+which sorts the files based on the number of code lines::
 
-    from sphinx_gallery.sorting import AmountOfCodeSortKey
+    from sphinx_gallery.sorting import NumberOfCodeLinesSortKey
     sphinx_gallery_conf = {
         ...
-        'within_subsection_order': AmountOfCodeSortKey,
+        'within_subsection_order': NumberOfCodeLinesSortKey,
     }
 
-However, other options exist that can be instantiated for use with
+However, multiple convenience classes are provided for use with
 ``within_subsection_order``:
 
+- :class:`sphinx_gallery.sorting.NumberOfCodeLinesSortKey` (default) to sort by
+  the number of code lines.
 - :class:`sphinx_gallery.sorting.FileSizeSortKey` to sort by file size.
 - :class:`sphinx_gallery.sorting.FileNameSortKey` to sort by file name.
 - :class:`sphinx_gallery.sorting.ExampleTitleSortKey` to sort by example title.

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -160,7 +160,7 @@ which sorts the files based on the number of code lines::
         'within_subsection_order': NumberOfCodeLinesSortKey,
     }
 
-However, multiple convenience classes are provided for use with
+In addition, multiple convenience classes are provided for use with
 ``within_subsection_order``:
 
 - :class:`sphinx_gallery.sorting.NumberOfCodeLinesSortKey` (default) to sort by

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -306,7 +306,7 @@ intersphinx_mapping = {
     'mayavi': ('http://docs.enthought.com/mayavi/mayavi', None),
 }
 
-from sphinx_gallery.sorting import ExplicitOrder, amount_of_code
+from sphinx_gallery.sorting import ExplicitOrder, AmountOfCodeSortKey
 examples_dirs = ['../examples', '../tutorials']
 gallery_dirs = ['auto_examples', 'tutorials']
 
@@ -336,7 +336,7 @@ sphinx_gallery_conf = {
     'subsection_order': ExplicitOrder(['../examples/sin_func',
                                        '../examples/no_output',
                                        '../tutorials/seaborn']),
-    'within_subsection_order': amount_of_code,
+    'within_subsection_order': AmountOfCodeSortKey,
     'find_mayavi_figures': find_mayavi_figures,
     'expected_failing_examples': ['../examples/no_output/plot_raise.py',
                                   '../examples/no_output/plot_syntaxerror.py']

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -306,7 +306,7 @@ intersphinx_mapping = {
     'mayavi': ('http://docs.enthought.com/mayavi/mayavi', None),
 }
 
-from sphinx_gallery.sorting import ExplicitOrder, AmountOfCodeSortKey
+from sphinx_gallery.sorting import ExplicitOrder, NumberOfCodeLinesSortKey
 examples_dirs = ['../examples', '../tutorials']
 gallery_dirs = ['auto_examples', 'tutorials']
 
@@ -336,7 +336,7 @@ sphinx_gallery_conf = {
     'subsection_order': ExplicitOrder(['../examples/sin_func',
                                        '../examples/no_output',
                                        '../tutorials/seaborn']),
-    'within_subsection_order': AmountOfCodeSortKey,
+    'within_subsection_order': NumberOfCodeLinesSortKey,
     'find_mayavi_figures': find_mayavi_figures,
     'expected_failing_examples': ['../examples/no_output/plot_raise.py',
                                   '../examples/no_output/plot_syntaxerror.py']

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -306,7 +306,7 @@ intersphinx_mapping = {
     'mayavi': ('http://docs.enthought.com/mayavi/mayavi', None),
 }
 
-from sphinx_gallery.sorting import ExplicitOrder
+from sphinx_gallery.sorting import ExplicitOrder, amount_of_code
 examples_dirs = ['../examples', '../tutorials']
 gallery_dirs = ['auto_examples', 'tutorials']
 
@@ -336,6 +336,7 @@ sphinx_gallery_conf = {
     'subsection_order': ExplicitOrder(['../examples/sin_func',
                                        '../examples/no_output',
                                        '../tutorials/seaborn']),
+    'within_subsection_order': amount_of_code,
     'find_mayavi_figures': find_mayavi_figures,
     'expected_failing_examples': ['../examples/no_output/plot_raise.py',
                                   '../examples/no_output/plot_syntaxerror.py']

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -21,6 +21,7 @@ from . import sphinx_compatibility
 from .gen_rst import generate_dir_rst, SPHX_GLR_SIG
 from .docs_resolv import embed_code_links
 from .downloads import generate_zipfiles
+from .sorting import AmountOfCodeSortKey
 
 try:
     FileNotFoundError
@@ -32,7 +33,7 @@ DEFAULT_GALLERY_CONF = {
     'filename_pattern': re.escape(os.sep) + 'plot',
     'examples_dirs': os.path.join('..', 'examples'),
     'subsection_order': None,
-    'within_subsection_order': None,
+    'within_subsection_order': AmountOfCodeSortKey,
     'gallery_dirs': 'auto_examples',
     'backreferences_dir': None,
     'doc_module': (),

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -32,6 +32,7 @@ DEFAULT_GALLERY_CONF = {
     'filename_pattern': re.escape(os.sep) + 'plot',
     'examples_dirs': os.path.join('..', 'examples'),
     'subsection_order': None,
+    'within_subsection_order': None,
     'gallery_dirs': 'auto_examples',
     'backreferences_dir': None,
     'doc_module': (),

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -21,7 +21,7 @@ from . import sphinx_compatibility
 from .gen_rst import generate_dir_rst, SPHX_GLR_SIG
 from .docs_resolv import embed_code_links
 from .downloads import generate_zipfiles
-from .sorting import AmountOfCodeSortKey
+from .sorting import NumberOfCodeLinesSortKey
 
 try:
     FileNotFoundError
@@ -33,7 +33,7 @@ DEFAULT_GALLERY_CONF = {
     'filename_pattern': re.escape(os.sep) + 'plot',
     'examples_dirs': os.path.join('..', 'examples'),
     'subsection_order': None,
-    'within_subsection_order': AmountOfCodeSortKey,
+    'within_subsection_order': NumberOfCodeLinesSortKey,
     'gallery_dirs': 'auto_examples',
     'backreferences_dir': None,
     'doc_module': (),

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -153,12 +153,15 @@ def codestr2rst(codestr, lang='python', lineno=None):
     return code_directive + indented_block
 
 
-def extract_intro(filename, docstring):
+def extract_intro_title(filename, docstring):
     """ Extract the first paragraph of module-level docstring. max:95 char"""
 
     # lstrip is just in case docstring has a '\n\n' at the beginning
     paragraphs = docstring.lstrip().split('\n\n')
+    paragraphs = [p for p in paragraphs if not p.startswith('..')]
     if len(paragraphs) > 1:
+        title = paragraphs[0].split('\n')
+        title = ' '.join(t for t in title if t[0] not in ['=', '-', '^', '~'])
         first_paragraph = re.sub('\n', ' ', paragraphs[1])
         first_paragraph = (first_paragraph[:95] + '...'
                            if len(first_paragraph) > 95 else first_paragraph)
@@ -168,7 +171,7 @@ def extract_intro(filename, docstring):
             "and at least a paragraph explaining what the example is about. "
             "Please check the example file:\n {}\n".format(filename))
 
-    return first_paragraph
+    return first_paragraph, title
 
 
 def get_md5sum(src_file):
@@ -537,7 +540,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
     example_file = os.path.join(target_dir, fname)
     shutil.copyfile(src_file, example_file)
     file_conf, script_blocks = split_code_and_text_blocks(src_file)
-    intro = extract_intro(fname, script_blocks[0][1])
+    intro, title = extract_intro_title(fname, script_blocks[0][1])
 
     if md5sum_is_current(example_file):
         return intro, 0

--- a/sphinx_gallery/sorting.py
+++ b/sphinx_gallery/sorting.py
@@ -13,6 +13,7 @@ from __future__ import division, absolute_import, print_function
 import os
 import types
 
+from .gen_rst import extract_intro_title
 from .py_source_parser import split_code_and_text_blocks
 
 
@@ -114,6 +115,5 @@ class ExampleTitleSortKey(_SortKey):
     def __call__(self, filename):
         src_file = os.path.normpath(os.path.join(self.src_dir, filename))
         _, script_blocks = split_code_and_text_blocks(src_file)
-        # title should be the second line of the first script_blocks entry
-        title = script_blocks[0][1].strip().split('\n')[1]
+        _, title = extract_intro_title(src_file, script_blocks[0][1])
         return title

--- a/sphinx_gallery/sorting.py
+++ b/sphinx_gallery/sorting.py
@@ -13,7 +13,7 @@ from __future__ import division, absolute_import, print_function
 import os
 import types
 
-from .gen_rst import extract_intro_title
+from .gen_rst import extract_intro_and_title
 from .py_source_parser import split_code_and_text_blocks
 
 
@@ -115,5 +115,5 @@ class ExampleTitleSortKey(_SortKey):
     def __call__(self, filename):
         src_file = os.path.normpath(os.path.join(self.src_dir, filename))
         _, script_blocks = split_code_and_text_blocks(src_file)
-        _, title = extract_intro_title(src_file, script_blocks[0][1])
+        _, title = extract_intro_and_title(src_file, script_blocks[0][1])
         return title

--- a/sphinx_gallery/sorting.py
+++ b/sphinx_gallery/sorting.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 r"""
-Sorters for Sphinx-Gallery subsections
-======================================
+Sorters for Sphinx-Gallery (sub)sections
+========================================
 
-Sorting key functions for gallery subsection folders
+Sorting key functions for gallery subsection folders and section files.
 """
 # Created: Sun May 21 20:38:59 2017
 # Author: Óscar Nájera
@@ -17,19 +17,19 @@ from .py_source_parser import split_code_and_text_blocks
 
 
 class ExplicitOrder(object):
-    """Sorting key for all galleries subsections
+    """Sorting key for all gallery subsections.
 
-    This requires all folders to be listed otherwise an exception is raised
+    This requires all folders to be listed otherwise an exception is raised.
 
     Parameters
     ----------
     ordered_list : list, tuple, types.GeneratorType
-        Hold the paths of each galleries' subsections
+        Hold the paths of each galleries' subsections.
 
     Raises
     ------
     ValueError
-        Wrong input type or Subgallery path missing
+        Wrong input type or Subgallery path missing.
     """
 
     def __init__(self, ordered_list):
@@ -50,21 +50,53 @@ class ExplicitOrder(object):
                              'found for {}'.format(item))
 
 
-def amount_of_code(src_dir):
-    """Sort examples in src_dir by amount of code """
-    def sort_files(filename):
-        src_file = os.path.normpath(os.path.join(src_dir, filename))
+class _SortKey(object):
+    """Base class for section order key classes."""
+
+    def __init__(self, src_dir):
+        self.src_dir = src_dir
+
+
+class AmountOfCodeSortKey(_SortKey):
+    """Sort examples in src_dir by amount of code.
+
+    Parameters
+    ----------
+    src_dir : str
+        The source directory.
+    """
+
+    def __call__(self, filename):
+        src_file = os.path.normpath(os.path.join(self.src_dir, filename))
         file_conf, script_blocks = split_code_and_text_blocks(src_file)
         amount_of_code = sum([len(bcontent)
                               for blabel, bcontent, lineno in script_blocks
                               if blabel == 'code'])
         return amount_of_code
-    return sort_files
 
 
-def file_size(src_dir):
-    """Sort examples in src_dir by file size"""
-    def sort_files(filename):
-        src_file = os.path.normpath(os.path.join(src_dir, filename))
+class FileSizeSortKey(_SortKey):
+    """Sort examples in src_dir by file size.
+
+    Parameters
+    ----------
+    src_dir : str
+        The source directory.
+    """
+
+    def __call__(self, filename):
+        src_file = os.path.normpath(os.path.join(self.src_dir, filename))
         return os.stat(src_file).st_size
-    return sort_files
+
+
+class FileNameSortKey(_SortKey):
+    """Sort examples in src_dir by file size.
+
+    Parameters
+    ----------
+    src_dir : str
+        The source directory.
+    """
+
+    def __call__(self, filename):
+        return filename

--- a/sphinx_gallery/sorting.py
+++ b/sphinx_gallery/sorting.py
@@ -57,8 +57,8 @@ class _SortKey(object):
         self.src_dir = src_dir
 
 
-class AmountOfCodeSortKey(_SortKey):
-    """Sort examples in src_dir by amount of code.
+class NumberOfCodeLinesSortKey(_SortKey):
+    """Sort examples in src_dir by the number of code lines.
 
     Parameters
     ----------
@@ -115,4 +115,5 @@ class ExampleTitleSortKey(_SortKey):
         src_file = os.path.normpath(os.path.join(self.src_dir, filename))
         _, script_blocks = split_code_and_text_blocks(src_file)
         # title should be the second line of the first script_blocks entry
-        return script_blocks[0][1].strip().split('\n')[1]
+        title = script_blocks[0][1].strip().split('\n')[1]
+        return title

--- a/sphinx_gallery/sorting.py
+++ b/sphinx_gallery/sorting.py
@@ -13,6 +13,8 @@ from __future__ import division, absolute_import, print_function
 import os
 import types
 
+from .py_source_parser import split_code_and_text_blocks
+
 
 class ExplicitOrder(object):
     """Sorting key for all galleries subsections
@@ -46,3 +48,23 @@ class ExplicitOrder(object):
             raise ValueError('If you use an explicit folder ordering, you '
                              'must specify all folders. Explicit order not '
                              'found for {}'.format(item))
+
+
+def amount_of_code(src_dir):
+    """Sort examples in src_dir by amount of code """
+    def sort_files(filename):
+        src_file = os.path.normpath(os.path.join(src_dir, filename))
+        file_conf, script_blocks = split_code_and_text_blocks(src_file)
+        amount_of_code = sum([len(bcontent)
+                              for blabel, bcontent, lineno in script_blocks
+                              if blabel == 'code'])
+        return amount_of_code
+    return sort_files
+
+
+def file_size(src_dir):
+    """Sort examples in src_dir by file size"""
+    def sort_files(filename):
+        src_file = os.path.normpath(os.path.join(src_dir, filename))
+        return os.stat(src_file).st_size
+    return sort_files

--- a/sphinx_gallery/sorting.py
+++ b/sphinx_gallery/sorting.py
@@ -100,3 +100,19 @@ class FileNameSortKey(_SortKey):
 
     def __call__(self, filename):
         return filename
+
+
+class ExampleTitleSortKey(_SortKey):
+    """Sort examples in src_dir by example title.
+
+    Parameters
+    ----------
+    src_dir : str
+        The source directory.
+    """
+
+    def __call__(self, filename):
+        src_file = os.path.normpath(os.path.join(self.src_dir, filename))
+        _, script_blocks = split_code_and_text_blocks(src_file)
+        # title should be the second line of the first script_blocks entry
+        return script_blocks[0][1].strip().split('\n')[1]

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -172,7 +172,6 @@ def _check_order(config_app, key):
     regex = '.*:%s=(.):.*' % key
     with codecs.open(index_fname, 'r', 'utf-8') as fid:
         for line in fid:
-            print(line)
             if 'sphx-glr-thumbcontainer' in line:
                 order.append(int(re.match(regex, line).group(1)))
     assert len(order) == 3

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -172,6 +172,7 @@ def _check_order(config_app, key):
     regex = '.*:%s=(.):.*' % key
     with codecs.open(index_fname, 'r', 'utf-8') as fid:
         for line in fid:
+            print(line)
             if 'sphx-glr-thumbcontainer' in line:
                 order.append(int(re.match(regex, line).group(1)))
     assert len(order) == 3

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -5,15 +5,17 @@ r"""
 Test Sphinx-Gallery
 """
 
-from __future__ import division, absolute_import, print_function, unicode_literals
+from __future__ import (division, absolute_import, print_function,
+                        unicode_literals)
+import codecs
 import os
-import tempfile
+import re
 import shutil
+import tempfile
 import pytest
 from sphinx.application import Sphinx
 from sphinx.errors import ExtensionError
 from sphinx_gallery.gen_rst import MixedEncodingStringIO
-from sphinx_gallery.gen_gallery import DEFAULT_GALLERY_CONF
 from sphinx_gallery import sphinx_compatibility
 
 
@@ -162,3 +164,55 @@ def test_config_backreferences(config_app):
         'gen_modules', 'backreferences')
     build_warn = config_app._warning.getvalue()
     assert build_warn == ""
+
+
+def _check_order(config_app, key):
+    index_fname = os.path.join(config_app.outdir, '..', 'ex', 'index.rst')
+    order = list()
+    regex = '.*:%s=(.):.*' % key
+    with codecs.open(index_fname, 'r', 'utf-8') as fid:
+        for line in fid:
+            if 'sphx-glr-thumbcontainer' in line:
+                order.append(int(re.match(regex, line).group(1)))
+    assert len(order) == 3
+    assert order == [1, 2, 3]
+
+
+@pytest.mark.conf_file(content="""
+import sphinx_gallery
+extensions = ['sphinx_gallery.gen_gallery']
+sphinx_gallery_conf = {
+    'examples_dirs': 'src',
+    'gallery_dirs': 'ex',
+}""")
+def test_example_sorting_default(config_app):
+    """Test sorting of examples by default key (number of code lines)."""
+    _check_order(config_app, 'lines')
+
+
+@pytest.mark.conf_file(content="""
+import sphinx_gallery
+from sphinx_gallery.sorting import FileSizeSortKey
+extensions = ['sphinx_gallery.gen_gallery']
+sphinx_gallery_conf = {
+    'examples_dirs': 'src',
+    'gallery_dirs': 'ex',
+    'within_subsection_order': FileSizeSortKey,
+}""")
+def test_example_sorting_filesize(config_app):
+    """Test sorting of examples by default key (number of code lines)."""
+    _check_order(config_app, 'filesize')
+
+
+@pytest.mark.conf_file(content="""
+import sphinx_gallery
+from sphinx_gallery.sorting import FileNameSortKey
+extensions = ['sphinx_gallery.gen_gallery']
+sphinx_gallery_conf = {
+    'examples_dirs': 'src',
+    'gallery_dirs': 'ex',
+    'within_subsection_order': FileNameSortKey,
+}""")
+def test_example_sorting_filename(config_app):
+    """Test sorting of examples by default key (number of code lines)."""
+    _check_order(config_app, 'filename')

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -200,7 +200,7 @@ sphinx_gallery_conf = {
     'within_subsection_order': FileSizeSortKey,
 }""")
 def test_example_sorting_filesize(config_app):
-    """Test sorting of examples by default key (number of code lines)."""
+    """Test sorting of examples by filesize."""
     _check_order(config_app, 'filesize')
 
 
@@ -214,5 +214,19 @@ sphinx_gallery_conf = {
     'within_subsection_order': FileNameSortKey,
 }""")
 def test_example_sorting_filename(config_app):
-    """Test sorting of examples by default key (number of code lines)."""
+    """Test sorting of examples by filename."""
     _check_order(config_app, 'filename')
+
+
+@pytest.mark.conf_file(content="""
+import sphinx_gallery
+from sphinx_gallery.sorting import ExampleTitleSortKey
+extensions = ['sphinx_gallery.gen_gallery']
+sphinx_gallery_conf = {
+    'examples_dirs': 'src',
+    'gallery_dirs': 'ex',
+    'within_subsection_order': ExampleTitleSortKey,
+}""")
+def test_example_sorting_title(config_app):
+    """Test sorting of examples by title."""
+    _check_order(config_app, 'title')

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -26,6 +26,7 @@ import matplotlib.pyplot as plt
 
 CONTENT = [
     '"""',
+    '================',
     'Docstring header',
     '================',
     '',
@@ -109,8 +110,9 @@ def test_codestr2rst():
     assert reference == output
 
 
-def test_extract_intro_title():
-    intro, title = sg.extract_intro_title('<string>', '\n'.join(CONTENT[1:9]))
+def test_extract_intro_and_title():
+    intro, title = sg.extract_intro_and_title('<string>',
+                                              '\n'.join(CONTENT[1:10]))
     assert title == 'Docstring header'
     assert 'Docstring' not in intro
     assert intro == 'This is the description of the example which goes on and on, Óscar'  # noqa

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -25,7 +25,7 @@ from sphinx_gallery import sphinx_compatibility
 import matplotlib.pyplot as plt
 
 CONTENT = [
-    '"""'
+    '"""',
     'Docstring header',
     '================',
     '',
@@ -109,11 +109,12 @@ def test_codestr2rst():
     assert reference == output
 
 
-def test_extract_intro():
-    result = sg.extract_intro('<string>', '\n'.join(CONTENT[1:9]))
-    assert 'Docstring' not in result
-    assert result == 'This is the description of the example which goes on and on, Óscar'  # noqa
-    assert 'second paragraph' not in result
+def test_extract_intro_title():
+    intro, title = sg.extract_intro_title('<string>', '\n'.join(CONTENT[1:9]))
+    assert title == 'Docstring header'
+    assert 'Docstring' not in intro
+    assert intro == 'This is the description of the example which goes on and on, Óscar'  # noqa
+    assert 'second paragraph' not in intro
 
 
 def test_md5sums():

--- a/sphinx_gallery/tests/test_sorting.py
+++ b/sphinx_gallery/tests/test_sorting.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 r"""
-Tests for sorting keys on gallery sections
-==========================================
+Tests for sorting keys on gallery (sub)sections
+===============================================
 
 """
 # Author: Óscar Nájera

--- a/sphinx_gallery/tests/testconfs/src/plot_1.py
+++ b/sphinx_gallery/tests/testconfs/src/plot_1.py
@@ -1,0 +1,11 @@
+"""
+======
+B test
+======
+
+:filename=1:title=2:lines=3:filesize=2:
+"""
+
+print('foo')
+print('bar')
+print('again')

--- a/sphinx_gallery/tests/testconfs/src/plot_1.py
+++ b/sphinx_gallery/tests/testconfs/src/plot_1.py
@@ -1,7 +1,9 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
 """
-======
-B test
-======
+======================================
+B test, with two junk lines at the top
+======================================
 
 :filename=1:title=2:lines=3:filesize=2:
 """

--- a/sphinx_gallery/tests/testconfs/src/plot_1.py
+++ b/sphinx_gallery/tests/testconfs/src/plot_1.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
 """
-======================================
-B test, with two junk lines at the top
-======================================
+======
+B test
+======
 
 :filename=1:title=2:lines=3:filesize=2:
 """

--- a/sphinx_gallery/tests/testconfs/src/plot_2.py
+++ b/sphinx_gallery/tests/testconfs/src/plot_2.py
@@ -1,0 +1,9 @@
+"""
+======
+C test
+======
+
+:filename=2:title=3:lines=1:filesize=1:
+"""
+
+print('foo')

--- a/sphinx_gallery/tests/testconfs/src/plot_3.py
+++ b/sphinx_gallery/tests/testconfs/src/plot_3.py
@@ -1,4 +1,8 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
 """
+.. _extra_ref:
+
 ===========================================================
 A test with a really long title to make the filesize larger
 ===========================================================

--- a/sphinx_gallery/tests/testconfs/src/plot_3.py
+++ b/sphinx_gallery/tests/testconfs/src/plot_3.py
@@ -1,0 +1,10 @@
+"""
+===========================================================
+A test with a really long title to make the filesize larger
+===========================================================
+
+:filename=3:title=1:lines=2:filesize=3:
+"""
+
+print('foo')
+print('bar')


### PR DESCRIPTION
Closes #275.
Closes #278. (Take over of this PR.)

This adds sort keys for sorting within subsections. I don't need explicit reordering currently (filename-based is good enough for now) so I didn't bother implementing it for now. But it at least sets up the framework for it later.

~~WIP for now because I'm not updating the doc until #279 is merged and I can rebase to avoid conflicts.~~