### PR TITLE
MRG, ENH: Catch and write warnings

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -379,16 +379,13 @@ def handle_exception(exc_info, src_file, script_vars, gallery_conf):
 
 # Adapted from github.com/python/cpython/blob/3.7/Lib/warnings.py
 def _showwarning(message, category, filename, lineno, file=None, line=None):
-    msg = warnings.WarningMessage(
-        message, category, filename, lineno, file, line)
-    file = msg.file
     if file is None:
         file = sys.stderr
         if file is None:
             # sys.stderr is None when run with pythonw.exe:
             # warnings get lost
             return
-    text = warnings._formatwarnmsg(msg)
+    text = warnings.formatwarning(message, category, filename, lineno, line)
     try:
         file.write(text)
     except OSError:

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -207,6 +207,12 @@ def test_embed_links_and_styles(sphinx_app):
         rst = fid.read()
     assert '.. code-block:: python3\n' in rst
 
+    # warnings
+    want_warn = ('plot_numpy_matplotlib.py:31: RuntimeWarning: This'
+                 ' warning should show up in the output')
+    assert want_warn in lines
+    sys.stdout.write(lines)
+
 
 def test_backreferences(sphinx_app):
     """Test backreferences."""

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -40,6 +40,7 @@ CONTENT = [
     '# and now comes the module code',
     'import logging',
     'import sys',
+    'from warnings import warn',
     'x, y = 1, 2',
     'print(u"Óscar output") # need some code output',
     'logger = logging.getLogger()',
@@ -49,6 +50,7 @@ CONTENT = [
     'logger.addHandler(lh)',
     'logger.info(u"Óscar")',
     'print(r"$\\langle n_\\uparrow n_\\downarrow \\rangle$")',
+    'warn("WarningsAbound", RuntimeWarning)',
 ]
 
 
@@ -316,8 +318,9 @@ def test_pattern_matching(gallery_conf, log_collector):
                    '\n'
                    '    Óscar output\n'
                    '    log:Óscar\n'
-                   '    $\\langle n_\\uparrow n_\\downarrow \\rangle$\n\n'
+                   '    $\\langle n_\\uparrow n_\\downarrow \\rangle$'
                    )
+    warn_output = 'RuntimeWarning: WarningsAbound'
     # create three files in tempdir (only one matches the pattern)
     fnames = ['plot_0.py', 'plot_1.py', 'plot_2.py']
     for fname in fnames:
@@ -326,8 +329,10 @@ def test_pattern_matching(gallery_conf, log_collector):
         if re.search(gallery_conf['filename_pattern'],
                      os.path.join(gallery_conf['gallery_dir'], rst_fname)):
             assert code_output in rst
+            assert warn_output in rst
         else:
             assert code_output not in rst
+            assert warn_output not in rst
 
 
 @pytest.mark.parametrize('test_str', [
@@ -388,7 +393,7 @@ def test_rst_example(gallery_conf):
 def test_output_indentation(gallery_conf):
     """Test whether indentation of code output is retained."""
     compiler = codeop.Compile()
-    
+
     test_string = r"\n".join([
         "  A B",
         "A 1 2",

--- a/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
@@ -9,6 +9,8 @@ Use :mod:`sphinx_gallery` to link to other packages, like
 FYI this gallery uses :obj:`sphinx_gallery.sorting.FileNameSortKey`.
 """
 
+from warnings import warn
+
 import numpy as np
 from matplotlib.colors import is_color_like
 import matplotlib
@@ -26,3 +28,4 @@ orig_dpi = 80. if matplotlib.__version__[0] < '2' else 100.
 assert plt.rcParams['figure.dpi'] == orig_dpi
 plt.rcParams['figure.dpi'] = 70.
 assert plt.rcParams['figure.dpi'] == 70.
+warn('This warning should show up in the output', RuntimeWarning)


### PR DESCRIPTION
Closes #491.

It wasn't as simple as just overriding `sys.stderr` (which I did do), I also had to monkey-patch `warnings.showwarning` to use the default implementation, presumably because something else (Sphinx probably?) was overriding it already. This monkey patches it only during code execution, which seems like the right thing to do.

@drammock can you see if this fixes your problem? No config change should be necessary.