### PR TITLE
[MRG] Use static.mybinder.org for badge image

### DIFF
--- a/sphinx_gallery/binder.py
+++ b/sphinx_gallery/binder.py
@@ -82,7 +82,7 @@ def gen_binder_rst(fname, binder_conf):
         The reStructuredText for the Binder badge that links to this file.
     """
     binder_url = gen_binder_url(fname, binder_conf)
-    rst = (".. figure:: https://mybinder.org/badge.svg\n"
+    rst = (".. figure:: https://static.mybinder.org/badge.svg\n"
            "      :target: {}\n").format(
         binder_url)
     rst += "      :width: 150 px\n      :figclass: binder-badge\n\n"


### PR DESCRIPTION
This prevents cookies used in mybinder.org from being sent 
when requesting the badge, enhancing privacy.

https://github.com/jupyterhub/binderhub/issues/379 for original
issue about this.