### PR TITLE
Add list of external image scrapers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,11 @@ Sphinx-Gallery has also support for packages like:
 * Seaborn
 * Mayavi
 
+Other packages that maintain their own Sphinx-Gallery image scrapers include:
+
+* `PyVista <https://github.com/pyvista/pyvista>`_
+* `PyGMT <https://github.com/GenericMappingTools/pygmt>`_
+
 Install as a developer
 ----------------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -62,6 +62,12 @@ Sphinx-Gallery has also support for packages like:
 * Seaborn
 * Mayavi
 
+Other packages that maintain their own Sphinx-Gallery image scrapers include:
+
+* `PyVista <https://github.com/pyvista/pyvista>`_
+* `PyGMT <https://github.com/GenericMappingTools/pygmt>`_
+
+
 Install as a developer
 ----------------------
 


### PR DESCRIPTION
I think it would be useful to start a list of image scrapers that are maintained by external projects. This helps new users realize that they can use this power tool in their own projects when leveraging plotting libraries other the Matplotlib and Mayavi.

I also think that as this tools becomes more widely adopted that plenty of other plotting libraries will maintain their own image scrapers. Sphinx-Gallery should let the world know what plotting tools are supporting this project so more projects can leverage this new way of showing examples