### PR TITLE
Show peak memory usage if memory_profiler is installed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   global:
     PYTHON: "C:\\conda"
     MINICONDA_VERSION: "latest"
-    CONDA_DEPENDENCIES: "numpy seaborn matplotlib sphinx pillow pytest pytest-cov"
+    CONDA_DEPENDENCIES: "numpy seaborn matplotlib sphinx pillow pytest pytest-cov memory_profiler"
 
   matrix:
     - PYTHON_VERSION: "2.7"

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -39,6 +39,7 @@ elif [ "$DISTRIB" == "ubuntu" ]; then
     pip install -U requests[security]  # ensure SSL certificate works
     pip install "tornado<5"
     pip install -r requirements.txt
+    pip uninstall memory_profiler  # test show_memory=True without memory_profiler
     pip install seaborn sphinx==1.5.5 pytest "six>=1.10.0" pytest-cov
 else
     echo "invalid value for DISTRIB environment variable: $DISTRIB"

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -39,7 +39,7 @@ elif [ "$DISTRIB" == "ubuntu" ]; then
     pip install -U requests[security]  # ensure SSL certificate works
     pip install "tornado<5"
     pip install -r requirements.txt
-    pip uninstall memory_profiler  # test show_memory=True without memory_profiler
+    pip uninstall -y memory_profiler  # test show_memory=True without memory_profiler
     pip install seaborn sphinx==1.5.5 pytest "six>=1.10.0" pytest-cov
 else
     echo "invalid value for DISTRIB environment variable: $DISTRIB"

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -18,7 +18,8 @@ if [ "$DISTRIB" == "conda" ]; then
     # force no mkl because mayavi requires old version of numpy
     # which then crashes with pandas and seaborn
     conda create --yes -n testenv python=$PYTHON_VERSION pip nomkl numpy\
-        setuptools matplotlib pillow pytest pytest-cov coverage seaborn
+        setuptools matplotlib pillow pytest pytest-cov coverage seaborn\
+        memory_profiler
     source activate testenv
     if [ "$INSTALL_MAYAVI" == "true" ]; then
         conda install --yes mayavi

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -346,5 +346,6 @@ sphinx_gallery_conf = {
                'url': 'https://mybinder.org',
                'branch': 'master',
                'dependencies': './binder/requirements.txt'
-               }
+               },
+    'show_memory': True
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -346,6 +346,5 @@ sphinx_gallery_conf = {
                'url': 'https://mybinder.org',
                'branch': 'master',
                'dependencies': './binder/requirements.txt'
-               },
-    'show_memory': True
+               }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 pillow
 sphinx
 pytest
+memory_profiler

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -730,8 +730,11 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
         if time_elapsed >= gallery_conf["min_reported_time"]:
             example_rst += ("**Total running time of the script:**"
                             " ({0: .0f} minutes {1: .3f} seconds)\n\n"
-                            "**Peak memory usage:** {2: .3f}MB\n\n".format(
-                                time_m, time_s, peak_mem))
+                            .format(time_m, time_s))
+        if PROFILE_MEMORY:
+            example_rst += ("**Peak memory usage:** {2: .3f}MB\n\n"
+                            .format(time_m, time_s, peak_mem))
+
         # Generate a binder URL if specified
         binder_badge_rst = ''
         if len(binder_conf) > 0:

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -735,7 +735,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
                             .format(time_m, time_s))
         if show_memory:
             peak_mem = max(memory_measurements)
-            example_rst += ("**Peak memory usage:** {0: .3f}MB\n\n"
+            example_rst += ("**Peak memory usage:** {0: .0f} MB\n\n"
                             .format(peak_mem))
 
         # Generate a binder URL if specified

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -732,8 +732,8 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
                             " ({0: .0f} minutes {1: .3f} seconds)\n\n"
                             .format(time_m, time_s))
         if PROFILE_MEMORY:
-            example_rst += ("**Peak memory usage:** {2: .3f}MB\n\n"
-                            .format(time_m, time_s, peak_mem))
+            example_rst += ("**Peak memory usage:** {0: .3f}MB\n\n"
+                            .format(peak_mem))
 
         # Generate a binder URL if specified
         binder_badge_rst = ''

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -60,5 +60,6 @@ def test_embed_links(sphinx_app):
     assert 'scipy.signal.firwin.html' in lines
     assert '#module-numpy' in lines
     assert 'numpy.arange.html' in lines
+    assert 'Peak memory' in lines
     # assert '#module-matplotlib.pyplot' in lines
     # assert 'pyplot.html' in lines

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -60,6 +60,11 @@ def test_embed_links(sphinx_app):
     assert 'scipy.signal.firwin.html' in lines
     assert '#module-numpy' in lines
     assert 'numpy.arange.html' in lines
-    assert 'Peak memory' in lines
+    try:
+        import memory_profiler
+    except ImportError:
+        assert "Peak memory" not in lines
+    else:
+        assert "Peak memory" in lines
     # assert '#module-matplotlib.pyplot' in lines
     # assert 'pyplot.html' in lines

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -29,6 +29,6 @@ sphinx_gallery_conf = {
     'backreferences_dir': 'gen_modules/backreferences',
     'within_section_order': FileNameSortKey,
     'expected_failing_examples': ['examples/plot_future_imports_broken.py'],
-    'show_memory': True;
+    'show_memory': True,
 }
 nitpicky = True

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -29,5 +29,6 @@ sphinx_gallery_conf = {
     'backreferences_dir': 'gen_modules/backreferences',
     'within_section_order': FileNameSortKey,
     'expected_failing_examples': ['examples/plot_future_imports_broken.py'],
+    'show_memory': True;
 }
 nitpicky = True


### PR DESCRIPTION
This is just a small modification which will add an extra line below the "Total running time of the script..." showing the peak memory usage.

The line will only be displayed if `memory_profiler` is installed.

Example output:

```
Total running time of the script: ( 0 minutes 0.363 seconds)

Peak memory usage: 167.664MB
```