### PR TITLE
MRG: Remove outdated cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,6 @@ matrix:
     - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="3.6" LOCALE=C
     - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="2.7" SPHINX_VERSION="dev"
-      if: type = cron
-    - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="3.6" SPHINX_VERSION="dev"
       if: type = cron
 


### PR DESCRIPTION
Our CRON job [failed](https://travis-ci.org/sphinx-gallery/sphinx-gallery/jobs/426532591#L761) because:
```
ERROR: Sphinx requires at least Python 3.5 to run.
```
This PR thus removes the 2.7 + Sphinx `master` cron job.