### PR TITLE
[MRG] Add note at the beginning of the example to the download section at the bottom

### DIFF
--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -147,54 +147,13 @@ div.sphx-glr-download a:hover {
   background-color: #d5d57e;
 }
 
-/* On large screens, float the download and binder buttons on the right */
-@media only screen and (min-width: 140ex) {
-    div.sphx-glr-footer-example  {
-	position: fixed;
-	right: 0px;
-	top: 100px;
-	background: rgba(200, 200, 200, 0.3);
-	padding: 0ex .5ex;
-	border: solid 1px #ccc;
-	max-width: 24ex;
-	width: fit-content;
-	width: -moz-min-content;
-    }
-
-    /* Avoid overflow of long file names */
-    div.sphx-glr-footer-example code {
-	max-width: 100%;
-	overflow: hidden;
-    }
-
-    div.sphx-glr-footer-example a {
-	max-width: 95%;
-	overflow: hidden;
-	padding: .5ex;
-    }
-
-    div.sphx-glr-footer-example a code span:last-child {
-	font-size: smaller;
-    }
+.sphx-glr-example-title > :target::before {
+  display: block;
+  content: "";
+  margin-top: -50px;
+  height: 50px;
+  visibility: hidden;
 }
-
-/* On very large screen, don't flush it too far */
-@media only screen and (min-width: 190ex) {
-    div.sphx-glr-footer-example  {
-	right: 5%;
-	max-width: 29ex;
-    }
-}
-
-/* Special case the RTD theme, capturing "section.wy-nav-content" */
-@media only screen and (min-width: 190ex) {
-    section.wy-nav-content-wrap div.sphx-glr-footer-example  {
-	right: unset;
-	left: 150ex;
-    }
-}
-
-
 
 ul.sphx-glr-horizontal {
   list-style: none;

--- a/sphinx_gallery/downloads.py
+++ b/sphinx_gallery/downloads.py
@@ -13,6 +13,8 @@ import os
 import zipfile
 
 CODE_DOWNLOAD = """
+.. _sphx_glr_download_{3}:
+
 \n.. only :: html
 
  .. container:: sphx-glr-footer

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -628,6 +628,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
     binder_text = (" or run this example in your browser via Binder"
                    if len(binder_conf) else "")
     example_rst = (".. note::\n"
+                   "    :class: sphx-glr-download-link-note\n\n"
                    "    Click :ref:`here <sphx_glr_download_{0}>` "
                    "to download the full example code{1}\n"
                    ".. rst-class:: sphx-glr-example-title\n\n"

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -625,7 +625,16 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
 
     ref_fname = os.path.relpath(example_file, gallery_conf['src_dir'])
     ref_fname = ref_fname.replace(os.path.sep, '_')
-    example_rst = """\n\n.. _sphx_glr_{0}:\n\n""".format(ref_fname)
+    binder_text = (" or run this example in your browser via Binder"
+                   if len(binder_conf) else "")
+    example_rst = (".. note::\n"
+                   "    Click :ref:`here <sphx_glr_download_{0}>` "
+                   "to download the full example code{1}\n"
+                   ".. rst-class:: sphx-glr-example-title\n\n"
+                   ".. _sphx_glr_{0}:\n\n"
+                   ).format(
+                       ref_fname,
+                       binder_text)
 
     filename_pattern = gallery_conf.get('filename_pattern')
     execute_script = re.search(filename_pattern, src_file) and gallery_conf[
@@ -713,7 +722,8 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
 
         example_rst += CODE_DOWNLOAD.format(fname,
                                             replace_py_ipynb(fname),
-                                            binder_badge_rst)
+                                            binder_badge_rst,
+                                            ref_fname)
         example_rst += SPHX_GLR_SIG
         f.write(example_rst)
 


### PR DESCRIPTION
This is my attempt at removing the floating right download buttons , which I feel is just too hard to configure right by default for a majority of sphinx themes, sorry @GaelVaroquaux ... 

There is a little bit of (at least for me) advanced CSS so that the link to the example from the gallery show the note (i.e. it behaves as if you go to the example section and then scroll up a bit so that you can see the note).

Comments more than welcome!

See #340 as well.