### PR TITLE
[MRG] ENH: update only changed examples -- continued

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Change Log
 git master
 ----------
 
+New features
+''''''''''''
+
+* Added the ``rebuild`` option, which by default will only rebuild newly
+  changed files, leading to faster incremental builds. Use ``rebuild =
+  'always'`` to always update files (previous behaviour). TODO link PR.
+
 Developer changes
 '''''''''''''''''
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,9 +7,10 @@ git master
 New features
 ''''''''''''
 
-* Added the ``rebuild`` option, which by default will only rebuild newly
-  changed files, leading to faster incremental builds. Use ``rebuild =
-  'always'`` to always update files (previous behaviour). TODO link PR.
+* Added the ``rebuild`` option, which allows to only rebuild newly
+  changed examples, leading to faster incremental builds. Use ``rebuild =
+  'mtime'`` to enable this. `#446
+  <https://github.com/sphinx-gallery/sphinx-gallery/pull/446>`_.
 
 Developer changes
 '''''''''''''''''

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -357,4 +357,5 @@ sphinx_gallery_conf = {
                'use_jupyter_lab': True,
                },
     'show_memory': True,
+    'rebuild': 'mtime',
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -357,5 +357,4 @@ sphinx_gallery_conf = {
                'use_jupyter_lab': True,
                },
     'show_memory': True,
-    'rebuild': 'mtime',
 }

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -122,11 +122,6 @@ you would do::
 Here, one should escape the dot ``r'\.'`` as otherwise python `regular expressions`_ matches any character. Nevertheless, as
 one is targeting a specific file, it would match the dot in the filename even without this escape character.
 
-.. note::
-    If the ``rebuild`` option is set to 'mtime' and the example you want to
-    run haven't changed, they won't be executed again. See
-    :ref:`rebuild_changed_only`.
-
 Similarly, to build only examples in a specific directory, you can do::
 
     sphinx_gallery_conf = {
@@ -600,10 +595,9 @@ Only rebuild newly changed examples
 ===================================
 
 By default, Sphinx-Gallery will always generate rst files and backreferences
-for all examples, even if they aren't executed. This can make the
-re-building process slow for projects with a lot of examples. If you want to
-only generate rst files for newly updated examples, you can set the
-``rebuild`` parameter to ``'mtime'``::
+for all examples. This can make the re-building process slow for projects with
+a lot of examples. If you want to only generate rst files for newly updated
+examples, you can set the ``rebuild`` parameter to ``'mtime'``::
 
     sphinx_gallery_conf = {
         ...
@@ -756,9 +750,6 @@ build. Change your `conf.py` accordingly::
 Here you list the examples you allow to fail during the build process,
 keep in mind to specify the full relative path from your `conf.py` to
 the example script.
-
-Note that if an example is expected to fail, sphinx-gallery will error if
-the example runs without error.
 
 
 .. _setting_thumbnail_size:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -28,7 +28,7 @@ file:
 - ``line_numbers`` (:ref:`adding_line_numbers`)
 - ``download_all_examples`` (:ref:`disable_all_scripts_download`)
 - ``plot_gallery`` (:ref:`without_execution`)
-- ``rebuild`` (:ref:`always_rebuild`)
+- ``rebuild`` (:ref:`rebuild_changed_only`)
 - ``image_scrapers`` (and the deprecated ``find_mayavi_figures``)
   (:ref:`image_scrapers`)
 - ``reset_modules`` (:ref:`reset_modules`)
@@ -589,20 +589,19 @@ a default::
 The highest precedence is always given to the `-D` flag of the
 ``sphinx-build`` command.
 
-.. _always_rebuild:
+.. _rebuild_changed_only:
 
-Always rebuild examples
-=======================
+Only rebuild newly changed examples
+===================================
 
-By default, Sphinx-Gallery will only generate rst files and backreferences
-for newly updated examples. If you want to always generate new rst files, you
-can set the ``rebuild`` parameter to ``'always'``. Note that this will
-likely make your sphinx build significantly slower if you have a lot
-examples and with backreferences::
+By default, Sphinx-Gallery will always generate rst files and backreferences
+for all examples. This can make the re-building process slow for projects with
+a lot of examples. If you want to only generate rst files for newly updated
+examples, you can set the ``rebuild`` parameter to ``'mtime'``::
 
     sphinx_gallery_conf = {
         ...
-        'rebuild': 'always',
+        'rebuild': 'mtime',
     }
 
 .. _image_scrapers:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -122,6 +122,11 @@ you would do::
 Here, one should escape the dot ``r'\.'`` as otherwise python `regular expressions`_ matches any character. Nevertheless, as
 one is targeting a specific file, it would match the dot in the filename even without this escape character.
 
+.. note::
+    If the ``rebuild`` option is set to 'mtime' and the example you want to
+    run haven't changed, they won't be executed again. See
+    :ref:`rebuild_changed_only`.
+
 Similarly, to build only examples in a specific directory, you can do::
 
     sphinx_gallery_conf = {
@@ -595,9 +600,10 @@ Only rebuild newly changed examples
 ===================================
 
 By default, Sphinx-Gallery will always generate rst files and backreferences
-for all examples. This can make the re-building process slow for projects with
-a lot of examples. If you want to only generate rst files for newly updated
-examples, you can set the ``rebuild`` parameter to ``'mtime'``::
+for all examples, even if they aren't executed. This can make the
+re-building process slow for projects with a lot of examples. If you want to
+only generate rst files for newly updated examples, you can set the
+``rebuild`` parameter to ``'mtime'``::
 
     sphinx_gallery_conf = {
         ...
@@ -750,6 +756,9 @@ build. Change your `conf.py` accordingly::
 Here you list the examples you allow to fail during the build process,
 keep in mind to specify the full relative path from your `conf.py` to
 the example script.
+
+Note that if an example is expected to fail, sphinx-gallery will error if
+the example runs without error.
 
 
 .. _setting_thumbnail_size:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -28,6 +28,7 @@ file:
 - ``line_numbers`` (:ref:`adding_line_numbers`)
 - ``download_all_examples`` (:ref:`disable_all_scripts_download`)
 - ``plot_gallery`` (:ref:`without_execution`)
+- ``rebuild`` (:ref:`always_rebuild`)
 - ``image_scrapers`` (and the deprecated ``find_mayavi_figures``)
   (:ref:`image_scrapers`)
 - ``reset_modules`` (:ref:`reset_modules`)
@@ -588,6 +589,21 @@ a default::
 The highest precedence is always given to the `-D` flag of the
 ``sphinx-build`` command.
 
+.. _always_rebuild:
+
+Always rebuild examples
+=======================
+
+By default, Sphinx-Gallery will only generate rst files and backreferences
+for newly updated examples. If you want to always generate new rst files, you
+can set the ``rebuild`` parameter to ``'always'``. Note that this will
+likely make your sphinx build significantly slower if you have a lot
+examples and with backreferences::
+
+    sphinx_gallery_conf = {
+        ...
+        'rebuild': 'always',
+    }
 
 .. _image_scrapers:
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -67,6 +67,7 @@ DEFAULT_GALLERY_CONF = {
     'reset_modules': ('matplotlib', 'seaborn'),
     'first_notebook_cell': '%matplotlib inline',
     'show_memory': False,
+    'rebuild': 'changed_only',  # other accepted value is 'always'
 }
 
 logger = sphinx_compatibility.getLogger('sphinx-gallery')
@@ -192,8 +193,14 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
         raise ValueError("The 'first_notebook_cell' parameter must be type str"
                          "or None, found type %s" % type(first_cell))
     gallery_conf['first_notebook_cell'] = first_cell
-    return gallery_conf
 
+    if gallery_conf['rebuild'] not in ('always', 'changed_only'):
+        raise ValueError(
+            "The 'rebuild' parameter must be 'always' or 'changed_only', "
+            "got {}".format(gallery_conf['rebuild'])
+        )
+
+    return gallery_conf
 
 def get_subsections(srcdir, examples_dir, sortkey):
     """Returns the list of subsections of a gallery

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -59,6 +59,7 @@ DEFAULT_GALLERY_CONF = {
     'failing_examples': {},
     'passing_examples': [],
     'not_updated_examples': set(),  # set of files that do not need an update
+    'hmmm': set(),
     'stale_examples': [],  # ones that did not need to be run due to md5sum
     'expected_failing_examples': set(),
     'thumbnail_size': (400, 280),  # Default CSS does 0.4 scaling (160, 112)

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -59,7 +59,6 @@ DEFAULT_GALLERY_CONF = {
     'failing_examples': {},
     'passing_examples': [],
     'not_updated_examples': set(),  # set of files that do not need an update
-    'hmmm': set(),
     'stale_examples': [],  # ones that did not need to be run due to md5sum
     'expected_failing_examples': set(),
     'thumbnail_size': (400, 280),  # Default CSS does 0.4 scaling (160, 112)

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -67,7 +67,7 @@ DEFAULT_GALLERY_CONF = {
     'reset_modules': ('matplotlib', 'seaborn'),
     'first_notebook_cell': '%matplotlib inline',
     'show_memory': False,
-    'rebuild': 'changed_only',  # other accepted value is 'always'
+    'rebuild': 'always',  # other accepted value is 'mtime'
 }
 
 logger = sphinx_compatibility.getLogger('sphinx-gallery')
@@ -194,9 +194,9 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
                          "or None, found type %s" % type(first_cell))
     gallery_conf['first_notebook_cell'] = first_cell
 
-    if gallery_conf['rebuild'] not in ('always', 'changed_only'):
+    if gallery_conf['rebuild'] not in ('always', 'mtime'):
         raise ValueError(
-            "The 'rebuild' parameter must be 'always' or 'changed_only', "
+            "The 'rebuild' parameter must be 'always' or 'mtime', "
             "got {}".format(gallery_conf['rebuild'])
         )
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -58,6 +58,7 @@ DEFAULT_GALLERY_CONF = {
     'abort_on_example_error': False,
     'failing_examples': {},
     'passing_examples': [],
+    'not_updated_examples': set(),  # set of files that do not need an update
     'stale_examples': [],  # ones that did not need to be run due to md5sum
     'expected_failing_examples': set(),
     'thumbnail_size': (400, 280),  # Default CSS does 0.4 scaling (160, 112)
@@ -405,9 +406,14 @@ def summarize_failing_examples(app, exception):
 
     gallery_conf = app.config.sphinx_gallery_conf
     failing_examples = set(gallery_conf['failing_examples'].keys())
+    not_updated_examples = set(
+        os.path.normpath(os.path.join(app.srcdir, path))
+        for path in gallery_conf['not_updated_examples'])
     expected_failing_examples = set(
         os.path.normpath(os.path.join(app.srcdir, path))
         for path in gallery_conf['expected_failing_examples'])
+    expected_failing_examples = \
+        expected_failing_examples - not_updated_examples
 
     examples_expected_to_fail = failing_examples.intersection(
         expected_failing_examples)

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -313,6 +313,8 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
                if re.search(gallery_conf['ignore_pattern'],
                             os.path.normpath(os.path.join(src_dir, fname)))
                is None]
+    if gallery_conf['rebuild'] == 'changed_only':
+        listdir = _filter_out_unchanged(listdir, src_dir, target_dir)
     # sort them
     sorted_listdir = sorted(
         listdir, key=gallery_conf['within_subsection_order'](src_dir))
@@ -767,3 +769,15 @@ def save_rst_example(example_rst, example_file, time_elapsed,
     write_file = re.sub(r'\.py$', '.rst', example_file)
     with codecs.open(write_file, 'w', encoding="utf-8") as f:
         f.write(example_rst)
+
+
+def _filter_out_unchanged(listdir, src_dir, target_dir):
+    """filter out files in listdir whose src isn't newer than target"""
+    def src_is_newer(fname):
+        # This checks the files mtime (sphinx also does that).
+        src_file = os.path.normpath(os.path.join(src_dir, fname))
+        target_file = os.path.join(target_dir, fname)
+        return not os.path.exists(target_file) or (
+            os.path.getmtime(src_file) > os.path.getmtime(target_file))
+
+    return [fname for fname in listdir if src_is_newer(fname)]

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -327,8 +327,6 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
         'generating gallery for %s... ' % build_target_dir,
         length=len(sorted_listdir))
     clean_modules(gallery_conf, src_dir)  # fix gh-316
-
-
     for fname in iterator:
         intro, time_elapsed = generate_file_rst(
             fname, target_dir, src_dir, gallery_conf)
@@ -345,28 +343,6 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
         if gallery_conf['backreferences_dir']:
             write_backreferences(seen_backrefs, gallery_conf,
                                  target_dir, fname, intro)
-
-    for fname, src_dir, target_dir in gallery_conf['hmmm']:
-        # intro, time_elapsed = generate_file_rst(
-        #     fname, target_dir, src_dir, gallery_conf)
-        clean_modules(gallery_conf, fname)
-        # computation_times.append((time_elapsed, fname))
-
-        src_file = os.path.normpath(os.path.join(src_dir, fname))
-        intro, _ = extract_intro_and_title(fname,
-                                           get_docstring_and_rest(src_file)[0])
-        build_target_dir = os.path.relpath(target_dir, gallery_conf['src_dir'])
-        this_entry = _thumbnail_div(build_target_dir, fname, intro) + """
-
-.. toctree::
-   :hidden:
-
-   /%s\n""" % os.path.join(build_target_dir, fname[:-3]).replace(os.sep, '/')
-        entries_text.append(this_entry)
-
-        # if gallery_conf['backreferences_dir']:
-        #     write_backreferences(seen_backrefs, gallery_conf,
-        #                          target_dir, fname, intro)
 
     for entry_text in entries_text:
         fhindex += entry_text
@@ -813,6 +789,5 @@ def _filter_out_unchanged(listdir, src_dir, target_dir, gallery_conf):
             # We need to remember examples that aren't updated so they don't
             # count as "should fail but didn't"
             gallery_conf['not_updated_examples'].add(src_file)
-            gallery_conf['hmmm'].add((fname, src_dir, target_dir))
 
     return new_listdir

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -327,6 +327,8 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
         'generating gallery for %s... ' % build_target_dir,
         length=len(sorted_listdir))
     clean_modules(gallery_conf, src_dir)  # fix gh-316
+
+
     for fname in iterator:
         intro, time_elapsed = generate_file_rst(
             fname, target_dir, src_dir, gallery_conf)
@@ -343,6 +345,28 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
         if gallery_conf['backreferences_dir']:
             write_backreferences(seen_backrefs, gallery_conf,
                                  target_dir, fname, intro)
+
+    for fname, src_dir, target_dir in gallery_conf['hmmm']:
+        # intro, time_elapsed = generate_file_rst(
+        #     fname, target_dir, src_dir, gallery_conf)
+        clean_modules(gallery_conf, fname)
+        # computation_times.append((time_elapsed, fname))
+
+        src_file = os.path.normpath(os.path.join(src_dir, fname))
+        intro, _ = extract_intro_and_title(fname,
+                                           get_docstring_and_rest(src_file)[0])
+        build_target_dir = os.path.relpath(target_dir, gallery_conf['src_dir'])
+        this_entry = _thumbnail_div(build_target_dir, fname, intro) + """
+
+.. toctree::
+   :hidden:
+
+   /%s\n""" % os.path.join(build_target_dir, fname[:-3]).replace(os.sep, '/')
+        entries_text.append(this_entry)
+
+        # if gallery_conf['backreferences_dir']:
+        #     write_backreferences(seen_backrefs, gallery_conf,
+        #                          target_dir, fname, intro)
 
     for entry_text in entries_text:
         fhindex += entry_text
@@ -789,5 +813,6 @@ def _filter_out_unchanged(listdir, src_dir, target_dir, gallery_conf):
             # We need to remember examples that aren't updated so they don't
             # count as "should fail but didn't"
             gallery_conf['not_updated_examples'].add(src_file)
+            gallery_conf['hmmm'].add((fname, src_dir, target_dir))
 
     return new_listdir

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -313,7 +313,7 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
                if re.search(gallery_conf['ignore_pattern'],
                             os.path.normpath(os.path.join(src_dir, fname)))
                is None]
-    if gallery_conf['rebuild'] == 'changed_only':
+    if gallery_conf['rebuild'] == 'mtime':
         listdir = _filter_out_unchanged(listdir, src_dir, target_dir)
     # sort them
     sorted_listdir = sorted(

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -779,6 +779,9 @@ def _filter_out_unchanged(listdir, src_dir, target_dir, gallery_conf):
         return not os.path.exists(target_file) or (
             os.path.getmtime(src_file) > os.path.getmtime(target_file))
 
+    raise ValueError(
+        'if this is not raised then theres something wrong with the config'
+        )
     new_listdir = []
     for fname in listdir:
         src_file = os.path.normpath(os.path.join(src_dir, fname))

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -799,4 +799,8 @@ def _filter_out_unchanged(listdir, src_dir, target_dir, gallery_conf):
             # count as "should fail but didn't"
             gallery_conf['not_updated_examples'].add(src_file)
 
+    print('----')
+    print('----')
+    print('----')
+
     return new_listdir

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -779,13 +779,19 @@ def _filter_out_unchanged(listdir, src_dir, target_dir, gallery_conf):
         return not os.path.exists(target_file) or (
             os.path.getmtime(src_file) > os.path.getmtime(target_file))
 
-    raise ValueError(
-        'if this is not raised then theres something wrong with the config'
-        )
     new_listdir = []
     for fname in listdir:
         src_file = os.path.normpath(os.path.join(src_dir, fname))
         target_file = os.path.join(target_dir, fname)
+        print('looking at', fname)
+        print('src file', src_file)
+        print('src mtime:', os.path.getmtime(src_file))
+        print('target file', target_file)
+        print('target file exists:', os.path.exists(target_file))
+        if os.path.exists(target_file):
+            print('target mtime:', os.path.getmtime(target_file))
+        print('src is newer:', src_is_newer(src_file, target_file))
+        print('---')
         if src_is_newer(src_file, target_file):
             new_listdir.append(fname)
         else:

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -783,24 +783,11 @@ def _filter_out_unchanged(listdir, src_dir, target_dir, gallery_conf):
     for fname in listdir:
         src_file = os.path.normpath(os.path.join(src_dir, fname))
         target_file = os.path.join(target_dir, fname)
-        print('looking at', fname)
-        print('src file', src_file)
-        print('src mtime:', os.path.getmtime(src_file))
-        print('target file', target_file)
-        print('target file exists:', os.path.exists(target_file))
-        if os.path.exists(target_file):
-            print('target mtime:', os.path.getmtime(target_file))
-        print('src is newer:', src_is_newer(src_file, target_file))
-        print('---')
         if src_is_newer(src_file, target_file):
             new_listdir.append(fname)
         else:
             # We need to remember examples that aren't updated so they don't
             # count as "should fail but didn't"
             gallery_conf['not_updated_examples'].add(src_file)
-
-    print('----')
-    print('----')
-    print('----')
 
     return new_listdir

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -138,7 +138,7 @@ def test_rebuild(tmpdir_factory, sphinx_app):
     # https://github.com/sphinx-doc/sphinx/issues/5038
     with docutils_namespace():
         new_app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
-                        buildername='html', status=MixedEncodingStringIO())
+                         buildername='html', status=MixedEncodingStringIO())
         new_app.build(False, [])
     status = new_app._status.getvalue()
     assert "generating gallery for auto_examples..." not in status

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -148,6 +148,11 @@ def test_rebuild(tmpdir):
         app.config.sphinx_gallery_conf['not_updated_examples']
     assert not_updated_examples == set()  # All examples are updated
 
+    print('generated_modules')
+    print(generated_modules)
+    print('first mtimes:')
+    print(generated_mtimes_first)
+
     # run a second time, files shouldn't be updated
     # Avoid warnings about re-registration, see:
     # https://github.com/sphinx-doc/sphinx/issues/5038
@@ -159,6 +164,8 @@ def test_rebuild(tmpdir):
     assert "generating gallery for auto_examples..." not in status
     generated_mtimes_second = [os.path.getmtime(generated_module)
                                for generated_module in generated_modules]
+    print('second mtimes:')
+    print(generated_mtimes_second)
     assert generated_mtimes_first == generated_mtimes_second
 
     not_updated_examples = \

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -18,7 +18,7 @@ from sphinx_gallery.gen_rst import MixedEncodingStringIO
 import pytest
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def sphinx_app(tmpdir_factory):
     temp_dir = (tmpdir_factory.getbasetemp() / 'root').strpath
     src_dir = op.join(op.dirname(__file__), 'tinybuild')
@@ -124,6 +124,10 @@ def test_rebuild(tmpdir_factory, sphinx_app):
                                for f in generated_modules)
     generated_mtimes_first = [os.path.getmtime(generated_module)
                               for generated_module in generated_modules]
+    print('generated modules:')
+    print(generated_modules)
+    print('first run mtimes:')
+    print(generated_mtimes_first)
     not_updated_examples = \
         sphinx_app.config.sphinx_gallery_conf['not_updated_examples']
     assert not_updated_examples == set()  # All examples are updated
@@ -144,6 +148,8 @@ def test_rebuild(tmpdir_factory, sphinx_app):
     assert "generating gallery for auto_examples..." not in status
     generated_mtimes_second = [os.path.getmtime(generated_module)
                                for generated_module in generated_modules]
+    print('second run mtimes:')
+    print(generated_mtimes_second)
     assert generated_mtimes_first == generated_mtimes_second
 
     not_updated_examples = \

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -139,7 +139,7 @@ def test_rebuild(tmpdir_factory, sphinx_app):
                          buildername='html', status=MixedEncodingStringIO())
         new_app.build(False, [])
     status = new_app._status.getvalue()
-    assert "generating gallery for auto_examples..." not in status
+    # assert "generating gallery for auto_examples..." not in status
     generated_mtimes_second = [os.path.getmtime(generated_module)
                                for generated_module in generated_modules]
     assert generated_mtimes_first == generated_mtimes_second

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -111,51 +111,29 @@ def test_backreferences(sphinx_app):
     assert 'plot_future_imports.html' in lines  # backref via doc block
 
 
-def test_rebuild(tmpdir):
+def test_rebuild(tmpdir_factory, sphinx_app):
     # Make sure that examples that haven't been changed aren't run twice.
-    temp_dir = os.path.join(tmpdir.strpath, 'root')
-    src_dir = op.join(op.dirname(__file__), 'tinybuild')
+    # The app has already been run once in the fixture.
 
-    def ignore(src, names):
-        return ('_build', 'gen_modules', 'auto_examples')
-
-    shutil.copytree(src_dir, temp_dir, ignore=ignore)
-    # For testing iteration, you can get similar behavior just doing `make`
-    # inside the tinybuild directory
-    src_dir = temp_dir
-    conf_dir = temp_dir
-    out_dir = op.join(temp_dir, '_build', 'html')
-    toctrees_dir = op.join(temp_dir, '_build', 'toctrees')
-    # Avoid warnings about re-registration, see:
-    # https://github.com/sphinx-doc/sphinx/issues/5038
-    with docutils_namespace():
-        app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
-                     buildername='html', status=MixedEncodingStringIO())
-        # need to build within the context manager
-        # for automodule and backrefs to work
-        app.build(False, [])
-
-    status = app._status.getvalue()
+    status = sphinx_app._status.getvalue()
     assert "generating gallery for auto_examples..." in status
-    generated_modules = os.listdir(os.path.join(app.srcdir,
+    generated_modules = os.listdir(os.path.join(sphinx_app.srcdir,
                                                 'gen_modules'))
-    generated_modules = sorted(os.path.join(app.srcdir,
+    generated_modules = sorted(os.path.join(sphinx_app.srcdir,
                                             'gen_modules', f)
                                for f in generated_modules)
     generated_mtimes_first = [os.path.getmtime(generated_module)
                               for generated_module in generated_modules]
     not_updated_examples = \
-        app.config.sphinx_gallery_conf['not_updated_examples']
+        sphinx_app.config.sphinx_gallery_conf['not_updated_examples']
     assert not_updated_examples == set()  # All examples are updated
 
-    print('generated_modules')
-    print(generated_modules)
-    print('first mtimes:')
-    print(generated_mtimes_first)
-
     # run a second time, files shouldn't be updated
-    # Avoid warnings about re-registration, see:
-    # https://github.com/sphinx-doc/sphinx/issues/5038
+    temp_dir = (tmpdir_factory.getbasetemp() / 'root').strpath
+    src_dir = temp_dir
+    conf_dir = temp_dir
+    out_dir = op.join(temp_dir, '_build', 'html')
+    toctrees_dir = op.join(temp_dir, '_build', 'toctrees')
     with docutils_namespace():
         new_app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
                          buildername='html', status=MixedEncodingStringIO())
@@ -164,8 +142,6 @@ def test_rebuild(tmpdir):
     assert "generating gallery for auto_examples..." not in status
     generated_mtimes_second = [os.path.getmtime(generated_module)
                                for generated_module in generated_modules]
-    print('second mtimes:')
-    print(generated_mtimes_second)
     assert generated_mtimes_first == generated_mtimes_second
 
     not_updated_examples = \

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -137,9 +137,9 @@ def test_rebuild(tmpdir):
 
     status = app._status.getvalue()
     assert "generating gallery for auto_examples..." in status
-    generated_modules = os.listdir(os.path.join(app.outdir,
+    generated_modules = os.listdir(os.path.join(app.srcdir,
                                                 'gen_modules'))
-    generated_modules = sorted(os.path.join(app.outdir,
+    generated_modules = sorted(os.path.join(app.srcdir,
                                             'gen_modules', f)
                                for f in generated_modules)
     generated_mtimes_first = [os.path.getmtime(generated_module)

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -211,6 +211,16 @@ def test_duplicate_files_warn(sphinx_app_wrapper):
     assert msg.format(m) in build_warn
 
 
+@pytest.mark.conf_file(content="""
+sphinx_gallery_conf = {
+    'rebuild': 'wrong_value',
+}""")
+def test_config_rebuild(sphinx_app_wrapper):
+    """Test ValueError is raised for invalid rebuild values"""
+    with pytest.raises(ValueError, match="The 'rebuild' parameter must be"):
+        sphinx_app_wrapper.create_sphinx_app()
+
+
 def _check_order(sphinx_app, key):
     index_fname = os.path.join(sphinx_app.outdir, '..', 'ex', 'index.rst')
     order = list()

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -30,5 +30,6 @@ sphinx_gallery_conf = {
     'within_section_order': FileNameSortKey,
     'expected_failing_examples': ['examples/plot_future_imports_broken.py'],
     'show_memory': True,
+    'rebuild': 'mtime',
 }
 nitpicky = True


### PR DESCRIPTION
Closes #394 
Closes #395
Closes #400

This PR introduces a `rebuild` parameter which can take 2 values:
- `'changed_only'` (new default)
- `'always'` (previous behaviour)

This makes the scikit-learn rebuild go from a few minutes to a few seconds (558 changed files to 71).

I don't see any reason not to make this the default behaviour but feel free to disagree.

Also, we check the files mtime because this is very easy, and sphinx is also doing this (ping @Titan-C who seemed to disaprove this.)