### PR TITLE
BUG: Fix execution time writing

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -359,7 +359,7 @@ def write_computation_times(gallery_conf, target_dir, computation_times):
         # sort by time (descending) then alphabetical
         for ct in sorted(computation_times, key=lambda x: (-x[0], x[1])):
             example_link = 'sphx_glr_%s_%s' % (target_dir_clean, ct[1])
-            fid.write(u'- **{0}**: :ref:`{2}` ({1})\n'.format(
+            fid.write(u'- **{0}**: :ref:`{2}` (``{1}``)\n'.format(
                 _sec_to_readable(ct[0]), ct[1], example_link))
 
 


### PR DESCRIPTION
Tiny bugfix for names that can end in underscores like `my_example_.py`, which can cause RST parsing problems. Fix it by rendering it as code (which looks better anyway IMO).

@drammock can you see if this fixes your problem with names that end in underscores in MNE?