### PR TITLE
Fix surprising interaction between file_pattern and expected_failing_examples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,9 @@ Bug Fixes
 * Fix SphinxDocLinkResolver error with sphinx 1.7. See `#352
   <https://github.com/sphinx-gallery/sphinx-gallery/pull/352>`_ for more
   details.
+* Fix unexpected interaction between ``file_pattern`` and
+  ``expected_failing_examples``. See `#379
+  <https://github.com/sphinx-gallery/sphinx-gallery/pull/352>`_
 
 Incompatible Changes
 ''''''''''''''''''''

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -16,6 +16,7 @@ import copy
 import re
 import os
 
+from sphinx.util.console import red
 from . import sphinx_compatibility, glr_path_static, __version__ as _sg_version
 from .gen_rst import generate_dir_rst, SPHX_GLR_SIG
 from .docs_resolv import embed_code_links
@@ -286,7 +287,7 @@ def sumarize_failing_examples(app, exception):
         expected_failing_examples)
     fail_msgs = []
     if examples_not_expected_to_fail:
-        fail_msgs.append("Unexpected failing examples:")
+        fail_msgs.append(red("Unexpected failing examples:"))
         for fail_example in examples_not_expected_to_fail:
             fail_msgs.append(fail_example + ' failed leaving traceback:\n' +
                              gallery_conf['failing_examples'][fail_example] +
@@ -294,8 +295,13 @@ def sumarize_failing_examples(app, exception):
 
     examples_not_expected_to_pass = expected_failing_examples.difference(
         failing_examples)
+    # filter from examples actually run
+    filename_pattern = gallery_conf.get('filename_pattern')
+    examples_not_expected_to_pass = [src_file
+                                     for src_file in examples_not_expected_to_pass
+                                     if re.search(filename_pattern, src_file)]
     if examples_not_expected_to_pass:
-        fail_msgs.append("Examples expected to fail, but not failing:\n" +
+        fail_msgs.append(red("Examples expected to fail, but not failing:\n") +
                          "Please remove these examples from\n" +
                          "sphinx_gallery_conf['expected_failing_examples']\n" +
                          "in your conf.py file"

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -55,6 +55,9 @@ def config_app(tempdir, conf_file):
 import os
 import sphinx_gallery
 extensions = ['sphinx_gallery.gen_gallery']
+exclude_patterns = ['_build']
+source_suffix = '.rst'
+master_doc = 'index'
 # General information about the project.
 project = u'Sphinx-Gallery <Tests>'\n\n
 """
@@ -282,3 +285,19 @@ def test_binder_copy_files(config_app, tmpdir):
         assert os.path.exists(os.path.join(
             config_app.outdir, 'ntbk_folder', gallery_conf['gallery_dirs'][0],
             i_file+'.ipynb'))
+
+
+@pytest.mark.conf_file(content="""
+sphinx_gallery_conf = {
+    'examples_dirs': 'src',
+    'gallery_dirs': 'ex',
+    'filename_pattern': 'plot_1.py',
+    'expected_failing_examples' :['src/plot_2.py'],
+}""")
+def test_expected_failing_examples_were_executed(config_app):
+    """Testing that no exception is issued when broken example is not built
+
+    Refer to issue #335
+    """
+    # Build docs there should be no exception raised
+    config_app.build(False, [])

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -51,8 +51,15 @@ def config_app(tempdir, conf_file):
     shutil.copytree(os.path.join(_fixturedir, "src"),
                     os.path.join(tempdir, "examples"))
 
+    base_config = """
+import os
+import sphinx_gallery
+extensions = ['sphinx_gallery.gen_gallery']
+# General information about the project.
+project = u'Sphinx-Gallery <Tests>'\n\n
+"""
     with open(os.path.join(srcdir, "conf.py"), "w") as conffile:
-        conffile.write(conf_file['content'])
+        conffile.write(base_config + conf_file['content'])
 
     app = Sphinx(srcdir, srcdir, os.path.join(srcdir, "_build"),
                  os.path.join(srcdir, "_build", "toctree"),
@@ -62,12 +69,6 @@ def config_app(tempdir, conf_file):
     return app
 
 
-@pytest.mark.conf_file(content="""
-import os
-import sphinx_gallery
-extensions = ['sphinx_gallery.gen_gallery']
-# General information about the project.
-project = u'Sphinx-Gallery <Tests>'""")
 def test_default_config(config_app):
     """Test the default Sphinx-Gallery configuration is loaded
 
@@ -82,12 +83,6 @@ def test_default_config(config_app):
 
 
 @pytest.mark.conf_file(content="""
-import os
-import sphinx_gallery
-extensions = ['sphinx_gallery.gen_gallery']
-# General information about the project.
-project = u'Sphinx-Gallery <Tests>'
-
 sphinx_gallery_conf = {
     'examples_dirs': 'src',
     'gallery_dirs': 'ex',
@@ -107,12 +102,6 @@ def test_no_warning_simple_config(config_app):
 
 
 @pytest.mark.conf_file(content="""
-import os
-import sphinx_gallery
-extensions = ['sphinx_gallery.gen_gallery']
-# General information about the project.
-project = u'Sphinx-Gallery <Tests>'
-
 sphinx_gallery_conf = {
     'mod_example_dir' : os.path.join('modules', 'gen'),
     'examples_dirs': 'src',
@@ -137,12 +126,6 @@ def test_config_old_backreferences_conf(config_app):
 
 
 @pytest.mark.conf_file(content="""
-import os
-import sphinx_gallery
-extensions = ['sphinx_gallery.gen_gallery']
-# General information about the project.
-project = u'Sphinx-Gallery <Tests>'
-
 sphinx_gallery_conf = {
     'backreferences_dir': os.path.join('gen_modules', 'backreferences'),
     'examples_dirs': 'src',
@@ -192,8 +175,6 @@ def _check_order(config_app, key):
 
 
 @pytest.mark.conf_file(content="""
-import sphinx_gallery
-extensions = ['sphinx_gallery.gen_gallery']
 sphinx_gallery_conf = {
     'examples_dirs': 'src',
     'gallery_dirs': 'ex',
@@ -204,9 +185,7 @@ def test_example_sorting_default(config_app):
 
 
 @pytest.mark.conf_file(content="""
-import sphinx_gallery
 from sphinx_gallery.sorting import FileSizeSortKey
-extensions = ['sphinx_gallery.gen_gallery']
 sphinx_gallery_conf = {
     'examples_dirs': 'src',
     'gallery_dirs': 'ex',
@@ -218,9 +197,7 @@ def test_example_sorting_filesize(config_app):
 
 
 @pytest.mark.conf_file(content="""
-import sphinx_gallery
 from sphinx_gallery.sorting import FileNameSortKey
-extensions = ['sphinx_gallery.gen_gallery']
 sphinx_gallery_conf = {
     'examples_dirs': 'src',
     'gallery_dirs': 'ex',
@@ -232,9 +209,7 @@ def test_example_sorting_filename(config_app):
 
 
 @pytest.mark.conf_file(content="""
-import sphinx_gallery
 from sphinx_gallery.sorting import ExampleTitleSortKey
-extensions = ['sphinx_gallery.gen_gallery']
 sphinx_gallery_conf = {
     'examples_dirs': 'src',
     'gallery_dirs': 'ex',

--- a/sphinx_gallery/tests/testconfs/index.rst
+++ b/sphinx_gallery/tests/testconfs/index.rst
@@ -1,0 +1,4 @@
+Tiny test build
+===============
+
+Minimal testing example


### PR DESCRIPTION
Apply a filter to examples_not_expected_to_pass to validate that they where
actually run.

Put color to error messages header so that they can be easily found on
sphinx log.

Fix #335.

