### PR TITLE
FIX: Minor fixes for memory profiling

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -131,7 +131,7 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
         try:
             from memory_profiler import memory_usage  # noqa, analysis:ignore
         except ImportError:
-            logger.warning("Please install 'memory_profile' to enable peak "
+            logger.warning("Please install 'memory_profiler' to enable peak "
                            "memory measurements.")
             gallery_conf['show_memory'] = False
     gallery_conf['memory_base'] = _get_memory_base(gallery_conf)

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -406,8 +406,13 @@ def _get_memory_base(gallery_conf):
         sleep, timeout = (1, 2) if sys.platform == 'win32' else (0.5, 1)
         proc = subprocess.Popen(
             [sys.executable, '-c',
-             'import time, sys; time.sleep(%s), sys.exit(0)' % sleep])
-        memory_base = max(memory_usage(proc, interval=1e-3, timeout=timeout))
+             'import time, sys; time.sleep(%s); sys.exit(0)' % sleep],
+            close_fds=True)
+        memories = memory_usage(proc, interval=1e-3, timeout=timeout)
+        proc.communicate(timeout=timeout)
+        # On OSX sometimes the last entry can be None
+        memories = [mem for mem in memories if mem is not None] + [0.]
+        memory_base = max(memories)
     return memory_base
 
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -409,7 +409,8 @@ def _get_memory_base(gallery_conf):
              'import time, sys; time.sleep(%s); sys.exit(0)' % sleep],
             close_fds=True)
         memories = memory_usage(proc, interval=1e-3, timeout=timeout)
-        proc.communicate(timeout=timeout)
+        kwargs = dict(timeout=timeout) if sys.version_info >= (3, 5) else {}
+        proc.communicate(**kwargs)
         # On OSX sometimes the last entry can be None
         memories = [mem for mem in memories if mem is not None] + [0.]
         memory_base = max(memories)


### PR DESCRIPTION
When building the MNE doc on OSX I sometimes got:
```
  File "/Users/larsoner/python/sphinx-gallery/sphinx_gallery/gen_rst.py", line 410, in _get_memory_base
    memory_base = max(memory_usage(proc, interval=1e-3, timeout=timeout))
TypeError: '>' not supported between instances of 'NoneType' and 'float'

Exception occurred:
  File "/Users/larsoner/python/sphinx-gallery/sphinx_gallery/gen_rst.py", line 410, in _get_memory_base
    memory_base = max(memory_usage(proc, interval=1e-3, timeout=timeout))
TypeError: '>' not supported between instances of 'NoneType' and 'float'
```
It turns out sometimes the last entry in the list returned by `memory_usage` was `None`, so now we cull that from the list. It's difficult to write a test for this, so no new test has been added.

Once it worked, sometimes I would get a warning about unclosed file descriptors, so I added `close_fds=True` to `Popen`. Once we are Py3k-only, we can use `Popen` as a context manager, too, which will be nice.

Also fixes a typo where we recommend `memory_profile` instead of `memory_profiler`.