### PR TITLE
MAINT: Simplify CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,19 +40,9 @@ jobs:
       - run: python setup.py build_sphinx
       - store_artifacts:
           path: doc/_build/html/
-          destination: html
+          destination: rtd_html
       - store_test_results:
           path: doc/_build/html/
-
-      - run: SPHX_GLR_THEME=rtd sphinx-build doc rtd_html
-      - store_artifacts:
-          path: rtd_html
-          destination: rtd_html
-
-      - run: SPHX_GLR_THEME=alabaster sphinx-build doc alabaster_html
-      - store_artifacts:
-          path: alabaster_html
-          destination: alabaster_html
 
       - run: sphinx-build sphinx_gallery/tests/tinybuild/ tiny_html
       - store_artifacts:
@@ -65,7 +55,7 @@ jobs:
           destination: latex
 
       - persist_to_workspace:
-          root: rtd_html
+          root: doc/_build/html
           paths: .
 
   deploy_docs:

--- a/sphinx_gallery/__init__.py
+++ b/sphinx_gallery/__init__.py
@@ -4,7 +4,7 @@ Sphinx Gallery
 
 """
 import os
-__version__ = '0.3.1'
+__version__ = '0.4.0.dev0'
 
 
 def glr_path_static():


### PR DESCRIPTION
Instead of building multiple styles that we don't use (see #461), let's just build the one that we do.

Also bump version to `0.4.0.dev0`