### PR TITLE
Log example output as it happens.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,11 @@ Bug Fixes
   <https://github.com/sphinx-gallery/sphinx-gallery/pull/311>`_ for more
   details.
 
+* In verbose mode, example output is printed to the console during execution of
+  the example, rather than only at the end. See `#301
+  <https://github.com/sphinx-gallery/sphinx-gallery/issues/301>`_ for a use
+  case where it matters.
+
 Developer changes
 '''''''''''''''''
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -98,38 +98,39 @@ logger = sphinx_compatibility.getLogger('sphinx-gallery')
 class LoggingTee(object):
     """A tee object to redirect streams to the logger"""
 
-    def __init__(self, output_file, logger, src_file):
+    def __init__(self, output_file, logger, src_filename):
         self.output_file = output_file
         self.logger = logger
-        self.src_file = src_file
+        self.src_filename = src_filename
         self.first_write = True
-        self.buf = ''
+        self.logger_buffer = ''
 
     def write(self, data):
         self.output_file.write(data)
 
         if self.first_write:
-            self.logger.verbose('Output from %s', self.src_file, color='brown')
+            self.logger.verbose('Output from %s', self.src_filename,
+                                color='brown')
             self.first_write = False
 
-        data = self.buf + data
+        data = self.logger_buffer + data
         lines = data.splitlines()
         if data and data[-1] not in '\r\n':
             # Wait to write last line if it's incomplete. It will write next
             # time or when the LoggingTee is flushed.
-            self.buf = lines[-1]
+            self.logger_buffer = lines[-1]
             lines = lines[:-1]
         else:
-            self.buf = ''
+            self.logger_buffer = ''
 
         for line in lines:
             self.logger.verbose('%s', line)
 
     def flush(self):
         self.output_file.flush()
-        if self.buf:
-            self.logger.verbose('%s', self.buf)
-            self.buf = ''
+        if self.logger_buffer:
+            self.logger.verbose('%s', self.logger_buffer)
+            self.logger_buffer = ''
 
     # When called from a local terminal seaborn needs it in Python3
     def isatty(self):

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -98,17 +98,18 @@ logger = sphinx_compatibility.getLogger('sphinx-gallery')
 class LoggingTee(object):
     """A tee object to redirect streams to the logger"""
 
-    def __init__(self, file1, src_file):
-        self.file1 = file1
+    def __init__(self, output_file, logger, src_file):
+        self.output_file = output_file
+        self.logger = logger
         self.src_file = src_file
         self.first_write = True
         self.buf = ''
 
     def write(self, data):
-        self.file1.write(data)
+        self.output_file.write(data)
 
         if self.first_write:
-            logger.verbose('Output from %s', self.src_file, color='brown')
+            self.logger.verbose('Output from %s', self.src_file, color='brown')
             self.first_write = False
 
         data = self.buf + data
@@ -122,17 +123,17 @@ class LoggingTee(object):
             self.buf = ''
 
         for line in lines:
-            logger.verbose('%s', line)
+            self.logger.verbose('%s', line)
 
     def flush(self):
-        self.file1.flush()
+        self.output_file.flush()
         if self.buf:
-            logger.verbose('%s', self.buf)
+            self.logger.verbose('%s', self.buf)
             self.buf = ''
 
     # When called from a local terminal seaborn needs it in Python3
     def isatty(self):
-        return self.file1.isatty()
+        return self.output_file.isatty()
 
 
 class MixedEncodingStringIO(StringIO):
@@ -518,7 +519,7 @@ def execute_code_block(compiler, src_file, code_block, lineno, example_globals,
 
     my_stdout = MixedEncodingStringIO()
     os.chdir(os.path.dirname(src_file))
-    sys.stdout = LoggingTee(my_stdout, src_file)
+    sys.stdout = LoggingTee(my_stdout, logger, src_file)
 
     try:
         dont_inherit = 1

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -327,7 +327,7 @@ class TestLoggingTee:
     def setup(self):
         self.output = io.StringIO()
         self.source_name = 'source file name'
-        self.tee = sg.LoggingTee(self.output, self.source_name)
+        self.tee = sg.LoggingTee(self.output, sg.logger, self.source_name)
 
     def test_full_line(self, log_collector):
         # A full line is output immediately.

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -328,7 +328,8 @@ class TestLoggingTee:
     def setup(self):
         self.output_file = io.StringIO()
         self.src_filename = 'source file name'
-        self.tee = sg.LoggingTee(self.output_file, sg.logger, self.src_filename)
+        self.tee = sg.LoggingTee(self.output_file, sg.logger,
+                                 self.src_filename)
 
     def test_full_line(self, log_collector):
         # A full line is output immediately.
@@ -376,13 +377,11 @@ class TestLoggingTee:
         assert 'second line' in verbose_calls[2].args
         assert self.tee.logger_buffer == 'third line'
 
-    def test_isatty(self, capsys):
-        with capsys.disabled():
-            tee = sg.LoggingTee(sys.stdout, sg.logger, self.src_filename)
-            assert tee.isatty()
+    def test_isatty(self, monkeypatch):
+        assert not self.tee.isatty()
 
-        tee.output_file = io.StringIO()
-        assert not tee.isatty()
+        monkeypatch.setattr(self.tee.output_file, 'isatty', lambda: True)
+        assert self.tee.isatty()
 
 # TODO: test that broken thumbnail does appear when needed
 # TODO: test that examples are not executed twice

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -10,12 +10,13 @@ import ast
 import codecs
 import copy
 import io
-import logging
 import tempfile
 import re
 import os
 import shutil
 import zipfile
+import sys
+
 import pytest
 
 import sphinx_gallery.gen_rst as sg
@@ -325,25 +326,25 @@ def test_figure_rst():
 
 class TestLoggingTee:
     def setup(self):
-        self.output = io.StringIO()
-        self.source_name = 'source file name'
-        self.tee = sg.LoggingTee(self.output, sg.logger, self.source_name)
+        self.output_file = io.StringIO()
+        self.src_filename = 'source file name'
+        self.tee = sg.LoggingTee(self.output_file, sg.logger, self.src_filename)
 
     def test_full_line(self, log_collector):
         # A full line is output immediately.
         self.tee.write('Output\n')
         self.tee.flush()
-        assert self.output.getvalue() == 'Output\n'
+        assert self.output_file.getvalue() == 'Output\n'
         assert len(log_collector.calls['verbose']) == 2
-        assert self.source_name in log_collector.calls['verbose'][0].args
+        assert self.src_filename in log_collector.calls['verbose'][0].args
         assert 'Output' in log_collector.calls['verbose'][1].args
 
     def test_incomplete_line_with_flush(self, log_collector):
         # An incomplete line ...
         self.tee.write('Output')
-        assert self.output.getvalue() == 'Output'
+        assert self.output_file.getvalue() == 'Output'
         assert len(log_collector.calls['verbose']) == 1
-        assert self.source_name in log_collector.calls['verbose'][0].args
+        assert self.src_filename in log_collector.calls['verbose'][0].args
 
         # ... should appear when flushed.
         self.tee.flush()
@@ -353,17 +354,35 @@ class TestLoggingTee:
     def test_incomplete_line_with_more_output(self, log_collector):
         # An incomplete line ...
         self.tee.write('Output')
-        assert self.output.getvalue() == 'Output'
+        assert self.output_file.getvalue() == 'Output'
         assert len(log_collector.calls['verbose']) == 1
-        assert self.source_name in log_collector.calls['verbose'][0].args
+        assert self.src_filename in log_collector.calls['verbose'][0].args
 
         # ... should appear when more data is written.
         self.tee.write('\nMore output\n')
-        assert self.output.getvalue() == 'Output\nMore output\n'
+        assert self.output_file.getvalue() == 'Output\nMore output\n'
         assert len(log_collector.calls['verbose']) == 3
         assert 'Output' in log_collector.calls['verbose'][1].args
         assert 'More output' in log_collector.calls['verbose'][2].args
 
+    def test_multi_line(self, log_collector):
+        self.tee.write('first line\rsecond line\nthird line')
+        assert (self.output_file.getvalue() ==
+                'first line\rsecond line\nthird line')
+        verbose_calls = log_collector.calls['verbose']
+        assert len(verbose_calls) == 3
+        assert self.src_filename in verbose_calls[0].args
+        assert 'first line' in verbose_calls[1].args
+        assert 'second line' in verbose_calls[2].args
+        assert self.tee.logger_buffer == 'third line'
+
+    def test_isatty(self, capsys):
+        with capsys.disabled():
+            tee = sg.LoggingTee(sys.stdout, sg.logger, self.src_filename)
+            assert tee.isatty()
+
+        tee.output_file = io.StringIO()
+        assert not tee.isatty()
 
 # TODO: test that broken thumbnail does appear when needed
 # TODO: test that examples are not executed twice


### PR DESCRIPTION
Combining all output together for a long-running example can cause timeouts on CI, so send output to the log immediately.

Fixes #301.