### PR TITLE
[MRG] FIX import local modules in examples

### DIFF
--- a/examples/local_module.py
+++ b/examples/local_module.py
@@ -1,0 +1,5 @@
+"""
+A trivial local module to provide a value for plot_exp.py.
+"""
+
+N = 100

--- a/examples/plot_exp.py
+++ b/examples/plot_exp.py
@@ -14,9 +14,13 @@ stacking multiple images.
 import numpy as np
 import matplotlib.pyplot as plt
 
+# You can use modules local to the example being run, here
+# we just use a trivial NumPy wrapper
+from local_module import N  # = 100
+
 
 def main():
-    x = np.linspace(-1, 2, 100)
+    x = np.linspace(-1, 2, N)
     y = np.exp(x)
 
     plt.figure()

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -14,6 +14,7 @@ Files that generate images should start with 'plot'.
 # tricky errors come up with exec(code_blocks, ...) calls
 from __future__ import division, print_function, absolute_import
 from time import time
+import copy
 import ast
 import codecs
 import hashlib
@@ -434,6 +435,9 @@ def execute_code_block(compiler, block, example_globals,
 
     my_stdout = MixedEncodingStringIO()
     os.chdir(os.path.dirname(src_file))
+
+    sys_path = copy.deepcopy(sys.path)
+    sys.path.append(os.getcwd())
     sys.stdout = LoggingTee(my_stdout, logger, src_file)
 
     try:
@@ -466,6 +470,7 @@ def execute_code_block(compiler, block, example_globals,
     else:
         sys.stdout.flush()
         sys.stdout = orig_stdout
+        sys.path = sys_path
         os.chdir(cwd)
 
         my_stdout = my_stdout.getvalue().strip().expandtabs()
@@ -478,6 +483,7 @@ def execute_code_block(compiler, block, example_globals,
 
     finally:
         os.chdir(cwd)
+        sys.path = sys_path
         sys.stdout = orig_stdout
     script_vars['memory_delta'].append(mem)
 

--- a/sphinx_gallery/tests/tinybuild/examples/local_module.py
+++ b/sphinx_gallery/tests/tinybuild/examples/local_module.py
@@ -1,0 +1,5 @@
+"""
+Trivial module to provide a value for plot_numpy_scipy.py
+"""
+
+N = 1000

--- a/sphinx_gallery/tests/tinybuild/examples/plot_numpy_scipy.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_numpy_scipy.py
@@ -14,8 +14,10 @@ from scipy.signal import firwin
 import matplotlib
 import matplotlib.pyplot as plt
 
-t = np.arange(1001) / 1000.
-win = firwin(1001, 0.05)
+from local_module import N  # N = 1000
+
+t = np.arange(N) / float(N)
+win = firwin(N, 0.05)
 plt.plot(t, win)
 orig_dpi = 80. if matplotlib.__version__[0] < '2' else 100.
 assert plt.rcParams['figure.dpi'] == orig_dpi


### PR DESCRIPTION
This patch allows to import a module placed in the same folder as the examples when executing the example by adding the current directory to the sys.path.

I used a deepcopy to restore the sys.path to the original state (before running the example).

This patch relates to a problem we are having on https://github.com/matplotlib/matplotlib/pull/9402
I am honestly not entirely convince that sphinx-gallery *should* support this, as I think that good examples are self-contained examples.