### PR TITLE
MRG: Fix gzip/BytesIO error

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -304,6 +304,7 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('https://matplotlib.org/', None),
     'mayavi': ('http://docs.enthought.com/mayavi/mayavi', None),
+    'sklearn': ('http://scikit-learn.org/stable', None),
 }
 
 from sphinx_gallery.sorting import ExplicitOrder, NumberOfCodeLinesSortKey
@@ -330,7 +331,9 @@ sphinx_gallery_conf = {
     'reference_url': {
         'sphinx_gallery': None,
         'matplotlib': 'https://matplotlib.org',
-        'numpy': 'https://docs.scipy.org/doc/numpy'},
+        'numpy': 'https://docs.scipy.org/doc/numpy',
+        'sklearn': 'http://scikit-learn.org/stable',
+        },
     'examples_dirs': examples_dirs,
     'gallery_dirs': gallery_dirs,
     'subsection_order': ExplicitOrder(['../examples/sin_func',

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -28,7 +28,7 @@ except ImportError:
     import urllib.parse as urllib_parse
     from urllib.error import HTTPError, URLError
 
-from io import StringIO
+from io import BytesIO
 
 from sphinx.search import js_index
 
@@ -47,7 +47,7 @@ def _get_data(url):
         if encoding == 'plain':
             data = data.decode('utf-8')
         elif encoding == 'gzip':
-            data = StringIO(data)
+            data = BytesIO(data)
             data = gzip.GzipFile(fileobj=data).read().decode('utf-8')
         else:
             raise RuntimeError('unknown encoding')
@@ -258,12 +258,10 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
         try:
             if url is None:
                 doc_resolvers[this_module] = SphinxDocLinkResolver(
-                    app.builder.outdir,
-                    src_gallery_dir,
-                    relative=True)
+                    app.builder.outdir, src_gallery_dir, relative=True)
             else:
-                doc_resolvers[this_module] = SphinxDocLinkResolver(url,
-                                                                   src_gallery_dir)
+                doc_resolvers[this_module] = SphinxDocLinkResolver(
+                    url, src_gallery_dir)
 
         except HTTPError as e:
             logger.warning(

--- a/sphinx_gallery/tests/test_docs_resolv.py
+++ b/sphinx_gallery/tests/test_docs_resolv.py
@@ -14,6 +14,12 @@ import pytest
 import sphinx_gallery.docs_resolv as sg
 
 
+def test_embed_code_links_get_data():
+    """Test that we can get data for code links."""
+    sg._get_data('http://docs.scipy.org/doc/scipy/reference')
+    sg._get_data('http://scikit-learn.org/stable/')  # GZip
+
+
 def test_shelve():
     """Test if shelve can be caches information
     retrieved after file is deleted"""


### PR DESCRIPTION
Over at MNE we are getting:
```
embedding documentation hyperlinks...

Exception occurred:
  File "/home/ubuntu/mne-python/sphinx-gallery/sphinx_gallery/docs_resolv.py", line 50, in _get_data
    data = StringIO(data)
TypeError: initial_value must be unicode or None, not str
```
I have a fix but I want to see if I can expose it first (TDD!).