### PR TITLE
[MRG] Add Travis sphinx master cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,12 @@ matrix:
       env: DISTRIB="conda" PYTHON_VERSION="2.7" LOCALE=C
     - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="3.6" LOCALE=C
+    - os: linux
+      env: DISTRIB="conda" PYTHON_VERSION="2.7" SPHINX_VERSION="dev"
+      if: type = cron
+    - os: linux
+      env: DISTRIB="conda" PYTHON_VERSION="3.6" SPHINX_VERSION="dev"
+      if: type = cron
 
 before_install:
   # Make sure that things work even if the locale is set to C (which

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -18,10 +18,15 @@ if [ "$DISTRIB" == "conda" ]; then
     # force no mkl because mayavi requires old version of numpy
     # which then crashes with pandas and seaborn
     conda create --yes -n testenv python=$PYTHON_VERSION pip nomkl numpy\
-        setuptools matplotlib pillow sphinx pytest pytest-cov coverage seaborn
+        setuptools matplotlib pillow pytest pytest-cov coverage seaborn
     source activate testenv
     if [ "$INSTALL_MAYAVI" == "true" ]; then
         conda install --yes mayavi
+    fi
+    if [ "$SPHINX_VERSION" != "dev" ]; then
+        conda install "sphinx=${SPHINX_VERSION-*}" --yes
+    else
+        pip install git+https://github.com/sphinx-doc/sphinx.git
     fi
 elif [ "$DISTRIB" == "ubuntu" ]; then
     # Use a separate virtual environment than the one provided by


### PR DESCRIPTION
This allows to detect possible problems with sphinx before it is released. It will be run as a daily cron job because rather than in PRs because most of the time sphinx master failures are not related to PR changes but to changes in sphinx.

We do something similar in scikit-learn to test against numpy-dev, scipy-dev and cython-dev and this has proved very useful to feed back issues upstream and get them ironed out before the next release.