### PR TITLE
FIX: No more workaround

### DIFF
--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -64,8 +64,12 @@ class SphinxAppWrapper(object):
         self.kwargs = kwargs
 
     def create_sphinx_app(self):
-        app = Sphinx(self.srcdir, self.confdir, self.outdir,
-                     self.doctreedir, self.buildername, **self.kwargs)
+        # Avoid warnings about re-registration, see:
+        # https://github.com/sphinx-doc/sphinx/issues/5038
+        from sphinx.util.docutils import docutils_namespace
+        with docutils_namespace():
+            app = Sphinx(self.srcdir, self.confdir, self.outdir,
+                         self.doctreedir, self.buildername, **self.kwargs)
         sphinx_compatibility._app = app
         return app
 
@@ -130,8 +134,7 @@ def test_no_warning_simple_config(sphinx_app_wrapper):
     cfg = sphinx_app.config
     assert cfg.project == "Sphinx-Gallery <Tests>"
     build_warn = sphinx_app._warning.getvalue()
-    # ignore 1.8.0 dev bug
-    assert build_warn == '' or 'up extension sphinx.domains.math' in build_warn
+    assert build_warn == ''
 
 
 @pytest.mark.conf_file(content="""
@@ -172,8 +175,7 @@ def test_config_backreferences(sphinx_app_wrapper):
     assert cfg.sphinx_gallery_conf['backreferences_dir'] == os.path.join(
         'gen_modules', 'backreferences')
     build_warn = sphinx_app._warning.getvalue()
-    # ignore 1.8.0 dev bug
-    assert build_warn == '' or 'up extension sphinx.domains.math' in build_warn
+    assert build_warn == ''
 
 
 def test_duplicate_files_warn(sphinx_app_wrapper):
@@ -188,8 +190,7 @@ def test_duplicate_files_warn(sphinx_app_wrapper):
     # No warning because no overlapping names
     check_duplicate_filenames(files[:-1])
     build_warn = sphinx_app._warning.getvalue()
-    # ignore 1.8.0 dev bug
-    assert build_warn == '' or 'up extension sphinx.domains.math' in build_warn
+    assert build_warn == ''
 
     # Warning because last file is named the same
     check_duplicate_filenames(files)

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -17,6 +17,8 @@ import pytest
 
 from sphinx.application import Sphinx
 from sphinx.errors import ExtensionError
+from sphinx.util.docutils import docutils_namespace
+
 from sphinx_gallery.gen_rst import MixedEncodingStringIO
 from sphinx_gallery import sphinx_compatibility
 from sphinx_gallery.gen_gallery import (check_duplicate_filenames,
@@ -66,7 +68,6 @@ class SphinxAppWrapper(object):
     def create_sphinx_app(self):
         # Avoid warnings about re-registration, see:
         # https://github.com/sphinx-doc/sphinx/issues/5038
-        from sphinx.util.docutils import docutils_namespace
         with docutils_namespace():
             app = Sphinx(self.srcdir, self.confdir, self.outdir,
                          self.doctreedir, self.buildername, **self.kwargs)


### PR DESCRIPTION
I suspect that this will die on older versions of Sphinx, in which case I'll probably add a context manager to the `sphinx_compatibility` submodule.