### PR TITLE
[MRG] Fix version parsing for scikit-learn doc

### DIFF
--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -92,7 +92,7 @@ def parse_sphinx_docopts(index):
         The documentation options from the page.
     """
 
-    pos = index.find('DOCUMENTATION_OPTIONS')
+    pos = index.find('var DOCUMENTATION_OPTIONS')
     if pos < 0:
         raise ValueError('Documentation options could not be found in index.')
     pos = index.find('{', pos)
@@ -171,7 +171,7 @@ class SphinxDocLinkResolver(object):
         # are being referenced, we need to try and get the index page first and
         # if that doesn't work, check for the documentation_options.js file.
         index = get_data(index_url, gallery_dir)
-        if 'DOCUMENTATION_OPTIONS' in index:
+        if 'var DOCUMENTATION_OPTIONS' in index:
             self._docopts = parse_sphinx_docopts(index)
         else:
             docopts = get_data(docopts_url, gallery_dir)


### PR DESCRIPTION
scikit-learn uses a layout which contains DOCUMENTATION_OPTIONS, see [this](https://github.com/scikit-learn/scikit-learn/blob/20cb37e8f6e1eb6859239bac6307fcc213ddd52e/doc/themes/scikit-learn/layout.html#L86).

This is related to https://github.com/sphinx-gallery/sphinx-gallery/pull/352, so pinging @astrofrog in case he has some objection.