### PR TITLE
Don't install latex recommended in Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
   pre:
     # Disable pyenv (no cleaner way provided by CircleCI as it prepends pyenv version to PATH)
     - sudo apt-get update
-    - sudo apt-get install texlive texlive-latex-extra latexmk
+    - sudo apt-get --no-install-recommends install -y texlive texlive-latex-extra latexmk
     - rm -rf ~/.pyenv
     - rm -rf ~/virtualenvs
     - wget -q https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O ~/miniconda.sh


### PR DESCRIPTION
Installing the texlive distribution in Circle CI, takes some time because Ubuntu by default installs some recommended packages. This PR avoids installing those recommended packages, which reduces the download time and install time. Build time drops by 1:30 mins