### PR TITLE
add link to view sourcecode in docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,6 +35,7 @@ from sphinx_gallery.sorting import ExplicitOrder, NumberOfCodeLinesSortKey
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',


### PR DESCRIPTION
Adding the [viewcode](https://www.sphinx-doc.org/en/master/usage/extensions/viewcode.html) sphinx extension to the docs build of sphinx-gallery will allow users to more easily inspect the sourcecode (when reading the docs and simply clicking on a link)