### PR TITLE
[MRG] MAINT: remove python setup.py test related things

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,10 +29,9 @@ install:
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-  # Run the project tests
-  - python setup.py test
-  # Build the docs
   - python setup.py develop
+  - pytest sphinx_gallery
+  # Build the docs
   - cd doc
   # The Makefile doesn't work directly on Windows PowerShell because of
   # slashes (but will work e.g. in Msys-git), so for now do these manually

--- a/continuous_integration/travis/test_script.sh
+++ b/continuous_integration/travis/test_script.sh
@@ -6,7 +6,6 @@
 
 set -e
 
-python setup.py test
 pytest sphinx_gallery
 cd doc
 make html-noplot

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,6 @@ python_files = tests/*.py
 norecursedirs = build _build auto_examples gen_modules
                 sphinx_gallery/tests/tinybuild
 
-[aliases]
-test=pytest
-
 [build_sphinx]
 source-dir = doc/
 build-dir  = doc/_build

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,6 @@ setup(
     author="Óscar Nájera",
     author_email='najera.oscar@gmail.com',
     install_requires=install_requires,
-    setup_requires=['pytest-runner'],
-    tests_require=['pytest', 'pytest-cov'],
     license='3-clause BSD',
     classifiers=['Intended Audience :: Developers',
                  'Development Status :: 3 - Alpha',


### PR DESCRIPTION
This is very likely not used and makes the Python 3.4 build fail for some obscure reasons (see https://travis-ci.org/sphinx-gallery/sphinx-gallery/jobs/340477597 for example).