### PR TITLE
[MRG] Fix: Gallery name for paths ending with '/'

### DIFF
--- a/sphinx_gallery/downloads.py
+++ b/sphinx_gallery/downloads.py
@@ -64,14 +64,7 @@ def python_zip(file_list, gallery_path, extension='.py'):
         zip file name, written as `target_dir_{python,jupyter}.zip`
         depending on the extension
     """
-    path_components = os.path.split(gallery_path)
-    if path_components[-1]:
-        zipname = path_components[-1]
-    elif len(path_components) <= 1:
-        zipname = 'gallery'
-    else:
-        # The path entered by the user ends with '/'
-        zipname = path_components[-2]
+    zipname = os.path.basename(os.path.normpath(gallery_path))
     zipname += '_python' if extension == '.py' else '_jupyter'
     zipname = os.path.join(gallery_path, zipname + '.zip')
 

--- a/sphinx_gallery/downloads.py
+++ b/sphinx_gallery/downloads.py
@@ -64,7 +64,14 @@ def python_zip(file_list, gallery_path, extension='.py'):
         zip file name, written as `target_dir_{python,jupyter}.zip`
         depending on the extension
     """
-    zipname = os.path.basename(gallery_path)
+    path_components = os.path.split(gallery_path)
+    if path_components[-1]:
+        zipname = path_components[-1]
+    elif len(path_components) <= 1:
+        zipname = 'gallery'
+    else:
+        # The path entered by the user ends with '/'
+        zipname = path_components[-2]
     zipname += '_python' if extension == '.py' else '_jupyter'
     zipname = os.path.join(gallery_path, zipname + '.zip')
 

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -23,8 +23,8 @@ sphinx_gallery_conf = {
     'doc_module': ('sphinx_gallery',),
     'reference_url': {
         'sphinx_gallery': None,
-        },
-    'examples_dirs': ['examples'],
+    },
+    'examples_dirs': ['examples/'],
     'gallery_dirs': ['auto_examples'],
     'backreferences_dir': 'gen_modules/backreferences',
     'within_section_order': FileNameSortKey,


### PR DESCRIPTION
If the user enters in the conf.py paths that end by '/', such as
'examples/', the filename of the downloads was '_python.zip'. This
commit fixes it.