### PR TITLE
fix wrong keyword in docs for "binder"

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -604,7 +604,7 @@ dictionary following the pattern below::
          # Required keys
          'org': '<github_org>',
          'repo': '<github_repo>',
-         'ref': '<ref-for-documentation>',  # Can be any branch, tag, or commit hash. Use a branch that hosts your docs.
+         'branch': '<github_branch>',  # Can be any branch, tag, or commit hash. Use a branch that hosts your docs.
          'binderhub_url': '<binder_url>',  # Any URL of a binderhub deployment. Must be full URL (e.g. https://mybinder.org).
          'dependencies': '<list_of_paths_to_dependency_files>',
          # Optional keys


### PR DESCRIPTION
see: https://github.com/sphinx-gallery/sphinx-gallery/blob/a69ad570fd175f593b428e8838e54b72211fe1af/sphinx_gallery/binder.py#L216

apparently the 'ref' keyword was used previously ... but it's now called "branch"