### PR TITLE
Add dedicated class for timing related block

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -159,6 +159,10 @@ CODE_OUTPUT = u""".. rst-class:: sphx-glr-script-out
 
 {0}\n"""
 
+TIMING_CONTENT = """
+.. rst-class:: sphx-glr-timing
+
+   **Total running time of the script:** ({0: .0f} minutes {1: .3f} seconds)\n\n"""
 
 SPHX_GLR_SIG = """\n
 .. only:: html
@@ -729,9 +733,7 @@ def save_rst_example(example_rst, example_file, time_elapsed,
 
     if time_elapsed >= gallery_conf["min_reported_time"]:
         time_m, time_s = divmod(time_elapsed, 60)
-        example_rst += ("**Total running time of the script:**"
-                        " ({0: .0f} minutes {1: .3f} seconds)\n\n"
-                        .format(time_m, time_s))
+        example_rst += TIMING_CONTENT.format(time_m, time_s)
     if gallery_conf['show_memory']:
         example_rst += ("**Estimated memory usage:** {0: .0f} MB\n\n"
                         .format(memory_used))

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -162,7 +162,9 @@ CODE_OUTPUT = u""".. rst-class:: sphx-glr-script-out
 TIMING_CONTENT = """
 .. rst-class:: sphx-glr-timing
 
-   **Total running time of the script:** ({0: .0f} minutes {1: .3f} seconds)\n\n"""
+   **Total running time of the script:** ({0: .0f} minutes {1: .3f} seconds)
+
+"""
 
 SPHX_GLR_SIG = """\n
 .. only:: html

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -52,8 +52,8 @@ def test_run_sphinx(sphinx_app):
     assert op.isdir(generated_examples_dir)
 
 
-def test_embed_links(sphinx_app):
-    """Test that links are embedded properly in doc."""
+def test_embed_links_and_styles(sphinx_app):
+    """Test that links and styles are embedded properly in doc."""
     out_dir = sphinx_app.outdir
     examples_dir = op.join(out_dir, 'auto_examples')
     assert op.isdir(examples_dir)
@@ -75,6 +75,9 @@ def test_embed_links(sphinx_app):
         assert "memory usage" not in lines
     else:
         assert "memory usage" in lines
+    # CSS styles
+    assert 'class="sphx-glr-signature"' in lines
+    assert 'class="sphx-glr-timing"' in lines
 
 
 def test_backreferences(sphinx_app):

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -302,7 +302,11 @@ def test_rst_example(gallery_conf):
     with codecs.open(test_file) as f:
         rst = f.read()
 
-        assert "lab/tree/notebooks/plot.ipy" in rst
+    assert "lab/tree/notebooks/plot.ipy" in rst
+
+    # CSS classes
+    assert "rst-class:: sphx-glr-signature" in rst
+    assert "rst-class:: sphx-glr-timing" in rst
 
 
 class TestLoggingTee:


### PR DESCRIPTION
This PR is for addressing the need to style timing block by adding a CSS class `sphx-glr-timing` class to `<p>`.