### PR TITLE
Add option to remove sphinx_gallery config comments

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -438,7 +438,7 @@ Removing config comments
 ========================
 
 Some configurations can be done on a file-by-file basis by adding a special
-comment with the pattern ``# sphinx_gallery_[config] = [value]`` to the
+comment with the pattern :samp:`# sphinx_gallery_{config} = {value}` to the
 example source files. By default, the source files are parsed as is and thus
 the comment will appear in the example.
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -26,6 +26,7 @@ file:
 - ``default_thumb_file`` (:ref:`custom_default_thumb`)
 - ``thumbnail_size`` (:ref:`setting_thumbnail_size`)
 - ``line_numbers`` (:ref:`adding_line_numbers`)
+- ``remove_config_comments`` (:ref:`removing_config_comments`)
 - ``download_all_examples`` (:ref:`disable_all_scripts_download`)
 - ``plot_gallery`` (:ref:`without_execution`)
 - ``image_scrapers`` (and the deprecated ``find_mayavi_figures``)
@@ -44,6 +45,9 @@ Some options can also be set or overridden on a file-by-file basis:
 
 - ``# sphinx_gallery_line_numbers`` (:ref:`adding_line_numbers`)
 - ``# sphinx_gallery_thumbnail_number`` (:ref:`choosing_thumbnail`)
+
+See also :ref:`removing_config_comments` to hide these comments from the
+rendered examples.
 
 Some options can be set during the build execution step, e.g. using a Makefile:
 
@@ -428,6 +432,22 @@ setting::
 Note that for Sphinx < 1.3, the line numbers will not be consistent with the
 original file.
 
+.. _removing_config_comments
+
+Removing config comments
+========================
+
+Some configurations can be done on a file-by-file basis by adding a special
+comment with the pattern ``# sphinx_gallery_[config] = [value]`` to the
+example source files. By default, the source files are parsed as is and thus
+the comment will appear in the example.
+
+To remove the comment from the rendered example set the option::
+
+    sphinx_gallery_conf = {
+        ...
+        'remove_config_comments': True,
+    }
 
 .. _first_notebook_cell:
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -70,6 +70,7 @@ DEFAULT_GALLERY_CONF = {
     'image_scrapers': ('matplotlib',),
     'reset_modules': ('matplotlib', 'seaborn'),
     'first_notebook_cell': '%matplotlib inline',
+    'remove_config_comments': False,
     'show_memory': False,
     'junit': '',
     'log_level': {'backreference_missing': 'warning'},

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -61,7 +61,7 @@ from . import sphinx_compatibility
 from .backreferences import write_backreferences, _thumbnail_div
 from .downloads import CODE_DOWNLOAD
 from .py_source_parser import (split_code_and_text_blocks,
-                               get_docstring_and_rest)
+                               get_docstring_and_rest, remove_config_comments)
 
 from .notebook import jupyter_notebook, save_notebook
 from .binder import check_binder_conf, gen_binder_rst
@@ -642,6 +642,14 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
         'target_file': target_file}
 
     file_conf, script_blocks = split_code_and_text_blocks(src_file)
+
+    if gallery_conf['remove_config_comments']:
+        script_blocks = [
+            (label, remove_config_comments(content), line_number)
+            for label, content, line_number in script_blocks
+        ]
+
+
     output_blocks, time_elapsed = execute_script(script_blocks,
                                                  script_vars,
                                                  gallery_conf)

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -36,6 +36,7 @@ CONTENT = [
     'And this is a second paragraph',
     '"""',
     '',
+    '# sphinx_gallery_thumbnail_number = 1'
     '# and now comes the module code',
     'import logging',
     'import sys',
@@ -247,6 +248,53 @@ def test_fail_example(gallery_conf, log_collector):
             raise ValueError('Did not stop executing script after error')
 
 
+def _generate_rst(gallery_conf, fname, content):
+    """
+    Helper function returning the rst text a given example content.
+
+    This writes a file gallery_conf['examples_dir']/fname with *content*,
+    creates the corresponding rst file by running generate_file_rst() and
+    returns the generated rest code.
+
+    Parameters
+    ----------
+    gallery_conf
+        A gallery_conf as cerated by the gallery_conf fixture.
+    fname : str
+        A filename; e.g. 'test.py'. This is relative to
+        gallery_conf['examples_dir']
+    content : str
+        The content of fname.
+
+    Returns
+    -------
+    rst : str
+        The generated rst code.
+    """
+    with codecs.open(os.path.join(gallery_conf['examples_dir'], fname),
+                     mode='w', encoding='utf-8') as f:
+        f.write('\n'.join(content))
+    # generate rst file
+    sg.generate_file_rst(fname, gallery_conf['gallery_dir'],
+                         gallery_conf['examples_dir'], gallery_conf)
+    # read rst file and check if it contains code output
+    rst_fname = os.path.splitext(fname)[0] + '.rst'
+    with codecs.open(os.path.join(gallery_conf['gallery_dir'], rst_fname),
+                     mode='r', encoding='utf-8') as f:
+        rst = f.read()
+    return rst
+
+
+def test_remove_config_comments(gallery_conf):
+    """Test the gallery_conf['remove_config_comments'] setting."""
+    rst = _generate_rst(gallery_conf, 'test.py', CONTENT)
+    assert '# sphinx_gallery_thumbnail_number = 1' in rst
+
+    gallery_conf['remove_config_comments'] = True
+    rst = _generate_rst(gallery_conf, 'test.py', CONTENT)
+    assert '# sphinx_gallery_thumbnail_number = 1' not in rst
+
+
 def test_gen_dir_rst(gallery_conf, fakesphinxapp):
     """Test gen_dir_rst."""
     print(os.listdir(gallery_conf['examples_dir']))
@@ -273,17 +321,8 @@ def test_pattern_matching(gallery_conf, log_collector):
     # create three files in tempdir (only one matches the pattern)
     fnames = ['plot_0.py', 'plot_1.py', 'plot_2.py']
     for fname in fnames:
-        with codecs.open(os.path.join(gallery_conf['examples_dir'], fname),
-                         mode='w', encoding='utf-8') as f:
-            f.write('\n'.join(CONTENT))
-        # generate rst file
-        sg.generate_file_rst(fname, gallery_conf['gallery_dir'],
-                             gallery_conf['examples_dir'], gallery_conf)
-        # read rst file and check if it contains code output
+        rst = _generate_rst(gallery_conf, fname, CONTENT)
         rst_fname = os.path.splitext(fname)[0] + '.rst'
-        with codecs.open(os.path.join(gallery_conf['gallery_dir'], rst_fname),
-                         mode='r', encoding='utf-8') as f:
-            rst = f.read()
         if re.search(gallery_conf['filename_pattern'],
                      os.path.join(gallery_conf['gallery_dir'], rst_fname)):
             assert code_output in rst

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -254,7 +254,7 @@ def _generate_rst(gallery_conf, fname, content):
 
     This writes a file gallery_conf['examples_dir']/fname with *content*,
     creates the corresponding rst file by running generate_file_rst() and
-    returns the generated rest code.
+    returns the generated rST code.
 
     Parameters
     ----------

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -259,7 +259,7 @@ def _generate_rst(gallery_conf, fname, content):
     Parameters
     ----------
     gallery_conf
-        A gallery_conf as cerated by the gallery_conf fixture.
+        A gallery_conf as created by the gallery_conf fixture.
     fname : str
         A filename; e.g. 'test.py'. This is relative to
         gallery_conf['examples_dir']

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -269,7 +269,7 @@ def _generate_rst(gallery_conf, fname, content):
     Returns
     -------
     rst : str
-        The generated rst code.
+        The generated rST code.
     """
     with codecs.open(os.path.join(gallery_conf['examples_dir'], fname),
                      mode='w', encoding='utf-8') as f:

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -250,7 +250,7 @@ def test_fail_example(gallery_conf, log_collector):
 
 def _generate_rst(gallery_conf, fname, content):
     """
-    Helper function returning the rst text a given example content.
+    Helper function returning the rST text of a given example content.
 
     This writes a file gallery_conf['examples_dir']/fname with *content*,
     creates the corresponding rst file by running generate_file_rst() and

--- a/sphinx_gallery/tests/test_py_source_parser.py
+++ b/sphinx_gallery/tests/test_py_source_parser.py
@@ -41,3 +41,25 @@ def test_get_docstring_and_rest(unicode_sample, tmpdir):
 ])
 def test_extract_file_config(content, file_conf):
     assert sg.extract_file_config(content) == file_conf
+
+
+@pytest.mark.parametrize('contents, result', [
+    ("No config\nin here.",
+     "No config\nin here."),
+    ("# sphinx_gallery_line_numbers = True",
+     ""),
+    ("  #   sphinx_gallery_line_numbers   =   True   ",
+     ""),
+    ("#sphinx_gallery_line_numbers=True",
+     ""),
+    ("#sphinx_gallery_thumbnail_number\n=\n5",
+     ""),
+    ("a = 1\n# sphinx_gallery_line_numbers = True\nb = 1",
+     "a = 1\nb = 1"),
+    ("a = 1\n\n# sphinx_gallery_line_numbers = True\n\nb = 1",
+     "a = 1\n\n\nb = 1"),
+    ("# comment\n# sphinx_gallery_line_numbers = True\n# commment 2",
+     "# comment\n# commment 2"),
+])
+def test_remove_config_comments(contents, result):
+    assert sg.remove_config_comments(contents) == result

--- a/sphinx_gallery/tests/test_py_source_parser.py
+++ b/sphinx_gallery/tests/test_py_source_parser.py
@@ -25,3 +25,19 @@ def test_get_docstring_and_rest(unicode_sample, tmpdir):
         fid.write('print("hello")\n')
     with pytest.raises(ValueError, match='Could not find docstring'):
         sg.get_docstring_and_rest(fname)
+
+
+@pytest.mark.parametrize('content, file_conf', [
+    ("No config\nin here.",
+     {}),
+    ("# sphinx_gallery_line_numbers = True",
+     {'line_numbers': True}),
+    ("  #   sphinx_gallery_line_numbers   =   True   ",
+     {'line_numbers': True}),
+    ("#sphinx_gallery_line_numbers=True",
+     {'line_numbers': True}),
+    ("#sphinx_gallery_thumbnail_number\n=\n5",
+     {'thumbnail_number': 5}),
+])
+def test_extract_file_config(content, file_conf):
+    assert sg.extract_file_config(content) == file_conf


### PR DESCRIPTION
The in-file comments `# sphinx_gallery_line_numbers` and `# sphinx_gallery_thumbnail_number` are meant to control sphinx gallery behavior. They have any meaning for the reader of the generated example.

This PR introduces the option `remove_config_comments` (default False, corresponding to the current behavior), which allows to remove these comments from the rendered example.

Closes #481.