### PR TITLE
MRG: Fix for latest pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ norecursedirs = build _build auto_examples gen_modules
 filterwarnings =
     ignore:.*HasTraits.trait_.*:DeprecationWarning
     ignore:np.loads is deprecated, use pickle.loads instead:DeprecationWarning
+    ignore:'U' mode is deprecated:DeprecationWarning
 
 [build_sphinx]
 source-dir = doc/

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -108,12 +108,12 @@ def extract_object_names_from_docs(filename):
     text = split_code_and_text_blocks(filename)[1]
     text = '\n'.join(t[1] for t in text if t[0] == 'text')
     regex = re.compile(r':(?:'
-                       'func(?:tion)?|'
-                       'meth(?:od)?|'
-                       'attr(?:ibute)?|'
-                       'obj(?:ect)?|'
-                       'class):`(\S*)`')
-
+                       r'func(?:tion)?|'
+                       r'meth(?:od)?|'
+                       r'attr(?:ibute)?|'
+                       r'obj(?:ect)?|'
+                       r'class):`(\S*)`'
+                       )
     return [(x, x) for x in re.findall(regex, text)]
 
 

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -28,7 +28,10 @@ from sphinx_gallery.utils import _TempDir
 
 @pytest.fixture
 def conf_file(request):
-    env = request.node.get_marker('conf_file')
+    try:
+        env = request.node.get_closest_marker('conf_file')
+    except AttributeError:  # old pytest
+        env = request.node.get_marker('conf_file')
     kwargs = env.kwargs if env else {}
     result = {
         'content': "",


### PR DESCRIPTION
On the latest `master` run we got:
```
E       RemovedInPytest4Warning: MarkInfo objects are deprecated as they contain merged marks which are hard to deal with correctly.
E       Please use node.get_closest_marker(name) or node.iter_markers(name).
E       Docs: https://docs.pytest.org/en/latest/mark.html#updating-code
```
i.e., we get a DeprecationWarning from pytest. This works around it.

We also get warnings from `Sphinx` about `'U'` mode, which we can safely ignore.

Will merge once CIs are happy to keep things green.