### PR TITLE
Activating travis on pre-release of python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,12 @@ matrix:
     - python: "nightly"
       env: PYTHON_VERSION="nightly"
       os: linux
+      addons:
+        apt:
+          packages:
+            libblas-dev
+            liblapack-dev
+            gfortran
   allow_failures:
     - python: "nightly"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,5 +69,4 @@ script:
   - bash continuous_integration/travis/test_script.sh
 
 after_success:
-  - pip install codecov
-  - codecov
+  - bash continuous_integration/travis/after_success.sh 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: python
-sudo: false
-addons:
-  apt:
-    packages:
-    - xvfb # For mayavi headless
 
-virtualenv:
-        system_site_packages: true
+dist: xenial
+sudo: false
+
+services:
+  - xvfb # For mayavi headless
 
 matrix:
   include:
@@ -37,8 +35,15 @@ matrix:
     - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="3.6" LOCALE=C
     - os: linux
+      env: DISTRIB="conda" PYTHON_VERSION="3.7" LOCALE=C
+    - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="3.6" SPHINX_VERSION="dev"
       if: type = cron
+    - python: "nightly"
+      env: PYTHON_VERSION="nightly"
+      os: linux
+  allow_failures:
+    - python: "nightly"
 
 before_install:
   # Make sure that things work even if the locale is set to C (which
@@ -53,13 +58,6 @@ before_install:
 
 install:
   - source continuous_integration/travis/install.sh
-
-# To test the mayavi environment follow the instructions at
-# https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
 
 script:
   - bash continuous_integration/travis/test_script.sh

--- a/continuous_integration/travis/after_success.sh
+++ b/continuous_integration/travis/after_success.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# This script is meant to be called by the "after_success" step defined in
+# .travis.yml. See https://docs.travis-ci.com/ for more details.
+
+# License: 3-clause BSD
+
+if [[ "$PYTHON_VERSION" != "nightly" ]]; then
+    pip install codecov
+    codecov
+fi

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -32,6 +32,9 @@ if [ "$DISTRIB" == "conda" ]; then
     else
         pip install "https://api.github.com/repos/sphinx-doc/sphinx/zipball/master"
     fi
+elif [ "$PYTHON_VERSION" == "nightly" ]; then
+    # Python nightly requires to use the virtual env provided by travis.
+    pip install -r requirements.txt | cat
 elif [ "$DISTRIB" == "ubuntu" ]; then
     # Use a separate virtual environment than the one provided by
     # Travis because it contains numpy and we want to use numpy

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -36,6 +36,8 @@ elif [ "$PYTHON_VERSION" == "nightly" ]; then
     # Python nightly requires to use the virtual env provided by travis.
     pip install numpy scipy
     pip install -r requirements.txt | cat
+    pip install seaborn sphinx==1.5.5 pytest "six>=1.10.0" pytest-cov sphinx_rtd_theme
+
 elif [ "$DISTRIB" == "ubuntu" ]; then
     # Use a separate virtual environment than the one provided by
     # Travis because it contains numpy and we want to use numpy

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -42,6 +42,7 @@ elif [ "$DISTRIB" == "ubuntu" ]; then
     deactivate
     virtualenv --system-site-packages testvenv
     source testvenv/bin/activate
+    pip install --upgrade pip setuptools wheel pyopenssl
     pip install -U requests[security]  # ensure SSL certificate works
     pip install "tornado<5"
     # The pipe just gets rid of the progress bars

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -34,6 +34,7 @@ if [ "$DISTRIB" == "conda" ]; then
     fi
 elif [ "$PYTHON_VERSION" == "nightly" ]; then
     # Python nightly requires to use the virtual env provided by travis.
+    pip install numpy scipy
     pip install -r requirements.txt | cat
 elif [ "$DISTRIB" == "ubuntu" ]; then
     # Use a separate virtual environment than the one provided by


### PR DESCRIPTION
Activating travis on 3.7 and nightly build of latest dev (with allowed failure, currently python 3.8 which is in pre-release, and apparently breaks sphinx-gallery (unchecked)).