### PR TITLE
adding notes for filename

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -81,6 +81,11 @@ Keep in mind that both lists have to be of the same length.
 Parsing and executing examples based on matching patterns
 =========================================================
 
+.. note::
+
+   Sphinx-Gallery will only run files that begin with `plot_` by default. See below for
+   instructions on how to modify this behavior.
+
 By default, Sphinx-Gallery will **parse and add** all files with a ``.py``
 extension to the gallery. To ignore some files and omit them from the gallery
 entirely, you can use a regular expression (the default is shown here)::

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -78,48 +78,47 @@ Keep in mind that both lists have to be of the same length.
 
 .. _build_pattern:
 
-Parsing and executing examples based on matching patterns
-=========================================================
-
-.. note::
-
-   Sphinx-Gallery will only run files that begin with `plot_` by default. See below for
-   instructions on how to modify this behavior.
+Parsing and executing examples via matching patterns
+====================================================
 
 By default, Sphinx-Gallery will **parse and add** all files with a ``.py``
-extension to the gallery. To ignore some files and omit them from the gallery
-entirely, you can use a regular expression (the default is shown here)::
+extension to the gallery, but only **execute** files beginning with ``plot_``.
+These behaviors are controlled by the ``ignore_pattern`` and ``filename_pattern``
+entries, which have the default values::
 
     sphinx_gallery_conf = {
         ...
-        'ignore_pattern': '__init__\.py',
+        'filename_pattern': '/plot_',
+        'ignore_pattern': r'__init__\.py',
     }
 
-Of the files that get **parsed and added** to the gallery, by default
-Sphinx-Gallery only **executes** files whose name begins with ``plot``.
-However, if this naming convention does not suit your project, you can modify
-the pattern of filenames to build in your Sphinx ``conf.py``. For example::
+To omit some files from the gallery entirely (i.e., not execute, parse, or
+add them), you can change the ``ignore_pattern`` option.
+To choose which of the parsed and added Python scripts are actualy
+executed, you can modify ``filename_pattern``. For example::
 
     sphinx_gallery_conf = {
         ...
         'filename_pattern': '/plot_compute_',
     }
 
-will build all examples starting with ``plot_compute_``. The key ``filename_pattern`` accepts
-`regular expressions`_ which will be matched with the full path of the example. This is the reason
-the leading ``'/'`` is required. Users are advised to use ``os.sep`` instead of ``'/'`` if
-they want to be agnostic to the operating system.
+will build all examples starting with ``plot_compute_``. The key
+``filename_pattern`` (and ``ignore_pattern``) accepts `regular expressions`_
+which will be matched with the full path of the example. This is the reason
+the leading ``'/'`` is required. Users are advised to use ``re.escape(os.sep)``
+instead of ``'/'`` if they want to be agnostic to the operating system.
 
-This option is also useful if you want to build only a subset of the examples. For example, you may
+The ``filename_pattern`` option is also useful if you want to build only a
+subset of the examples. For example, you may
 want to build only one example so that you can link it in the documentation. In that case,
 you would do::
 
     sphinx_gallery_conf = {
         ...
-        'filename_pattern': 'plot_awesome_example\.py',
+        'filename_pattern': r'plot_awesome_example\.py',
     }
 
-Here, one should escape the dot ``'\.'`` as otherwise python `regular expressions`_ matches any character. Nevertheless, as
+Here, one should escape the dot ``r'\.'`` as otherwise python `regular expressions`_ matches any character. Nevertheless, as
 one is targeting a specific file, it would match the dot in the filename even without this escape character.
 
 Similarly, to build only examples in a specific directory, you can do::

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -51,7 +51,7 @@ Structure the examples folder
 
 .. note::
 
-   Sphinx-Gallery will only run files that begin with `plot_` by default. For
+   Sphinx-Gallery will only run files that begin with ``plot_`` by default. For
    instructions on how to modify this behavior, see :ref:`build_pattern`.
 
 In order for Sphinx-Gallery to build a gallery from your ``examples`` folder,
@@ -69,7 +69,7 @@ this folder must have the following things:
 * **Example Python Scripts**: A collection of Python scripts that will be
   processed when you build your HTML documentation.  For information on how
   to structure these Python scripts with embedded rST, see
-  :ref:`python_script_syntax`. By default files prefixed with ``plot``
+  :ref:`python_script_syntax`. By default files prefixed with ``plot_``
   will be executed and their outputs captured to incorporate them in the
   HTML version of the script. Files without that prefix will be only parsed
   and presented in a rich literate programming fashion, without any output.
@@ -107,10 +107,8 @@ relative to ``conf.py`` (``../examples``) as well as the location of the
 directory to be generated when your gallery is built (``auto_examples``).::
 
     sphinx_gallery_conf = {
-         # path to your examples scripts
-         'examples_dirs': '../examples',
-         # path where to save gallery generated examples
-         'gallery_dirs': 'auto_examples',
+         'examples_dirs': '../examples',   # path to your example scripts
+         'gallery_dirs': 'auto_examples',  # path where to save gallery generated examples
     }
 
 After building your documentation, ``gallery_dirs`` will contain rST files

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -49,6 +49,11 @@ cover next.
 Structure the examples folder
 -----------------------------
 
+.. note::
+
+   Sphinx-Gallery will only run files that begin with `plot_` by default. For
+   instructions on how to modify this behavior, see :ref:`build_pattern`.
+
 In order for Sphinx-Gallery to build a gallery from your ``examples`` folder,
 this folder must have the following things:
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -58,6 +58,7 @@ DEFAULT_GALLERY_CONF = {
     'abort_on_example_error': False,
     'failing_examples': {},
     'passing_examples': [],
+    'stale_examples': [],  # ones that did not need to be run due to md5sum
     'expected_failing_examples': set(),
     'thumbnail_size': (400, 280),  # Default CSS does 0.4 scaling (160, 112)
     'min_reported_time': 0,
@@ -438,13 +439,18 @@ def summarize_failing_examples(app, exception):
     # standard message
     n_good = len(gallery_conf['passing_examples'])
     n_tot = len(gallery_conf['failing_examples']) + n_good
-    logger.info('\nSuccessfully executed %d out of %d example '
+    n_stale = len(gallery_conf['stale_examples'])
+    logger.info('\nSphinx-gallery successfully executed %d out of %d '
                 'file%s subselected by:\n\n'
                 '    gallery_conf["filename_pattern"] = %r\n'
                 '    gallery_conf["ignore_pattern"]   = %r\n'
+                '\nafter excluding %d file%s that had previously been run '
+                '(based on MD5).\n'
                 % (n_good, n_tot, 's' if n_tot != 1 else '',
                    gallery_conf['filename_pattern'],
-                   gallery_conf['ignore_pattern']),
+                   gallery_conf['ignore_pattern'],
+                   n_stale, 's' if n_stale != 1 else '',
+                   ),
                 color='brown')
 
     if fail_msgs:

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -57,6 +57,7 @@ DEFAULT_GALLERY_CONF = {
     'download_all_examples': True,
     'abort_on_example_error': False,
     'failing_examples': {},
+    'passing_examples': [],
     'expected_failing_examples': set(),
     'thumbnail_size': (400, 280),  # Default CSS does 0.4 scaling (160, 112)
     'min_reported_time': 0,
@@ -390,6 +391,8 @@ def summarize_failing_examples(app, exception):
 
     # Under no-plot Examples are not run so nothing to summarize
     if not app.config.sphinx_gallery_conf['plot_gallery']:
+        logger.info('Sphinx-gallery gallery_conf["plot_gallery"] was '
+                    'False, so no examples were executed.', color='brown')
         return
 
     gallery_conf = app.config.sphinx_gallery_conf
@@ -403,8 +406,10 @@ def summarize_failing_examples(app, exception):
     if examples_expected_to_fail:
         logger.info("Examples failing as expected:", color='brown')
         for fail_example in examples_expected_to_fail:
-            logger.info('%s failed leaving traceback:', fail_example)
-            logger.info(gallery_conf['failing_examples'][fail_example])
+            logger.info('%s failed leaving traceback:', fail_example,
+                        color='brown')
+            logger.info(gallery_conf['failing_examples'][fail_example],
+                        color='brown')
 
     examples_not_expected_to_fail = failing_examples.difference(
         expected_failing_examples)
@@ -429,6 +434,18 @@ def summarize_failing_examples(app, exception):
                          "sphinx_gallery_conf['expected_failing_examples']\n" +
                          "in your conf.py file"
                          "\n".join(examples_not_expected_to_pass))
+
+    # standard message
+    n_good = len(gallery_conf['passing_examples'])
+    n_tot = len(gallery_conf['failing_examples']) + n_good
+    logger.info('\nSuccessfully executed %d out of %d example '
+                'file%s subselected by:\n\n'
+                '    gallery_conf["filename_pattern"] = %r\n'
+                '    gallery_conf["ignore_pattern"]   = %r\n'
+                % (n_good, n_tot, 's' if n_tot != 1 else '',
+                   gallery_conf['filename_pattern'],
+                   gallery_conf['ignore_pattern']),
+                color='brown')
 
     if fail_msgs:
         raise ValueError("Here is a summary of the problems encountered when "

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -618,7 +618,11 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
     intro, _ = extract_intro_and_title(fname,
                                        get_docstring_and_rest(src_file)[0])
 
+    executable = executable_script(src_file, gallery_conf)
+
     if md5sum_is_current(target_file):
+        if executable:
+            gallery_conf['stale_examples'].append(target_file)
         return intro, 0
 
     image_dir = os.path.join(target_dir, 'images')
@@ -630,7 +634,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
     image_path_template = os.path.join(image_dir, image_fname)
 
     script_vars = {
-        'execute_script': executable_script(src_file, gallery_conf),
+        'execute_script': executable,
         'image_path_iterator': ImagePathIterator(image_path_template),
         'src_file': src_file,
         'target_file': target_file}

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -581,10 +581,11 @@ def execute_script(script_blocks, script_vars, gallery_conf):
     sys.argv = argv_orig
 
     # Write md5 checksum if the example was meant to run (no-plot
-    # shall not cache md5sum) and has build correctly
+    # shall not cache md5sum) and has built correctly
     if script_vars['execute_script']:
         with open(script_vars['target_file'] + '.md5', 'w') as file_checksum:
             file_checksum.write(get_md5sum(script_vars['target_file']))
+        gallery_conf['passing_examples'].append(script_vars['src_file'])
 
     return output_blocks, time_elapsed
 

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -59,6 +59,7 @@ class SphinxAppWrapper(object):
     sphinx.application.Application.build.
 
     """
+
     def __init__(self, srcdir, confdir, outdir, doctreedir, buildername,
                  **kwargs):
         self.srcdir = srcdir


### PR DESCRIPTION
closes https://github.com/sphinx-gallery/sphinx-gallery/issues/435

this adds some notices to the documentation to remind people that SG will
only run scripts that begin with `plot_` by default - we've had a few people
get confused because they didn't realize that this was the default behavior.

@larsoner this doesn't implement your idea of raising a warning if no
executable scripts are found, mostly because I couldn't figure out where's the
right place for that to happen in the code. If you like, feel free to push
to this PR!