### PR TITLE
Support for custom default thumbnails in 'RGBA' space

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -385,7 +385,7 @@ def scale_image(in_fname, out_fname, max_width, max_height):
     # width_sc, height_sc = img.size  # necessary if using thumbnail
 
     # insert centered
-    thumb = Image.new('RGB', (max_width, max_height), (255, 255, 255))
+    thumb = Image.new('RGBA', (max_width, max_height), (255, 255, 255, 255))
     pos_insert = ((max_width - width_sc) // 2, (max_height - height_sc) // 2)
     thumb.paste(img, pos_insert)
 


### PR DESCRIPTION
This PR adds support for custom default thumbnails with transparency values. Up to now, the alpha value in RGBA PNG images is simply discarded, resulting in side effects like a black box surrounding the image.