### PR TITLE
MAINT: Drop 3.4, add mayavi to one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,9 @@ matrix:
       env: DISTRIB="conda" PYTHON_VERSION="2.7" INSTALL_MAYAVI="true"
     # This environment tests the Python 3 versions
     - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="3.4"
-    - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="3.5"
     - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="3.6"
+      env: DISTRIB="conda" PYTHON_VERSION="3.6" INSTALL_MAYAVI="true"
     - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="2.7" LOCALE=C
     - os: linux
@@ -71,4 +69,4 @@ script:
   - bash continuous_integration/travis/test_script.sh
 
 after_success:
-  - bash continuous_integration/travis/after_success.sh 
+  - bash continuous_integration/travis/after_success.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,18 @@ matrix:
             - python-pandas
     # This environment tests is for mayavi
     - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="2.7" INSTALL_MAYAVI="true"
+      env: DISTRIB="conda" PYTHON_VERSION="2.7" CONDA_PKGS="mayavi"
     # This environment tests the Python 3 versions
     - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="3.5"
     - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="3.6" INSTALL_MAYAVI="true"
+      env: DISTRIB="conda" PYTHON_VERSION="3.6"
     - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="2.7" LOCALE=C
     - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="3.6" LOCALE=C
     - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="3.7" LOCALE=C
+      env: DISTRIB="conda" PYTHON_VERSION="3.7" LOCALE=C PIP_PKGS="vtk mayavi"
     - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="3.6" SPHINX_VERSION="dev"
       if: type = cron

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -16,13 +16,12 @@ if [ "$DISTRIB" == "conda" ]; then
     conda update -y conda
 
     # Force conda to think about other dependencies that can break
-    export CONDA_PKGS="python=$PYTHON_VERSION pip numpy scipy setuptools matplotlib pillow pytest pytest-cov coverage seaborn sphinx_rtd_theme memory_profiler"
-    if [ "$INSTALL_MAYAVI" == "true" ]; then
-        conda create -yn testenv $CONDA_PKGS mayavi
-    else
-        conda create -yn testenv $CONDA_PKGS
-    fi
+    export CONDA_PKGS="python=$PYTHON_VERSION pip numpy scipy setuptools matplotlib pillow pytest pytest-cov coverage seaborn sphinx_rtd_theme memory_profiler $CONDA_PKGS"
+    conda create -yn testenv $CONDA_PKGS
     source activate testenv
+    if [[ ! -z "$PIP_PKGS" ]]; then
+        pip install -q $PIP_PKGS
+    fi
     # The 3.4 on is quite old
     if [ "$PYTHON_VERSION" == "3.4" ]; then
         conda remove -y memory_profiler


### PR DESCRIPTION
Python 3.4 reaches EOL in a few weeks, and it would be good to use Mayavi on a Py3k run.