### PR TITLE
[MRG] Fix title detection logic.

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -217,20 +217,22 @@ def extract_intro_and_title(filename, docstring):
     # Title is the first paragraph with any ReSTructuredText title chars
     # removed, i.e. lines that consist of (all the same) 7-bit non-ASCII chars.
     # This conditional is not perfect but should hopefully be good enough.
-    title = paragraphs[0].strip().split('\n')
-    title = ' '.join(t for t in title if len(t) > 0 and
-                     (ord(t[0]) >= 128 or t[0].isalnum()))
-    if len(title) == 0:
-        raise ValueError('Empty title detected from first paragraph:\n%s'
-                         % (paragraphs[0],))
-    # Use the title if no other paragraphs are provided
-    first_paragraph = title if len(paragraphs) < 2 else paragraphs[1]
-    # Concatenate all lines of the first paragraph and truncate at 95 chars
-    first_paragraph = re.sub('\n', ' ', first_paragraph)
-    first_paragraph = (first_paragraph[:95] + '...'
-                       if len(first_paragraph) > 95 else first_paragraph)
+    title_paragraph = paragraphs[0]
+    match = re.search(r'([\w ]+)', title_paragraph)
 
-    return first_paragraph, title
+    if match is None:
+        raise ValueError(
+            'Could not find a title in first paragraph:\n{}'.format(
+                         title_paragraph))
+    title = match.group(1).strip()
+    # Use the title if no other paragraphs are provided
+    intro_paragraph = title if len(paragraphs) < 2 else paragraphs[1]
+    # Concatenate all lines of the first paragraph and truncate at 95 chars
+    intro = re.sub('\n', ' ', intro_paragraph)
+    if len(intro) > 95:
+        intro = intro[:95] + '...'
+
+    return intro, title
 
 
 def get_md5sum(src_file):

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -132,12 +132,28 @@ def test_extract_intro_and_title():
     assert title_whitespace == title
 
     # Make example title optional (gh-222)
-    intro, title = sg.extract_intro_and_title('<string', 'Title\n-----')
+    intro, title = sg.extract_intro_and_title('<string>', 'Title\n-----')
     assert intro == title == 'Title'
 
+    # Title beginning with a space (gh-356)
+    intro, title = sg.extract_intro_and_title('filename',
+                                              '^^^^^\n   Title  two  \n^^^^^')
+    assert intro == title == 'Title  two'
+
+    # Long intro paragraph gets shortened
+    intro_paragraph = '\n'.join(['this is one line' for _ in range(10)])
+    intro, _ = sg.extract_intro_and_title(
+        'filename',
+        'Title\n-----\n\n' + intro_paragraph)
+    assert len(intro_paragraph) > 100
+    assert len(intro) < 100
+    assert intro.endswith('...')
+    assert intro_paragraph.replace('\n', ' ')[:95] == intro[:95]
+
+    # Errors
     with pytest.raises(ValueError, match='should have a header'):
         sg.extract_intro_and_title('<string>', '')  # no title
-    with pytest.raises(ValueError, match='Empty title'):
+    with pytest.raises(ValueError, match='Could not find a title'):
         sg.extract_intro_and_title('<string>', '-')  # no real title
 
 


### PR DESCRIPTION
I tried using sphinx-gallery from master in scikit-learn and I found that https://github.com/sphinx-gallery/sphinx-gallery/pull/345 introduces a regression in a edge case, where the title starts with a space, i.e. your example starts with something like this:

```py
"""
======================
        The title
======================
"""
```

I also added more tests for extract_intro_and_title. The detection is based on regex and I feel is as good as the previous one. I tried a docutils based solution using `docutils.core.publish_doctree` (I am guessing we could even check that the first paragraph is a title if we go this way) but I did not get anywhere convincing in a reasonable amount of time.

Note: to make a long story short, the title found by sphinx-gallery was empty before #345 but in practice this does not matter at all (except if you use ordering by title). The title for each example in the gallery is generated automatically by sphinx from a `:ref`: to the automatically added reference into the example rst.
