### PR TITLE
MRG: Add ignore_pattern

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,11 @@ New features
   "div.sphx-glr-footer-example" can be used to capture these specific
   case in project-specific CSS.
 
+* Added ``ignore_pattern`` configurable to allow not adding some python files
+  into the gallery. See `#346
+  <https://github.com/sphinx-gallery/sphinx-gallery/pull/346>`` for more
+  details.
+
 Bug Fixes
 '''''''''
 

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -16,7 +16,7 @@ Most sphinx-gallery configuration options are set in the Sphinx ``conf.py``
 file:
 
 - ``examples_dirs`` and ``gallery_dirs`` (:ref:`multiple_galleries_config`)
-- ``filename_pattern`` (:ref:`build_pattern`)
+- ``filename_pattern`` and ``ignore_pattern`` (:ref:`build_pattern`)
 - ``subsection_order`` (:ref:`sub_gallery_order`)
 - ``within_subsection_order`` (:ref:`within_gallery_order`)
 - ``reference_url`` (:ref:`link_to_documentation`)
@@ -69,12 +69,22 @@ Keep in mind that both lists have to be of the same length.
 
 .. _build_pattern:
 
-Building examples matching a pattern
-====================================
+Parsing and executing examples based on matching patterns
+=========================================================
 
-By default, Sphinx-Gallery execute only examples beginning with ``plot``. However,
-if this naming convention does not suit your project, you can modify this pattern
-in your Sphinx ``conf.py``. For example::
+By default, Sphinx-Gallery will **parse and add** all files with a ``.py``
+extension to the gallery. To ignore some files and omit them from the gallery
+entirely, you can use a regular expression (the default is shown here)::
+
+    sphinx_gallery_conf = {
+        ...
+        'ignore_pattern': '__init__\.py',
+    }
+
+Of the files that get **parsed and added** to the gallery, by default
+Sphinx-Gallery only **executes** files whose name begins with ``plot``.
+However, if this naming convention does not suit your project, you can modify
+the pattern of filenames to build in your Sphinx ``conf.py``. For example::
 
     sphinx_gallery_conf = {
         ...
@@ -92,11 +102,11 @@ you would do::
 
     sphinx_gallery_conf = {
         ...
-        'filename_pattern': 'plot_awesome_example.py',
+        'filename_pattern': 'plot_awesome_example\.py',
     }
 
 Here, one should escape the dot ``'\.'`` as otherwise python `regular expressions`_ matches any character. Nevertheless, as
-one is targeting a specific file, it is most certainly going to match the dot in the filename.
+one is targeting a specific file, it would match the dot in the filename even without this escape character.
 
 Similarly, to build only examples in a specific directory, you can do::
 
@@ -105,7 +115,7 @@ Similarly, to build only examples in a specific directory, you can do::
         'filename_pattern': '/directory/plot_',
     }
 
-Alternatively, you can skip some examples. For example, to skip building examples
+Alternatively, you can skip executing some examples. For example, to skip building examples
 starting with ``plot_long_examples_``, you would do::
 
     sphinx_gallery_conf = {
@@ -116,6 +126,13 @@ starting with ``plot_long_examples_``, you would do::
 As the patterns are parsed as `regular expressions`_, users are advised to consult the
 `regular expressions`_ module for more details.
 
+.. note::
+    Remember that Sphinx allows overriding ``conf.py`` values from the command
+    line, so you can for example build a single example directly via something like:
+
+    .. code-block:: console
+
+        $ sphinx-build -D sphinx_gallery_conf.filename_pattern=plot_specific_example\.py ...
 
 .. _sub_gallery_order:
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -15,7 +15,6 @@ import codecs
 import copy
 import re
 import os
-from copy import deepcopy
 
 from . import sphinx_compatibility, glr_path_static, __version__ as _sg_version
 from .gen_rst import generate_dir_rst, SPHX_GLR_SIG
@@ -32,6 +31,7 @@ except NameError:
 
 DEFAULT_GALLERY_CONF = {
     'filename_pattern': re.escape(os.sep) + 'plot',
+    'ignore_pattern': '__init__\.py',
     'examples_dirs': os.path.join('..', 'examples'),
     'subsection_order': None,
     'within_subsection_order': NumberOfCodeLinesSortKey,
@@ -51,7 +51,7 @@ DEFAULT_GALLERY_CONF = {
     'expected_failing_examples': set(),
     'thumbnail_size': (400, 280),  # Default CSS does 0.4 scaling (160, 112)
     'min_reported_time': 0,
-    'binder': {}
+    'binder': {},
 }
 
 logger = sphinx_compatibility.getLogger('sphinx-gallery')

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -434,9 +434,11 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
     # get filenames
     listdir = [fname for fname in os.listdir(src_dir)
                if fname.endswith('.py')]
-    # limit which to look at based on regex
+    # limit which to look at based on regex (similar to filename_pattern)
     listdir = [fname for fname in listdir
-               if re.match(gallery_conf['ignore_pattern'], fname) is None]
+               if re.search(gallery_conf['ignore_pattern'],
+                            os.path.normpath(os.path.join(src_dir, fname)))
+               is None]
     # sort them
     sorted_listdir = sorted(
         listdir, key=gallery_conf['within_subsection_order'](src_dir))

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -431,8 +431,13 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
 
     if not os.path.exists(target_dir):
         os.makedirs(target_dir)
+    # get filenames
     listdir = [fname for fname in os.listdir(src_dir)
                if fname.endswith('.py')]
+    # limit which to look at based on regex
+    listdir = [fname for fname in listdir
+               if re.match(gallery_conf['ignore_pattern'], fname) is None]
+    # sort them
     sorted_listdir = sorted(
         listdir, key=gallery_conf['within_subsection_order'](src_dir))
     entries_text = []

--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -114,7 +114,8 @@ def get_docstring_and_rest(filename):
 
     if not docstring:
         raise ValueError(('Could not find docstring in file "{0}". '
-                          'A docstring is required by sphinx-gallery')
+                          'A docstring is required by sphinx-gallery '
+                          'unless the file is ignored by "ignore_pattern"')
                          .format(filename))
     return docstring, rest, lineno
 

--- a/sphinx_gallery/tests/tinybuild/examples/__init__.py
+++ b/sphinx_gallery/tests/tinybuild/examples/__init__.py
@@ -1,0 +1,1 @@
+from numpy import pad

--- a/sphinx_gallery/tests/tinybuild/examples/__init__.py
+++ b/sphinx_gallery/tests/tinybuild/examples/__init__.py
@@ -1,1 +1,2 @@
-from numpy import pad
+# This file is ignored through ignore_pattern so it does not need to have a
+# docstring following the sphinx-gallery convention (i.e. title + description)


### PR DESCRIPTION
Hopefully the doc changes are clear enough, but this allows skipping some files entirely (i.e., not parsing or adding them to the gallery).

Closes #262.