### PR TITLE
FIX: Use unstyled pygments for output

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -173,7 +173,9 @@ SINGLE_IMAGE = """
 # This one could contain unicode
 CODE_OUTPUT = u""".. rst-class:: sphx-glr-script-out
 
- Out::
+ Out:
+
+ .. code-block:: none
 
 {0}\n"""
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -235,7 +235,7 @@ def test_pattern_matching(gallery_conf, log_collector):
 
     gallery_conf.update(filename_pattern=re.escape(os.sep) + 'plot_0')
 
-    code_output = ('\n Out::\n'
+    code_output = ('\n Out:\n\n .. code-block:: none\n'
                    '\n'
                    '    Óscar output\n'
                    '    log:Óscar\n'


### PR DESCRIPTION
We should probably use `none` as the markup language for outputs. This is more reflective of how they are rendered in the terminal (a key goal of SG). It also takes care of weird, unexpected formatting of log messages that the default `python` interpretation causes.

The only downside I can see is that `repr`s that were previously formated to look like Python objects no longer will be. But I'd argue this is reasonable behavior since this is more like what a terminal would display when you actually execute the commands.