### PR TITLE
Don't create spurious examples/ directory.

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -157,10 +157,6 @@ def _prepare_sphx_glr_dirs(gallery_conf, srcdir):
     if not isinstance(gallery_dirs, list):
         gallery_dirs = [gallery_dirs]
 
-    for outdir in gallery_dirs:
-        if not os.path.exists(outdir):
-            os.makedirs(outdir)
-
     if bool(gallery_conf['backreferences_dir']):
         backreferences_dir = os.path.join(
             srcdir, gallery_conf['backreferences_dir'])


### PR DESCRIPTION
When using the "separate source and build" layout, sphinx-gallery
creates a spurious (and ultimately empty) "examples/" directory next to
the Makefile, whereas the correct place for that directory is
"source/examples".  It is in fact not necessary to pre-create that
directory, because generate_dir_rst also contains the snippet

    if not os.path.exists(target_dir):
        os.makedirs(target_dir)

which will create the *correct* examples/ directory.