### PR TITLE
[MRG] Align binder badge with other download buttons

### DIFF
--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -108,6 +108,12 @@ div.sphx-glr-footer {
     text-align: center;
 }
 
+div.binder-badge {
+  display: inline-block;
+  margin: 1em auto 1ex 2ex;
+  vertical-align: middle;
+}
+
 div.sphx-glr-download {
   display: inline-block;
   margin: 1em auto 1ex 2ex;

--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -109,14 +109,12 @@ div.sphx-glr-footer {
 }
 
 div.binder-badge {
-  display: inline-block;
-  margin: 1em auto 1ex 2ex;
+  margin: 1em auto;
   vertical-align: middle;
 }
 
 div.sphx-glr-download {
-  display: inline-block;
-  margin: 1em auto 1ex 2ex;
+  margin: 1em auto;
   vertical-align: middle;
 }
 
@@ -127,36 +125,10 @@ div.sphx-glr-download a {
   border: 1px solid #c2c22d;
   color: #000;
   display: inline-block;
-  /* Not valid in old browser, hence we keep the line above to override */
-  display: table-caption;
   font-weight: bold;
   padding: 1ex;
   text-align: center;
 }
-
-/* The last child of a download button is the file name */
-div.sphx-glr-download a span:last-child {
-    font-size: smaller;
-}
-
-@media (min-width: 20em) {
-    div.sphx-glr-download a {
-	min-width: 10em;
-    }
-}
-
-@media (min-width: 30em) {
-    div.sphx-glr-download a {
-	min-width: 13em;
-    }
-}
-
-@media (min-width: 40em) {
-    div.sphx-glr-download a {
-	min-width: 16em;
-    }
-}
-
 
 div.sphx-glr-download code.download {
   display: inline-block;

--- a/sphinx_gallery/binder.py
+++ b/sphinx_gallery/binder.py
@@ -82,10 +82,12 @@ def gen_binder_rst(fname, binder_conf):
         The reStructuredText for the Binder badge that links to this file.
     """
     binder_url = gen_binder_url(fname, binder_conf)
-    rst = (".. figure:: https://mybinder.org/badge.svg\n"
-           "      :target: {}\n").format(
-        binder_url)
-    rst += "      :width: 150 px\n      :figclass: binder-badge\n\n"
+    rst = (
+        "\n"
+        "  .. container:: binder-badge\n\n"
+        "    .. image:: https://mybinder.org/badge.svg\n"
+        "      :target: {}\n"
+        "      :width: 150 px\n").format(binder_url)
     return rst
 
 

--- a/sphinx_gallery/downloads.py
+++ b/sphinx_gallery/downloads.py
@@ -17,6 +17,7 @@ CODE_DOWNLOAD = """
 
  .. container:: sphx-glr-footer
 
+{2}
 \n  .. container:: sphx-glr-download
 
      :download:`Download Python source code: {0} <{0}>`\n

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -701,11 +701,13 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
                             " ({0: .0f} minutes {1: .3f} seconds)\n\n".format(
                                 time_m, time_s))
         # Generate a binder URL if specified
+        binder_badge_rst = ''
         if len(binder_conf) > 0:
-            example_rst += gen_binder_rst(fname, binder_conf)
+            binder_badge_rst += gen_binder_rst(fname, binder_conf)
 
         example_rst += CODE_DOWNLOAD.format(fname,
-                                            replace_py_ipynb(fname))
+                                            replace_py_ipynb(fname),
+                                            binder_badge_rst)
         example_rst += SPHX_GLR_SIG
         f.write(example_rst)
 


### PR DESCRIPTION
The binder badge stands a bit on its own and I feel it should be on the same footing as the other download button (download .py + download .ipynb).

About the CSS part, I copied and pasted sphx-glr-download. The thing is that there the rule `div.sphx-glr-download a` was coloring the background around the binder badge and it did not look that great. Any improvements, let me know.

I'll paste links or snapshots once Circle finishes on this PR.