### PR TITLE
FIX: correct sorting docstring for the FileNameSortKey class

### DIFF
--- a/sphinx_gallery/sorting.py
+++ b/sphinx_gallery/sorting.py
@@ -91,7 +91,7 @@ class FileSizeSortKey(_SortKey):
 
 
 class FileNameSortKey(_SortKey):
-    """Sort examples in src_dir by file size.
+    """Sort examples in src_dir by file name.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR solves the copy-pasted docstring for the [`FileNameSortKey`](https://sphinx-gallery.readthedocs.io/en/latest/gen_modules/sphinx_gallery.sorting.html#sphinx_gallery.sorting.FileNameSortKey) class.