### PR TITLE
[MRG] Remove optipng optimization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,14 @@ Bug Fixes
   <https://github.com/sphinx-gallery/sphinx-gallery/issues/301>`_ for a use
   case where it matters.
 
+Incompatible Changes
+''''''''''''''''''''
+
+* Removed optipng feature that was triggered when the SKLEARN_DOC_OPTIPNG
+  variable was set. See `#349
+  <https://github.com/sphinx-gallery/sphinx-gallery/pull/349>`_ for more
+  details.
+
 Developer changes
 '''''''''''''''''
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -388,14 +388,6 @@ def scale_image(in_fname, out_fname, max_width, max_height):
     thumb.paste(img, pos_insert)
 
     thumb.save(out_fname)
-    # Use optipng to perform lossless compression on the resized image if
-    # software is installed
-    if os.environ.get('SKLEARN_DOC_OPTIPNG', False):
-        try:
-            subprocess.call(["optipng", "-quiet", "-o", "9", out_fname])
-        except Exception:
-            logger.warning(
-                'Install optipng to reduce the size of the generated images')
 
 
 def save_thumbnail(image_path_template, src_file, file_conf, gallery_conf):


### PR DESCRIPTION
Fixes #319. 

It is not used by anyone to the best of my knowledge. I did a github search for SKLEARN_DOC_OPTIPNG and only found matches in `gen_rst.py` files. scikit-learn is not using it even if this optimization originates from scikit-learn (see https://github.com/scikit-learn/scikit-learn/pull/2487).

We could consider a deprecation period but given how unlikely this is that this feature is used I am not sure this is worth it.
