### PR TITLE
Fix ReST block after docstring

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -714,7 +714,8 @@ def rst_blocks(script_blocks, output_blocks, file_conf, gallery_conf):
                     example_rst += "\n\n|\n\n"
                 example_rst += code_rst
         else:
-            example_rst += bcontent + '\n'
+            block_separator = '\n\n' if not bcontent.endswith('\n') else '\n'
+            example_rst += bcontent + block_separator
     return example_rst
 
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -97,6 +97,41 @@ def test_direct_comment_after_docstring():
     assert result == expected_result
 
 
+def test_rst_block_after_docstring(gallery_conf, tmpdir):
+    """Assert there is a blank line between the docstring and rst blocks."""
+    filename = str(tmpdir.join('temp.py'))
+    with open(filename, 'w') as f:
+        f.write('\n'.join(['"Docstring"',
+                           '####################',
+                           '# Paragraph 1',
+                           '',
+                           '####################',
+                           '# Paragraph 2',
+                           '']))
+    file_conf, blocks = sg.split_code_and_text_blocks(filename)
+
+    assert file_conf == {}
+    assert blocks[0][0] == 'text'
+    assert blocks[1][0] == 'text'
+    assert blocks[2][0] == 'text'
+
+    script_vars = {'execute_script': ''}
+
+    output_blocks, time_elapsed = sg.execute_script(blocks,
+                                                    script_vars,
+                                                    gallery_conf)
+
+    example_rst = sg.rst_blocks(blocks, output_blocks, file_conf, gallery_conf)
+    assert example_rst == '\n'.join([
+        'Docstring',
+        '',
+        'Paragraph 1',
+        '',
+        'Paragraph 2',
+        '',
+        ''])
+
+
 def test_codestr2rst():
     """Test the correct translation of a code block into rst"""
     output = sg.codestr2rst('print("hello world")')


### PR DESCRIPTION
Fixes #473.

I'm not sure if there is some assumption on the termination of `bcontent`. Text blocks from rST seem to already end with a newline, docstrings don't. This patch does not rely on any assumption and generates correct rST for both cases.

The test seems a bit longish, But I would like to test the full source to rST code conversion. Just creating blocks manually and passing them to `rst_blocks()` seems a bit fragile, because the code is sensitive to newlines at the end. OTOH calling `generate_file_rst()` seems too broad since it generates a lot more stuff like the thumbnail and writes everything to files. Please advise if I should modify the test.