### PR TITLE
clarifying Binder instructions and adding filepath prefix option

### DIFF
--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -405,7 +405,8 @@ Generate Binder links for gallery notebooks (experimental)
 
 Sphinx-Gallery automatically generates Jupyter notebooks for any
 examples built with the gallery. `Binder <http://mybinder.org>`_ makes it
-possible to create interactive GitHub repositories connect to cloud resources.
+possible to create interactive GitHub repositories that connect to cloud resources.
+
 If you host your documentation on a GitHub repository, it is possible to
 auto-generate a Binder link for each notebook. Clicking this link will
 take users to a live version of the Jupyter notebook where they may
@@ -426,18 +427,22 @@ dictionary following the pattern below::
       'binder': {
          'org': '<github_org>',
          'repo': '<github_repo>',
-         'url': '<binder_url>',  # URL serving binders (e.g. mybinder.org)
-         'branch': '<repo_branch>',  # Can also be a tag or commit hash
+         'url': '<binder_url>',  # Any URL of a binder server. Must be full URL (e.g. https://mybinder.org).
+         'branch': '<branch-for-documentation>',  # Can be any branch, tag, or commit hash. Use a branch that hosts your docs.
          'dependencies': '<list_of_paths_to_dependency_files>'
          }
     }
+
+Note that ``branch:`` should be the branch on which your documentation is hosted.
+If you host your documentation on GitHub, this is usually ``gh-pages``.
 
 .. important::
 
    ``dependencies`` should be a list of paths to Binder configuration files that
    define the environment needed to run the examples. For example, a
    ``requirements.txt`` file. These will be copied to
-   your documentation branch, and used by Binder to create your environment.
+   the documentation branch specified in ``branch:``. When a user clicks your
+   Binder link, these files will be used to create the environment.
    For more information on what files you can use, see `preparing your
    repository <https://mybinder.readthedocs.io/en/latest/using.html#preparing-a-repository-for-binder>`_
    in the `Binder documentation <docs.mybinder.org>`_ for more information on

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -429,12 +429,14 @@ dictionary following the pattern below::
          'repo': '<github_repo>',
          'url': '<binder_url>',  # Any URL of a binder server. Must be full URL (e.g. https://mybinder.org).
          'branch': '<branch-for-documentation>',  # Can be any branch, tag, or commit hash. Use a branch that hosts your docs.
-         'dependencies': '<list_of_paths_to_dependency_files>'
+         'dependencies': '<list_of_paths_to_dependency_files>',
+         'filepath_prefix': '<prefix>' # Optional, a prefix to append to any filepaths in Binder links.
+                            use this if you move your built documentation to a sub-folder of your repository (e.g., "v2.1")
          }
     }
 
 Note that ``branch:`` should be the branch on which your documentation is hosted.
-If you host your documentation on GitHub, this is usually ``gh-pages``.
+If you host your documentation on GitHub, this is usually ``gh-pages`` or ``master``.
 
 .. important::
 

--- a/sphinx_gallery/binder.py
+++ b/sphinx_gallery/binder.py
@@ -44,7 +44,10 @@ def gen_binder_url(fname, binder_conf):
         environment.
     """
     # Build the URL
+    fpath_prefix = binder_conf.get('filepath_prefix')
     binder_fpath = '_downloads/{}'.format(replace_py_ipynb(fname))
+    if fpath_prefix is not None:
+        binder_fpath = '/'.join([fpath_prefix.strip('/'), binder_fpath])
     binder_url = binder_conf['url']
     binder_url = '/'.join([binder_conf['url'],
                            'v2', 'gh',
@@ -116,6 +119,7 @@ def check_binder_conf(binder_conf):
 
     # Ensure all fields are populated
     req_values = ['url', 'org', 'repo', 'branch', 'dependencies']
+    optional_values = ['filepath_prefix']
     missing_values = []
     for val in req_values:
         if binder_conf.get(val) is None:
@@ -124,6 +128,10 @@ def check_binder_conf(binder_conf):
     if len(missing_values) > 0:
         raise ValueError('binder_conf is missing values for: {}'.format(
             missing_values))
+
+    for key in binder_conf.keys():
+        if key not in (req_values + optional_values):
+            raise ValueError("Unknown Binder config key: {}".format(key))
 
     # Ensure we have http in the URL
     if not any(binder_conf['url'].startswith(ii)

--- a/sphinx_gallery/tests/test_binder.py
+++ b/sphinx_gallery/tests/test_binder.py
@@ -26,6 +26,13 @@ def test_binder():
     url = gen_binder_url(file_path, conf1)
     assert url == 'http://test1.com/v2/gh/org/repo/branch?filepath=_downloads/myfile.ipynb'
 
+    # Assert filepath prefix is added
+    prefix = 'my_prefix/foo'
+    conf1['filepath_prefix'] = prefix
+    url = gen_binder_url(file_path, conf1)
+    assert url == 'http://test1.com/v2/gh/org/repo/branch?filepath={}/_downloads/myfile.ipynb'.format(prefix)
+    conf1.pop('filepath_prefix')
+
     # URL must have http
     with pytest.raises(ValueError) as excinfo:
         conf2 = deepcopy(conf1)
@@ -62,3 +69,10 @@ def test_binder():
     conf5 = check_binder_conf(None)
     for iconf in [conf4, conf5]:
         assert iconf == {}
+
+    # Assert extra unkonwn params
+    with pytest.raises(ValueError) as excinfo:
+        conf7 = deepcopy(conf1)
+        conf7['foo'] = 'blah'
+        url = check_binder_conf(conf7)
+    excinfo.match(r"Unknown Binder config key")


### PR DESCRIPTION
This attempts to clarify the instructions around Binder configuration. I'm going through the process of setting this up on some other repos to figure out where it's confusing / unclear / etc. It also adds the `filepath_prefix` option to the configuration, in case people put their documentation in a sub-folder of their repository (e.g. matplotlib puts theirs in one sub-folder per version, such as `1.2.3` etc).