### PR TITLE
MRG: Fix for newer sphinx

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,9 @@ addopts = --cov-report term-missing --cov=sphinx_gallery --durations=5 -rs
 python_files = tests/*.py
 norecursedirs = build _build auto_examples gen_modules
                 sphinx_gallery/tests/tinybuild
+filterwarnings =
+    ignore:.*HasTraits.trait_.*:DeprecationWarning
+    ignore:np.loads is deprecated, use pickle.loads instead:DeprecationWarning
 
 [build_sphinx]
 source-dir = doc/

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -39,7 +39,7 @@ except NameError:
 
 DEFAULT_GALLERY_CONF = {
     'filename_pattern': re.escape(os.sep) + 'plot',
-    'ignore_pattern': '__init__\.py',
+    'ignore_pattern': r'__init__\.py',
     'examples_dirs': os.path.join('..', 'examples'),
     'subsection_order': None,
     'within_subsection_order': NumberOfCodeLinesSortKey,
@@ -435,7 +435,10 @@ def setup(app):
     for key in ['plot_gallery', 'abort_on_example_error']:
         app.add_config_value(key, get_default_config_value(key), 'html')
 
-    app.add_stylesheet('gallery.css')
+    try:
+        app.add_css_file('gallery.css')
+    except AttributeError:  # Sphinx < 1.8
+        app.add_stylesheet('gallery.css')
 
     # Sphinx < 1.6 calls it `_extensions`, >= 1.6 is `extensions`.
     extensions_attr = '_extensions' if hasattr(

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -407,10 +407,11 @@ def _get_memory_base(gallery_conf):
     else:
         # There might be a cleaner way to do this at some point
         from memory_profiler import memory_usage
+        sleep, timeout = (1, 2) if sys.platform == 'win32' else (0.5, 1)
         proc = subprocess.Popen(
             [sys.executable, '-c',
-             'import time, sys; time.sleep(0.5), sys.exit(1)'])
-        memory_base = max(memory_usage(proc, interval=1e-3, timeout=1.))
+             'import time, sys; time.sleep(%s), sys.exit(0)' % sleep])
+        memory_base = max(memory_usage(proc, interval=1e-3, timeout=timeout))
     return memory_base
 
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -407,9 +407,10 @@ def _get_memory_base(gallery_conf):
     else:
         # There might be a cleaner way to do this at some point
         from memory_profiler import memory_usage
-        proc = subprocess.Popen([sys.executable, '-c',
-                                 'import time; time.sleep(1.0)'])
-        memory_base = max(memory_usage(proc, interval=1e-3, timeout=0.1))
+        proc = subprocess.Popen(
+            [sys.executable, '-c',
+             'import time, sys; time.sleep(0.5), sys.exit(1)'])
+        memory_base = max(memory_usage(proc, interval=1e-3, timeout=1.))
     return memory_base
 
 


### PR DESCRIPTION
As I was eradicating warnings during sphinx builds for MNE, I came across a DeprecationWarning and a warning about `\`. This fixes those.