### PR TITLE
adding ability to customize first cell of notebooks

### DIFF
--- a/doc/advanced_configuration.rst
+++ b/doc/advanced_configuration.rst
@@ -33,6 +33,7 @@ file:
 - ``expected_failing_examples`` (:ref:`dont_fail_exit`)
 - ``min_reported_time`` (:ref:`min_reported_time`)
 - ``binder`` (:ref:`binder_links`)
+- ``first_notebook_cell`` (:ref:`first_notebook_cell`)
 
 Some options can also be set or overridden on a file-by-file basis:
 
@@ -390,6 +391,36 @@ setting::
 
 Note that for Sphinx < 1.3, the line numbers will not be consistent with the
 original file.
+
+
+.. _first_notebook_cell:
+
+Add your own first notebook cell
+================================
+
+Sphinx-Gallery adds an extra cell to the beginning of every generated notebook.
+This is often for adding code that is required to run properly in the notebook,
+but not in a ``.py`` file. By default, this text is
+
+.. code-block:: python
+
+   %matplotlib inline
+
+You can choose whatever text you like by modifying the ``first_notebook_cell``
+configuration parameter. For example, the gallery of this documentation
+displays a comment along-side each the code shown above.
+
+.. code-block:: python
+
+  # This cell is added by sphinx-gallery
+  # It can be customized to whatever you like
+  %matplotlib inline
+
+Which is achieved by the following configuration::
+
+  'first_notebook_cell': ("# This cell is added by sphinx-gallery\n"
+                          "# It can be customized to whatever you like\n"
+                          "%matplotlib inline")
 
 
 .. _disable_all_scripts_download:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -348,5 +348,8 @@ sphinx_gallery_conf = {
                'dependencies': './binder/requirements.txt',
                'notebooks_dir': 'notebooks',
                'use_jupyter_lab': True,
-               }
+               },
+    'first_notebook_cell': ("# This cell is added by sphinx-gallery\n"
+                            "# It can be customized to whatever you like\n"
+                            "%matplotlib inline")
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -349,7 +349,4 @@ sphinx_gallery_conf = {
                'notebooks_dir': 'notebooks',
                'use_jupyter_lab': True,
                },
-    'first_notebook_cell': ("# This cell is added by sphinx-gallery\n"
-                            "# It can be customized to whatever you like\n"
-                            "%matplotlib inline")
 }

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -62,6 +62,7 @@ DEFAULT_GALLERY_CONF = {
     'binder': {},
     'image_scrapers': ('matplotlib',),
     'reset_modules': ('matplotlib', 'seaborn'),
+    'first_notebook_cell': '%matplotlib inline'
 }
 
 logger = sphinx_compatibility.getLogger('sphinx-gallery')

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -104,6 +104,7 @@ def parse_config(app):
     gallery_conf = _complete_gallery_conf(
         app.config.sphinx_gallery_conf, src_dir, plot_gallery,
         abort_on_example_error)
+
     # this assures I can call the config in other places
     app.config.sphinx_gallery_conf = gallery_conf
     app.config.html_static_path.append(glr_path_static())
@@ -172,16 +173,11 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
     del resetters
 
     # Ensure the first cell text is a string if we have it
-    first_cell = gallery_conf.get("first_notebook_cell", "%matplotlib inline")
+    first_cell = gallery_conf.get("first_notebook_cell")
     if not isinstance(first_cell, str):
         raise ValueError("The 'first_notebook_cell' parameter must be type str"
                          "found type %s" % type(first_cell))
     gallery_conf['first_notebook_cell'] = first_cell
-
-    # this assures I can call the config in other places
-    app.config.sphinx_gallery_conf = gallery_conf
-    app.config.html_static_path.append(glr_path_static())
-
     return gallery_conf
 
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -171,6 +171,17 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
     gallery_conf['reset_modules'] = tuple(resetters)
     del resetters
 
+    # Ensure the first cell text is a string if we have it
+    first_cell = gallery_conf.get("first_notebook_cell", "%matplotlib inline")
+    if not isinstance(first_cell, str):
+        raise ValueError("The 'first_notebook_cell' parameter must be type str"
+                         "found type %s" % type(first_cell))
+    gallery_conf['first_notebook_cell'] = first_cell
+
+    # this assures I can call the config in other places
+    app.config.sphinx_gallery_conf = gallery_conf
+    app.config.html_static_path.append(glr_path_static())
+
     return gallery_conf
 
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -174,7 +174,7 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
 
     # Ensure the first cell text is a string if we have it
     first_cell = gallery_conf.get("first_notebook_cell")
-    if not isinstance(first_cell, str):
+    if not isinstance(first_cell, basestring):
         raise ValueError("The 'first_notebook_cell' parameter must be type str"
                          "found type %s" % type(first_cell))
     gallery_conf['first_notebook_cell'] = first_cell

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -579,7 +579,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
 
     save_thumbnail(image_path_template, src_file, file_conf, gallery_conf)
 
-    example_nb = jupyter_notebook(script_blocks)
+    example_nb = jupyter_notebook(script_blocks, gallery_conf)
     save_notebook(example_nb, replace_py_ipynb(target_file))
 
     return intro, time_elapsed

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -15,6 +15,7 @@ import argparse
 import json
 import re
 import sys
+import copy
 
 from .py_source_parser import split_code_and_text_blocks
 from .utils import replace_py_ipynb
@@ -111,9 +112,6 @@ def jupyter_notebook(script_blocks, gallery_conf):
         The sphinx-gallery configuration dictionary.
     """
     first_cell = gallery_conf.get("first_notebook_cell", "%matplotlib inline")
-    if not isinstance(first_cell, str):
-        raise ValueError("The 'first_notebook_cell' parameter must be type str"
-                         "found type %s" % type(first_cell))
     work_notebook = jupyter_notebook_skeleton()
     add_code_cell(work_notebook, first_cell)
     fill_notebook(work_notebook, script_blocks)
@@ -185,6 +183,7 @@ def python_to_jupyter_cli(args=None, namespace=None):
 
     Takes the same arguments as ArgumentParser.parse_args
     """
+    from . import gen_gallery  # To avoid circular import
     parser = argparse.ArgumentParser(
         description='Sphinx-Gallery Notebook converter')
     parser.add_argument('python_src_file', nargs='+',
@@ -196,6 +195,6 @@ def python_to_jupyter_cli(args=None, namespace=None):
     for src_file in args.python_src_file:
         file_conf, blocks = split_code_and_text_blocks(src_file)
         print('Converting {0}'.format(src_file))
-        empty_conf = {}  # We use an empty gallery configuration file
-        example_nb = jupyter_notebook(blocks, empty_conf)
+        gallery_conf = copy.deepcopy(gen_gallery.DEFAULT_GALLERY_CONF)
+        example_nb = jupyter_notebook(blocks, gallery_conf)
         save_notebook(example_nb, replace_py_ipynb(src_file))

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -100,17 +100,22 @@ def rst2md(text):
     return text
 
 
-def jupyter_notebook(script_blocks):
+def jupyter_notebook(script_blocks, gallery_conf):
     """Generate a Jupyter notebook file cell-by-cell
 
     Parameters
     ----------
-    script_blocks: list
-        script execution cells
+    script_blocks : list
+        Script execution cells.
+    gallery_conf : dict
+        The sphinx-gallery configuration dictionary.
     """
-
+    first_cell = gallery_conf.get("first_notebook_cell", "%matplotlib inline")
+    if not isinstance(first_cell, str):
+        raise ValueError("The 'first_notebook_cell' parameter must be type str"
+                         "found type %s" % type(first_cell))
     work_notebook = jupyter_notebook_skeleton()
-    add_code_cell(work_notebook, "%matplotlib inline")
+    add_code_cell(work_notebook, first_cell)
     fill_notebook(work_notebook, script_blocks)
 
     return work_notebook
@@ -191,5 +196,6 @@ def python_to_jupyter_cli(args=None, namespace=None):
     for src_file in args.python_src_file:
         file_conf, blocks = split_code_and_text_blocks(src_file)
         print('Converting {0}'.format(src_file))
-        example_nb = jupyter_notebook(blocks)
+        empty_conf = {}  # We use an empty gallery configuration file
+        example_nb = jupyter_notebook(blocks, empty_conf)
         save_notebook(example_nb, replace_py_ipynb(src_file))

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -360,3 +360,14 @@ def test_examples_not_expected_to_pass(sphinx_app_wrapper):
     with pytest.raises(ValueError) as excinfo:
         sphinx_app_wrapper.build_sphinx_app()
     assert "expected to fail, but not failing" in str(excinfo.value)
+
+
+@pytest.mark.conf_file(content="""
+sphinx_gallery_conf = {
+    'first_notebook_cell': 2,
+}""")
+def test_first_notebook_cell_config(sphinx_app_wrapper):
+    from sphinx_gallery.gen_gallery import parse_config
+    # First cell must be str
+    with pytest.raises(ValueError):
+        parse_config(sphinx_app_wrapper.create_sphinx_app())

--- a/sphinx_gallery/tests/test_notebook.py
+++ b/sphinx_gallery/tests/test_notebook.py
@@ -14,6 +14,8 @@ import pytest
 import sphinx_gallery.gen_rst as sg
 from sphinx_gallery.notebook import (rst2md, jupyter_notebook, save_notebook,
                                      python_to_jupyter_cli)
+from sphinx_gallery.tests.test_gen_rst import gallery_conf
+
 try:
     FileNotFoundError
 except NameError:
@@ -78,10 +80,9 @@ For more details on interpolation see the page `channel_interpolation`.
     assert rst2md(rst) == markdown
 
 
-def test_jupyter_notebook():
+def test_jupyter_notebook(gallery_conf):
     """Test that written ipython notebook file corresponds to python object"""
     file_conf, blocks = sg.split_code_and_text_blocks('tutorials/plot_parse.py')
-    gallery_conf = {}
     example_nb = jupyter_notebook(blocks, gallery_conf)
 
     with tempfile.NamedTemporaryFile('w', delete=False) as f:
@@ -98,11 +99,6 @@ def test_jupyter_notebook():
     gallery_conf['first_notebook_cell'] = test_text
     example_nb = jupyter_notebook(blocks, gallery_conf)
     assert example_nb.get('cells')[0]['source'][0] == test_text
-
-    # First cell must be str
-    with pytest.raises(ValueError):
-        gallery_conf['first_notebook_cell'] = 12
-        jupyter_notebook(blocks, gallery_conf)
 
 ###############################################################################
 # Notebook shell utility

--- a/sphinx_gallery/tests/test_notebook.py
+++ b/sphinx_gallery/tests/test_notebook.py
@@ -81,7 +81,8 @@ For more details on interpolation see the page `channel_interpolation`.
 def test_jupyter_notebook():
     """Test that written ipython notebook file corresponds to python object"""
     file_conf, blocks = sg.split_code_and_text_blocks('tutorials/plot_parse.py')
-    example_nb = jupyter_notebook(blocks)
+    gallery_conf = {}
+    example_nb = jupyter_notebook(blocks, gallery_conf)
 
     with tempfile.NamedTemporaryFile('w', delete=False) as f:
         save_notebook(example_nb, f.name)
@@ -90,6 +91,18 @@ def test_jupyter_notebook():
             assert json.load(fname) == example_nb
     finally:
         os.remove(f.name)
+    assert example_nb.get('cells')[0]['source'][0] == "%matplotlib inline"
+
+    # Test custom first cell text
+    test_text = '# testing\n%matplotlib notebook'
+    gallery_conf['first_notebook_cell'] = test_text
+    example_nb = jupyter_notebook(blocks, gallery_conf)
+    assert example_nb.get('cells')[0]['source'][0] == test_text
+
+    # First cell must be str
+    with pytest.raises(ValueError):
+        gallery_conf['first_notebook_cell'] = 12
+        jupyter_notebook(blocks, gallery_conf)
 
 ###############################################################################
 # Notebook shell utility

--- a/sphinx_gallery/tests/test_utils.py
+++ b/sphinx_gallery/tests/test_utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 r"""
-Test utility functions 
+Test utility functions
 ==================
 
 
@@ -10,10 +10,11 @@ Test utility functions
 
 from __future__ import division, absolute_import, print_function
 import sphinx_gallery.utils as utils
+from sphinx_gallery.tests.test_gen_gallery import sphinx_app_wrapper
 import pytest
 
 def test_replace_py_ipynb():
-    
+
     # Test behavior of function with expected input:
     for file_name in ['some/file/name', '/corner.pycase']:
         assert utils.replace_py_ipynb(file_name+'.py') == file_name+'.ipynb'

--- a/sphinx_gallery/tests/test_utils.py
+++ b/sphinx_gallery/tests/test_utils.py
@@ -10,11 +10,9 @@ Test utility functions
 
 from __future__ import division, absolute_import, print_function
 import sphinx_gallery.utils as utils
-from sphinx_gallery.tests.test_gen_gallery import sphinx_app_wrapper
 import pytest
 
 def test_replace_py_ipynb():
-
     # Test behavior of function with expected input:
     for file_name in ['some/file/name', '/corner.pycase']:
         assert utils.replace_py_ipynb(file_name+'.py') == file_name+'.ipynb'


### PR DESCRIPTION
This adds a configuration parameter `first_notebook_cell` that lets users choose what text goes in the first cell of created notebooks. By default this remains the same (`%matplotlib inline`).

This could be useful for either other packages that need their own special configuration in a notebook context, or for people that want to run the notebook with the "interactive" matplotlib setting (`%matplotlib notebook`).

closes #388 and relevant to https://github.com/matplotlib/matplotlib/issues/11415

