### PR TITLE
MRG: Add refs from docstring to backrefs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,15 @@ jobs:
       - restore_cache:
           keys:
             - cache-pip
-      - run: pip install --user numpy scipy matplotlib seaborn sphinx_rtd_theme pillow sphinx pytest vtk traits traitsui pyface pyqt5
-      - run: pip install --user mayavi
+      - run: pip install --user numpy scipy matplotlib seaborn sphinx_rtd_theme pillow sphinx pytest vtk traits traitsui pyface pyqt5 mayavi
       - save_cache:
           key: cache-pip
           paths:
             - ~/.cache/pip
 
+      # Fix libgcc_s.so.1 pthread_cancel bug:
+      # https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
+      - run: sudo apt-get install libgl1-mesa-glx libegl1-mesa libxrandr2 libxrandr2 libxss1 libxcursor1 libxcomposite1 libasound2 libxi6 libxtst6
       - run: python -c "from mayavi import mlab; import matplotlib.pyplot as plt; mlab.figure(); plt.figure()"
       - run: python setup.py develop --user
 

--- a/doc/_templates/module.rst
+++ b/doc/_templates/module.rst
@@ -36,6 +36,12 @@
    .. autoclass:: {{ item }}
       :members:
 
+   .. include:: backreferences/{{fullname}}.{{item}}.examples
+
+   .. raw:: html
+
+	       <div style='clear:both'></div>
+
    {%- endfor %}
    {% endif %}
    {% endblock %}

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -252,7 +252,7 @@ typically implicitly returned rather than explicitly instantiated (e.g.,
 within function calls).
 
 For example, we can embed a small gallery of all examples that use or
-refer to :func:`numpy.exp`, which looks like this:
+refer to :obj:`numpy.exp`, which looks like this:
 
 .. include:: gen_modules/backreferences/numpy.exp.examples
 .. raw:: html
@@ -437,7 +437,7 @@ If you host your documentation on a GitHub repository, it is possible to
 auto-generate a Binder link for each notebook. Clicking this link will
 take users to a live version of the Jupyter notebook where they may
 run the code interactively. For more information see the `Binder documentation
-<http://docs.mybinder.org>`_.
+<http://docs.mybinder.org>`__.
 
 .. warning::
 
@@ -481,7 +481,7 @@ Binder links will point to these notebooks.
    Binder link, these files will be used to create the environment.
    For more information on what files you can use, see `preparing your
    repository <https://mybinder.readthedocs.io/en/latest/using.html#preparing-a-repository-for-binder>`_
-   in the `Binder documentation <docs.mybinder.org>`_ for more information on
+   in the `Binder documentation <docs.mybinder.org>`__ for more information on
    what build files are supported.
 
 See the Sphinx-Gallery `Sphinx configuration file <https://github.com/sphinx-gallery/sphinx-gallery/blob/master/doc/conf.py>`_

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -238,20 +238,29 @@ point to the directory containing ``searchindex.js``, such as
 Adding references to examples
 =============================
 
-Sphinx-Gallery enables you, when documenting your modules, to
-reference to the examples that use a particular function. For example
-if we are documenting the :func:`numpy.exp` function its possible to embed
-a small gallery of examples that is specific to this function and
-looks like this:
+When documenting a given function/class, Sphinx-Gallery enables you to link to
+any examples that either:
+
+1. Use the function/instantiate the class in the code.
+2. Refer to that function/class using sphinx markup ``:func:``/``:class:``
+   in a documentation block.
+
+The former is useful for auto-documenting functions that are used and classes
+that are explicitly instantiated. The latter is useful for classes that are
+typically implicitly returned rather than explicitly instantiated (e.g.,
+:class:`matplotlib.axes.Axes` which is most often instantiated only indirectly
+within function calls).
+
+For example, we can embed a small gallery of all examples that use or
+refer to :func:`numpy.exp`, which looks like this:
 
 .. include:: gen_modules/backreferences/numpy.exp.examples
 .. raw:: html
 
         <div style='clear:both'></div>
 
-
-For such behavior to be available, you have to activate it in your
-Sphinx-Gallery configuration ``conf.py`` file with::
+For such behavior to be available, you have to activate it in
+your Sphinx-Gallery configuration ``conf.py`` file with::
 
     sphinx_gallery_conf = {
         ...

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -430,14 +430,14 @@ Generate Binder links for gallery notebooks (experimental)
 ==========================================================
 
 Sphinx-Gallery automatically generates Jupyter notebooks for any
-examples built with the gallery. `Binder <http://mybinder.org>`_ makes it
+examples built with the gallery. `Binder <https://mybinder.org>`_ makes it
 possible to create interactive GitHub repositories that connect to cloud resources.
 
 If you host your documentation on a GitHub repository, it is possible to
 auto-generate a Binder link for each notebook. Clicking this link will
 take users to a live version of the Jupyter notebook where they may
 run the code interactively. For more information see the `Binder documentation
-<http://docs.mybinder.org>`__.
+<https://docs.mybinder.org>`__.
 
 .. warning::
 
@@ -481,7 +481,7 @@ Binder links will point to these notebooks.
    Binder link, these files will be used to create the environment.
    For more information on what files you can use, see `preparing your
    repository <https://mybinder.readthedocs.io/en/latest/using.html#preparing-a-repository-for-binder>`_
-   in the `Binder documentation <docs.mybinder.org>`__ for more information on
+   in the `Binder documentation <https://docs.mybinder.org>`__ for more information on
    what build files are supported.
 
 See the Sphinx-Gallery `Sphinx configuration file <https://github.com/sphinx-gallery/sphinx-gallery/blob/master/doc/conf.py>`_

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -345,10 +345,12 @@ saved in the directory we specified in the *toctree* option of the
 The files we are including are from the ``backreferences_dir``
 configuration option setup for Sphinx-Gallery.
 
+.. _code_tesiii:
+
 .. literalinclude:: _templates/module.rst
     :language: rst
     :lines: 3-
-    :emphasize-lines: 12-22
+    :emphasize-lines: 12-22, 32-42
     :linenos:
 
 

--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -345,8 +345,6 @@ saved in the directory we specified in the *toctree* option of the
 The files we are including are from the ``backreferences_dir``
 configuration option setup for Sphinx-Gallery.
 
-.. _code_tesiii:
-
 .. literalinclude:: _templates/module.rst
     :language: rst
     :lines: 3-

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -300,7 +300,7 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/{.major}'.format(sys.version_info), None),
-    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('https://matplotlib.org/', None),
     'mayavi': ('http://docs.enthought.com/mayavi/mayavi', None),

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -33,9 +33,9 @@ Here is an example gallery generated from a few Python scripts.
 
         <div style='clear:both'></div>
 
-Here we put only the examples of our gallery that use a specific
-function. This display granularity ready to use within your
-documentation, not just the gigantic galleries with all the examples
+Here we put only the examples of our gallery that refer to a specific
+function. This provides display granularity that can be used within your
+documentation in addition to large galleries with all examples
 together.
 
 Go ahead, click on those thumbnails to go to the examples. Beautifully

--- a/doc/maintainers.rst
+++ b/doc/maintainers.rst
@@ -1,49 +1,52 @@
+:orphan:
+
 How to make a release
 =====================
 
 * Update the change log
 
-Use `github_changelog_generator
-<https://github.com/skywinder/github-changelog-generator#installation>`_ to
-gather all merged pull requests and closed issues during the development
-cycle. We do this because our failing discipline of writing in the
-CHANGES.rst all relevant changes, this helps our memory.
+  Use `github_changelog_generator
+  <https://github.com/skywinder/github-changelog-generator#installation>`_ to
+  gather all merged pull requests and closed issues during the development
+  cycle. We do this because our failing discipline of writing in the
+  CHANGES.rst all relevant changes, this helps our memory.
 
-.. code-block:: bash
+  .. code-block:: bash
 
-   github_changelog_generator sphinx-gallery/sphinx-gallery
+     github_changelog_generator sphinx-gallery/sphinx-gallery
 
-Read the changes in the generated CHANGELOG.md and propagate the relevant to
-CHANGES.rst
+  Read the changes in the generated CHANGELOG.md and propagate the relevant to
+  CHANGES.rst
 
 * Update version
 
-Update the version in ``sphinx_gallery/__init__.py``.
+  Update the version in ``sphinx_gallery/__init__.py``.
 
 * Build the docs cleanly
 
-Make sure to clean all and have a clean build. Double-check visually that
-everything looks right.
+  Make sure to clean all and have a clean build. Double-check visually that
+  everything looks right.
 
 * Push to your own master branch and check CI is happy
 * Draft release
-copy and edit to github markdown all changes from CHANGELOG.md.
+
+  copy and edit to github markdown all changes from CHANGELOG.md.
 
 * Build a source distribution
 
-.. code-block:: bash
+  .. code-block:: bash
 
-   python setup.py sdist
+     python setup.py sdist
 
 * Test upload to PyPI
 
-.. code-block:: bash
+  .. code-block:: bash
 
-   twine upload --repository test dist/sphinx-gallery-<version>.tar.gz
+     twine upload --repository test dist/sphinx-gallery-<version>.tar.gz
 
 * Upload to PyPI
 
 
-.. code-block:: bash
+  .. code-block:: bash
 
-   twine upload dist/sphinx-gallery-<version>.tar.gz
+     twine upload dist/sphinx-gallery-<version>.tar.gz

--- a/examples/plot_function_identifier.py
+++ b/examples/plot_function_identifier.py
@@ -16,6 +16,7 @@ of the example that calls them, they will be shown in the backreferences.
 # Code source: Óscar Nájera
 # License: BSD 3 clause
 
+import os
 import matplotlib.pyplot as plt
 import sphinx_gallery.backreferences as spback
 
@@ -24,17 +25,17 @@ filename = spback.__file__.replace('.pyc', '.py')
 names = spback.identify_names(filename)
 figheight = len(names) + .5
 
-fontsize = 22
-fig = plt.figure()
+fontsize = 20
+fig = plt.figure(figsize=(7.5, 8))
 
 for i, (name, obj) in enumerate(names.items()):
-    fig.text(0.3, (float(len(names)) - 0.5 - i) / figheight,
+    fig.text(0.55, (float(len(names)) - 0.5 - i) / figheight,
              name,
              ha="right",
              size=fontsize,
              transform=fig.transFigure,
              bbox=dict(boxstyle='square', fc="w", ec="k"))
-    fig.text(0.35, (float(len(names)) - 0.5 - i) / figheight,
+    fig.text(0.6, (float(len(names)) - 0.5 - i) / figheight,
              obj["module"],
              ha="left",
              size=fontsize,

--- a/examples/plot_function_identifier.py
+++ b/examples/plot_function_identifier.py
@@ -3,8 +3,14 @@
 Identifying function names in a script
 ======================================
 
-Calls Sphinx-Gallery identify names function to figure out which
-functions are called in the script and to which module do they belong.
+This demonstrates how Sphinx-Gallery identifies names function to figure out
+which functions are called in the script and to which module do they belong.
+
+It uses both the code itself, as well as the docstrings (such as this one),
+as adding a reference to :func:`numpy.sin` and :func:`numpy.exp` will create
+proper backreferences even if they are not explicitly used. This is useful
+in particular when functions return classes -- if you add them to the docstring
+of the example that calls them, they will be shown in the backreferences.
 """
 
 # Code source: Óscar Nájera

--- a/examples/plot_function_identifier.py
+++ b/examples/plot_function_identifier.py
@@ -3,20 +3,14 @@
 Identifying function names in a script
 ======================================
 
-This demonstrates how Sphinx-Gallery identifies names function to figure out
+This demonstrates how Sphinx-Gallery identifies function names to figure out
 which functions are called in the script and to which module do they belong.
-
-It uses both the code itself, as well as the docstrings (such as this one),
-as adding a reference to :func:`numpy.sin` and :func:`numpy.exp` will create
-proper backreferences even if they are not explicitly used. This is useful
-in particular when functions return classes -- if you add them to the docstring
-of the example that calls them, they will be shown in the backreferences.
 """
 
 # Code source: Óscar Nájera
 # License: BSD 3 clause
 
-import os
+import os  # noqa, analysis:ignore
 import matplotlib.pyplot as plt
 import sphinx_gallery.backreferences as spback
 
@@ -26,6 +20,16 @@ names = spback.identify_names(filename)
 figheight = len(names) + .5
 
 fontsize = 20
+
+###############################################################################
+# Sphinx-Gallery examines both the executed code itself, as well as the
+# documentation blocks (such as this one, or the top-level one),
+# to find backreferences. This means that by writing :obj:`numpy.sin`
+# and :obj:`numpy.exp` here, a backreference will be created even though
+# they are not explicitly used in the code. This is useful in particular when
+# functions return classes -- if you add them to the documented blocks of
+# examples that use them, they will be shown in the backreferences.
+
 fig = plt.figure(figsize=(7.5, 8))
 
 for i, (name, obj) in enumerate(names.items()):

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -103,6 +103,19 @@ def get_short_module_name(module_name, obj_name):
     return short_name
 
 
+def extract_object_names_from_docs(filename):
+    """Add matches from the text blocks (must be full names!)"""
+    text = split_code_and_text_blocks(filename)[1]
+    text = '\n'.join(t[1] for t in text if t[0] == 'text')
+    regex = re.compile(r':(?:'
+                       'func(?:tion)?|'
+                       'meth(?:od)?|'
+                       'attr(?:ibute)?|'
+                       'class):`(\S*)`')
+
+    return [(x, x) for x in re.findall(regex, text)]
+
+
 def identify_names(filename):
     """Builds a codeobj summary by identifying and resolving used names."""
     node, _ = parse_source_file(filename)
@@ -113,16 +126,7 @@ def identify_names(filename):
     finder = NameFinder()
     finder.visit(node)
     names = list(finder.get_mapping())
-
-    # Add matches from the text blocks (must be full names!)
-    text = split_code_and_text_blocks(filename)[1]
-    text = '\n'.join(t[1] for t in text if t[0] == 'text')
-    regex = re.compile(r':(?:'
-                       'func(?:tion)?|'
-                       'meth(?:od)?|'
-                       'attr(?:ibute)?|'
-                       'class):`(\S*)`')
-    names += [(x, x) for x in re.findall(regex, text)]
+    names += extract_object_names_from_docs(filename)
 
     example_code_obj = {}
     for name, full_name in names:

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -111,6 +111,7 @@ def extract_object_names_from_docs(filename):
                        'func(?:tion)?|'
                        'meth(?:od)?|'
                        'attr(?:ibute)?|'
+                       'obj(?:ect)?|'
                        'class):`(\S*)`')
 
     return [(x, x) for x in re.findall(regex, text)]

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -8,10 +8,11 @@ Backreferences Generator
 Parses example file code in order to keep track of used functions
 """
 from __future__ import print_function, unicode_literals
-import codecs
-import ast
-import os
 
+import ast
+import codecs
+import os
+import re
 
 # Try Python 2 first, otherwise load from Python 3
 try:
@@ -27,7 +28,7 @@ except ImportError:
 
     escape = partial(escape, entities={'"': '&quot;'})
 
-from .py_source_parser import parse_source_file
+from .py_source_parser import parse_source_file, split_code_and_text_blocks
 
 
 class NameFinder(ast.NodeVisitor):
@@ -103,16 +104,30 @@ def get_short_module_name(module_name, obj_name):
 
 
 def identify_names(filename):
-    """Builds a codeobj summary by identifying and resolving used names"""
+    """Builds a codeobj summary by identifying and resolving used names."""
     node, _ = parse_source_file(filename)
     if node is None:
         return {}
 
+    # Get matches from the code (AST)
     finder = NameFinder()
     finder.visit(node)
+    names = list(finder.get_mapping())
+
+    # Add matches from the text blocks (must be full names!)
+    text = split_code_and_text_blocks(filename)[1]
+    text = '\n'.join(t[1] for t in text if t[0] == 'text')
+    regex = re.compile(r':(?:'
+                       'func(?:tion)?|'
+                       'meth(?:od)?|'
+                       'attr(?:ibute)?|'
+                       'class):`(\S*)`')
+    names += [(x, x) for x in re.findall(regex, text)]
 
     example_code_obj = {}
-    for name, full_name in finder.get_mapping():
+    for name, full_name in names:
+        if name in example_code_obj:
+            continue  # if someone puts it in the docstring and code
         # name is as written in file (e.g. np.asarray)
         # full_name includes resolved import path (e.g. numpy.asarray)
         splitted = full_name.rsplit('.', 1)

--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -27,7 +27,6 @@ def parse_source_file(filename):
     filename : str
         File path
 
-
     Returns
     -------
     node : AST node
@@ -61,9 +60,9 @@ def get_docstring_and_rest(filename):
 
     Returns
     -------
-    docstring: str
+    docstring : str
         docstring of ``filename``
-    rest: str
+    rest : str
         ``filename`` content without the docstring
     """
     node, content = parse_source_file(filename)
@@ -153,7 +152,7 @@ def split_code_and_text_blocks(source_file):
         ``# sphinx_gallery_<name> = <value>``
     blocks : list of (label, content)
         List where each element is a tuple with the label ('text' or 'code'),
-        and content string of block.
+        the content string of block, and the line number.
     """
     docstring, rest_of_content, lineno = get_docstring_and_rest(source_file)
     blocks = [('text', docstring, 1)]

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -83,6 +83,12 @@ def test_identify_names(unicode_sample):
 
 def test_identify_names2(tmpdir):
     code_str = b"""
+'''
+Title
+-----
+
+This is an example.
+'''
 # -*- coding: utf-8 -*-
 # \xc3\x9f
 from a.b import c
@@ -92,6 +98,23 @@ e.HelloWorld().f.g
 """
     expected = {'c': {'name': 'c', 'module': 'a.b', 'module_short': 'a.b'},
                 'e.HelloWorld': {'name': 'HelloWorld', 'module': 'd', 'module_short': 'd'}}
+
+    fname = tmpdir.join("indentify_names.py")
+    fname.write(code_str, 'wb')
+
+    res = sg.identify_names(fname.strpath)
+
+    assert expected == res
+
+    code_str = """
+'''
+Title
+-----
+
+This example uses :func:`h.i`.
+'''
+""" + code_str.split("'''")[-1]
+    expected['h.i'] = {u'module': u'h', u'module_short': u'h', u'name': u'i'}
 
     fname = tmpdir.join("indentify_names.py")
     fname.write(code_str, 'wb')

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -106,14 +106,14 @@ e.HelloWorld().f.g
 
     assert expected == res
 
-    code_str = """
+    code_str = b"""
 '''
 Title
 -----
 
 This example uses :func:`h.i`.
 '''
-""" + code_str.split("'''")[-1]
+""" + code_str.split(b"'''")[-1]
     expected['h.i'] = {u'module': u'h', u'module_short': u'h', u'name': u'i'}
 
     fname = tmpdir.join("indentify_names.py")

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -68,3 +68,12 @@ def test_embed_links(sphinx_app):
     assert 'numpy.arange.html' in lines
     # assert '#module-matplotlib.pyplot' in lines
     # assert 'pyplot.html' in lines
+
+
+def test_backreferences(sphinx_app):
+    """Test backreferences."""
+    out_dir = sphinx_app.outdir
+    mod_file = op.join(out_dir, 'gen_modules', 'sphinx_gallery.sorting.html')
+    with codecs.open(mod_file, 'r', 'utf-8') as fid:
+        lines = fid.read()
+    assert 'plot_numpy_scipy.html' in lines

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -37,7 +37,8 @@ def sphinx_app(tmpdir_factory):
     with docutils_namespace():
         app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
                      buildername='html')
-        # need to build with this mode for automodule and backrefs to work
+        # need to build within the context manager
+        # for automodule and backrefs to work
         app.build(False, [])
     return app
 
@@ -76,5 +77,7 @@ def test_backreferences(sphinx_app):
     mod_file = op.join(out_dir, 'gen_modules', 'sphinx_gallery.sorting.html')
     with codecs.open(mod_file, 'r', 'utf-8') as fid:
         lines = fid.read()
-    assert 'FileNameSortKey' in lines
-    assert 'plot_numpy_scipy.html' in lines
+    assert 'ExplicitOrder' in lines  # in API doc
+    assert 'plot_second_future_imports.html' in lines  # backref via code use
+    assert 'FileNameSortKey' in lines  # in API doc
+    assert 'plot_numpy_scipy.html' in lines  # backref via :class: in docstring

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -81,3 +81,9 @@ def test_backreferences(sphinx_app):
     assert 'plot_second_future_imports.html' in lines  # backref via code use
     assert 'FileNameSortKey' in lines  # in API doc
     assert 'plot_numpy_scipy.html' in lines  # backref via :class: in docstring
+    mod_file = op.join(out_dir, 'gen_modules',
+                       'sphinx_gallery.backreferences.html')
+    with codecs.open(mod_file, 'r', 'utf-8') as fid:
+        lines = fid.read()
+    assert 'identify_names' in lines  # in API doc
+    assert 'plot_future_imports.html' in lines  # backref via doc block

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -37,8 +37,8 @@ def sphinx_app(tmpdir_factory):
     with docutils_namespace():
         app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
                      buildername='html')
-
-    app.build(False, [])
+        # need to build with this mode for automodule and backrefs to work
+        app.build(False, [])
     return app
 
 
@@ -66,8 +66,8 @@ def test_embed_links(sphinx_app):
     assert 'scipy.signal.firwin.html' in lines
     assert '#module-numpy' in lines
     assert 'numpy.arange.html' in lines
-    # assert '#module-matplotlib.pyplot' in lines
-    # assert 'pyplot.html' in lines
+    assert '#module-matplotlib.pyplot' in lines
+    assert 'pyplot.html' in lines
 
 
 def test_backreferences(sphinx_app):
@@ -76,4 +76,5 @@ def test_backreferences(sphinx_app):
     mod_file = op.join(out_dir, 'gen_modules', 'sphinx_gallery.sorting.html')
     with codecs.open(mod_file, 'r', 'utf-8') as fid:
         lines = fid.read()
+    assert 'FileNameSortKey' in lines
     assert 'plot_numpy_scipy.html' in lines

--- a/sphinx_gallery/tests/tinybuild/_templates/module.rst
+++ b/sphinx_gallery/tests/tinybuild/_templates/module.rst
@@ -36,6 +36,8 @@
    .. autoclass:: {{ item }}
       :members:
 
+   .. include:: backreferences/{{fullname}}.{{item}}.examples
+
    {%- endfor %}
    {% endif %}
    {% endblock %}

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -1,4 +1,4 @@
-import sphinx_gallery  # noqa
+import sphinx_gallery  # noqa, analysis:ignore
 from sphinx_gallery.sorting import FileNameSortKey
 
 extensions = [

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -15,7 +15,7 @@ master_doc = 'index'
 exclude_patterns = ['_build']
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'matplotlib': ('https://matplotlib.org/', None),
 }

--- a/sphinx_gallery/tests/tinybuild/examples/plot_future_imports.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_future_imports.py
@@ -9,6 +9,7 @@ from __future__ import division
 from __future__ import print_function
 
 ####################
-# Dummy section
+# Dummy section, with :func:`sphinx_gallery.backreferences.identify_names` ref.
+
 assert 3/2 == 1.5
 print(3/2, end='')

--- a/sphinx_gallery/tests/tinybuild/examples/plot_numpy_scipy.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_numpy_scipy.py
@@ -6,7 +6,7 @@ Link to other packages
 Use :mod:`sphinx_gallery` to link to other packages, like
 :mod:`numpy`, :mod:`scipy.signal`, and :mod:`matplotlib.pyplot`.
 
-FYI this gallery uses :class:`sphinx_gallery.sorting.FileNameSortKey`.
+FYI this gallery uses :obj:`sphinx_gallery.sorting.FileNameSortKey`.
 """
 
 import numpy as np

--- a/sphinx_gallery/tests/tinybuild/examples/plot_numpy_scipy.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_numpy_scipy.py
@@ -5,6 +5,8 @@ Link to other packages
 
 Use :mod:`sphinx_gallery` to link to other packages, like
 :mod:`numpy`, :mod:`scipy.signal`, and :mod:`matplotlib.pyplot`.
+
+FYI this gallery uses :class:`sphinx_gallery.sorting.FileNameSortKey`.
 """
 
 import numpy as np

--- a/sphinx_gallery/tests/tinybuild/examples/plot_second_future_imports.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_second_future_imports.py
@@ -8,6 +8,9 @@ plot_future_statements.py.
 """
 
 import sys
+from sphinx_gallery.sorting import ExplicitOrder
+
+ExplicitOrder([])  # must actually be used to become a backref target!
 
 PY2 = sys.version_info[0] == 2
 


### PR DESCRIPTION
Adds to backreferences any function/class that gets `:func:` or `:meth:`'ed in the docstring. This should be particularly useful for things like `matplotlib.axes.Axes` and similar classes that get instantiated only indirectly.

Closes #205.