### PR TITLE
FIX: Bump version

### DIFF
--- a/sphinx_gallery/__init__.py
+++ b/sphinx_gallery/__init__.py
@@ -4,7 +4,7 @@ Sphinx Gallery
 
 """
 import os
-__version__ = '0.2.0'
+__version__ = '0.3.dev0'
 
 
 def glr_path_static():


### PR DESCRIPTION
We should have bumped to 0.3.dev0 immediately after pushing 0.2.0 out the door in June.