### PR TITLE
Fix 'Out:' label position in html output block

### DIFF
--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -83,10 +83,13 @@ thumbnail with its default link Background color */
   color: #888;
   margin: 0;
 }
+p.sphx-glr-script-out {
+    padding-top: 0.7em;
+}
 .sphx-glr-script-out .highlight {
   background-color: transparent;
   margin-left: 2.5em;
-  margin-top: -1.4em;
+  margin-top: -2.1em;
 }
 .sphx-glr-script-out .highlight pre {
   background-color: #fafae2;


### PR DESCRIPTION
Previously the 'Out:' label was aligned at the top of the block and not with the first line.

This results in an awkward appearance in particular for single line output:

![grafik](https://user-images.githubusercontent.com/2836374/57022573-dab3f400-6c2f-11e9-9ebf-846474b7bff1.png)

![grafik](https://user-images.githubusercontent.com/2836374/57022606-f28b7800-6c2f-11e9-9628-fc6bcdbf22e3.png)

This PR fixes this:

![grafik](https://user-images.githubusercontent.com/2836374/57022640-08993880-6c30-11e9-93a9-f059f52a695f.png)

![grafik](https://user-images.githubusercontent.com/2836374/57022650-1353cd80-6c30-11e9-916e-74a75a9720b6.png)

### Explanation

The layout appears to be a bit of a hack anyway because the rST code is

~~~
 Out:

 .. code-block:: none

{0}\n
~~~

So 'Out:' is its own paragraph that would naturally appear above the code. The margin shifting in `.sphx-glr-script-out .highlight` puts it back up. I've shifted the output text down by 0.7em and conversely shifted the code back up by the same amount because it's relative to the Out-paragraph. Effectively, the code stays in the same position, only the Out text is rendered a bit lower.

