### PR TITLE
Minor changes to log format.

### DIFF
--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -290,7 +290,7 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
             for dirpath, _, filenames in os.walk(html_gallery_dir)
             for filename in filenames]
     iterator = sphinx_compatibility.status_iterator(
-        flat, gallery_dir, color='fuchsia',
+        flat, '%s ' % gallery_dir, color='fuchsia',
         length=len(flat), stringify_func=lambda x: os.path.basename(x[1]))
     for dirpath, fname in iterator:
         full_fname = os.path.join(html_gallery_dir, dirpath, fname)
@@ -370,7 +370,7 @@ def embed_code_links(app, exception):
     if app.builder.name not in ['html', 'readthedocs']:
         return
 
-    logger.info('Embedding documentation hyperlinks in examples ...',
+    logger.info('embedding documentation hyperlinks in examples...',
                 color='white')
 
     gallery_conf = app.config.sphinx_gallery_conf

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -197,7 +197,7 @@ def generate_gallery_rst(app):
     Start the sphinx-gallery configuration and recursively scan the examples
     directories in order to populate the examples gallery
     """
-    logger.info('Generating gallery...', color='white')
+    logger.info('generating gallery...', color='white')
     gallery_conf = parse_config(app)
 
     clean_gallery_out(app.builder.outdir)
@@ -248,12 +248,12 @@ def generate_gallery_rst(app):
             fhindex.write(SPHX_GLR_SIG)
 
     if gallery_conf['plot_gallery']:
-        logger.info("Computation time summary:", color='white')
+        logger.info("computation time summary:", color='white')
         for time_elapsed, fname in sorted(computation_times)[::-1]:
             if time_elapsed is not None:
-                logger.info("\t- %s : %.2g sec", fname, time_elapsed)
+                logger.info("\t- %s: %.2g sec", fname, time_elapsed)
             else:
-                logger.info("\t- %s : not run", fname)
+                logger.info("\t- %s: not run", fname)
 
 
 def touch_empty_backreferences(app, what, name, obj, options, lines):

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -394,7 +394,7 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
     build_target_dir = os.path.relpath(target_dir, gallery_conf['src_dir'])
     iterator = sphinx_compatibility.status_iterator(
         sorted_listdir,
-        'Generating gallery for %s ' % build_target_dir,
+        'generating gallery for %s... ' % build_target_dir,
         length=len(sorted_listdir))
     for fname in iterator:
         intro, time_elapsed = generate_file_rst(


### PR DESCRIPTION
Consistently with other logs output by sphinx, don't capitalize the
first letter of the log.  Slight fixes to whitespace.