### PR TITLE
MAINT: Remove support for old Python and Sphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,16 @@ matrix:
             - python3-pip
             - python3-coverage
     - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="3.5" SPHINX_VERSION="1.8.3"
+      env: DISTRIB="conda" PYTHON_VERSION="3.5" SPHINX_VERSION="==1.8.3"
     - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="3.6" PIP_PKGS="vtk mayavi ipython"
+      env: DISTRIB="conda" PYTHON_VERSION="3.6"
     - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="3.6" LOCALE=C
     - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="3.7" LOCALE=C PIP_PKGS="vtk mayavi ipython"
+      env: DISTRIB="conda" PYTHON_VERSION="3.7" LOCALE=C
            SPHINXOPTS="-nWT --keep-going"
     - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="3.6" SPHINX_VERSION="dev"
-      if: type = cron
+      env: DISTRIB="conda" PYTHON_VERSION="3.7" SPHINX_VERSION="dev"
     - python: 3.7
       env: DISTRIB="minimal"
     - python: "nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,10 @@ matrix:
             - python-coverage
             - cython
             - python-pandas
-    # This environment tests is for mayavi
     - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="2.7" CONDA_PKGS="mayavi"
-    # This environment tests the Python 3 versions
+      env: DISTRIB="conda" PYTHON_VERSION="3.5" SPHINX_VERSION="==1.8.3"
     - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="3.5"
-    - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="3.6"
-    - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="2.7" LOCALE=C
+      env: DISTRIB="conda" PYTHON_VERSION="3.6" PIP_PKGS="vtk mayavi ipython"
     - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="3.6" LOCALE=C
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
             - python3-pip
             - python3-coverage
     - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="3.5" SPHINX_VERSION="==1.8.3"
+      env: DISTRIB="conda" PYTHON_VERSION="3.5" SPHINX_VERSION="1.8.3"
     - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="3.6" PIP_PKGS="vtk mayavi ipython"
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,15 @@ services:
 matrix:
   include:
     - os: linux
-      env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" SPHINXOPTS=""
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" SPHINXOPTS=""
       addons:
         apt:
           packages:
-            - python-numpy
-            - python-matplotlib
-            - python-scipy
-            - python-pip
-            - python-coverage
-            - cython
-            - python-pandas
+            - python3-numpy
+            - python3-matplotlib
+            - python3-scipy
+            - python3-pip
+            - python3-coverage
     - os: linux
       env: DISTRIB="conda" PYTHON_VERSION="3.5" SPHINX_VERSION="==1.8.3"
     - os: linux

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,20 @@ v0.4.0
 
 Developer changes
 '''''''''''''''''
+
+- N/A
+
+Incompatible changes
+''''''''''''''''''''
+
+- Dropped support for Sphinx < 1.8.3.
+- Dropped support for Python < 3.5.
+
+v0.4.0
+------
+
+Developer changes
+'''''''''''''''''
 - Added a private API contract for external scrapers to have string-based
   support, see:
 

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Who uses Sphinx-Gallery
 * `Cartopy <http://scitools.org.uk/cartopy/docs/latest/gallery/>`_
 * `PyVista <https://docs.pyvista.org/examples/>`_
 * `SimPEG <http://docs.simpeg.xyz/content/examples/>`_
-* `PlasmaPy <http://docs.plasmapy.org/en/master/auto_examples/>`_        
+* `PlasmaPy <http://docs.plasmapy.org/en/master/auto_examples/>`_
 
 Installation
 ============
@@ -54,7 +54,7 @@ Sphinx-Gallery will not manage its dependencies when installing, thus
 you are required to install them manually. Our minimal dependencies
 are:
 
-* Sphinx >= 1.5 (1.8 recommended)
+* Sphinx >= 1.8.3
 * Matplotlib
 * Pillow
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,8 +23,6 @@ install:
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "activate test"
-    - "pip install vtk"
-    - "pip install mayavi"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
     CONDA_DEPENDENCIES: "numpy seaborn matplotlib sphinx pillow pytest pytest-cov sphinx_rtd_theme vtk pyface traits traitsui ipython"
 
   matrix:
-    - PYTHON_VERSION: "2.7"
+    - PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "64"
     - PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
@@ -23,8 +23,8 @@ install:
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "activate test"
-    # mayavi only available for Python 2.7 through conda
-    - 'IF "%PYTHON_VERSION%"=="2.7" ( conda install mayavi )'
+    - "pip install vtk"
+    - "pip install mayavi"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -16,19 +16,18 @@ if [ "$DISTRIB" == "conda" ]; then
     conda update -y conda
 
     # Force conda to think about other dependencies that can break
-    export CONDA_PKGS="python=$PYTHON_VERSION pip numpy scipy setuptools matplotlib pillow pytest pytest-cov coverage seaborn memory_profiler flake8 $CONDA_PKGS"
-    conda create -yn testenv $CONDA_PKGS
+    conda create -yn testenv "python=$PYTHON_VERSION pip numpy scipy setuptools matplotlib pillow pytest pytest-cov coverage seaborn flake8 $CONDA_PKGS"
     source activate testenv
-    pip install -q $PIP_PKGS sphinx_rtd_theme
-    # The 3.4 on is quite old
-    if [ "$PYTHON_VERSION" == "3.5" ]; then
-        conda remove -y memory_profiler
+    # Optional packages
+    if [ "$PYTHON_VERSION" != "3.5" ]; then
+        pip install memory_profiler vtk mayavi ipython
     fi
     if [ "$SPHINX_VERSION" != "dev" ]; then
-        conda install "sphinx=${SPHINX_VERSION-*}" --yes
+        pip install "sphinx${SPHINX_VERSION}"
     else
         pip install "https://api.github.com/repos/sphinx-doc/sphinx/zipball/master"
     fi
+    pip install -q sphinx_rtd_theme
     python setup.py install
 elif [ "$PYTHON_VERSION" == "nightly" ]; then
     # Python nightly requires to use the virtual env provided by travis.

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -36,18 +36,9 @@ elif [ "$PYTHON_VERSION" == "nightly" ]; then
 elif [ "$DISTRIB" == "minimal" ]; then
     pip install . pytest pytest-cov
 elif [ "$DISTRIB" == "ubuntu" ]; then
-    # Use a separate virtual environment than the one provided by
-    # Travis because it contains numpy and we want to use numpy
-    # from apt-get
-    deactivate
-    virtualenv --system-site-packages testvenv
-    source testvenv/bin/activate
-    pip install --upgrade pip setuptools wheel pyopenssl
-    pip install -U requests[security]  # ensure SSL certificate works
-    # The pipe just gets rid of the progress bars
     pip install -r requirements.txt | cat
     # test show_memory=True without memory_profiler by not installing it (not in req)
-    pip install seaborn sphinx==1.5.5 pytest "six>=1.10.0" pytest-cov sphinx_rtd_theme
+    pip install seaborn sphinx==1.8.3 pytest pytest-cov sphinx_rtd_theme
     python setup.py install
 else
     echo "invalid value for DISTRIB environment variable: $DISTRIB"

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -40,7 +40,7 @@ elif [ "$DISTRIB" == "ubuntu" ]; then
     # Travis because it contains numpy and we want to use numpy
     # from apt-get
     deactivate
-    virtualenv --system-site-packages -p python$PYTHON_VERSION testvenv
+    virtualenv --system-site-packages testvenv
     source testvenv/bin/activate
     pip install --upgrade pip setuptools wheel pyopenssl
     pip install -U requests[security]  # ensure SSL certificate works

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -20,7 +20,7 @@ if [ "$DISTRIB" == "conda" ]; then
     source activate testenv
     # Optional packages
     if [ "$PYTHON_VERSION" != "3.5" ]; then
-        pip install memory_profiler vtk mayavi ipython
+        LOCALE= pip install memory_profiler vtk mayavi ipython
     fi
     if [ "$SPHINX_VERSION" != "dev" ]; then
         pip install "sphinx${SPHINX_VERSION}"

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -16,7 +16,7 @@ if [ "$DISTRIB" == "conda" ]; then
     conda update -y conda
 
     # Force conda to think about other dependencies that can break
-    conda create -yn testenv "python=$PYTHON_VERSION pip numpy scipy setuptools matplotlib pillow pytest pytest-cov coverage seaborn flake8 $CONDA_PKGS"
+    conda create -yn testenv python=$PYTHON_VERSION pip numpy scipy setuptools matplotlib pillow pytest pytest-cov coverage seaborn flake8 $CONDA_PKGS
     source activate testenv
     # Optional packages
     if [ "$PYTHON_VERSION" != "3.5" ]; then

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -20,7 +20,7 @@ if [ "$DISTRIB" == "conda" ]; then
     source activate testenv
     # Optional packages
     if [ "$PYTHON_VERSION" != "3.5" ]; then
-        LOCALE= pip install memory_profiler vtk mayavi ipython
+        LOCALE=UTF-8 pip install memory_profiler vtk mayavi ipython
     fi
     if [ "$SPHINX_VERSION" != "dev" ]; then
         pip install "sphinx${SPHINX_VERSION}"

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -19,8 +19,8 @@ if [ "$DISTRIB" == "conda" ]; then
     conda create -yn testenv python=$PYTHON_VERSION pip numpy scipy setuptools matplotlib pillow pytest pytest-cov coverage seaborn flake8 $CONDA_PKGS
     source activate testenv
     # Optional packages
-    if [ "$PYTHON_VERSION" != "3.5" ]; then
-        LOCALE=UTF-8 pip install memory_profiler vtk mayavi ipython
+    if [ "$PYTHON_VERSION" != "3.5" ] && [ "$PYTHON_VERSION" != "3.6" -o "$LOCALE" != "C" ]; then
+        pip install memory_profiler vtk mayavi ipython
     fi
     if [ "$SPHINX_VERSION" != "dev" ]; then
         pip install "sphinx${SPHINX_VERSION}"

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -38,7 +38,7 @@ elif [ "$DISTRIB" == "minimal" ]; then
 elif [ "$DISTRIB" == "ubuntu" ]; then
     pip install -r requirements.txt | cat
     # test show_memory=True without memory_profiler by not installing it (not in req)
-    pip install seaborn sphinx==1.8.3 pytest pytest-cov sphinx_rtd_theme
+    pip install seaborn sphinx==1.8.3 pytest pytest-cov sphinx_rtd_theme flake8
     python setup.py install
 else
     echo "invalid value for DISTRIB environment variable: $DISTRIB"

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -16,14 +16,14 @@ if [ "$DISTRIB" == "conda" ]; then
     conda update -y conda
 
     # Force conda to think about other dependencies that can break
-    export CONDA_PKGS="python=$PYTHON_VERSION pip numpy scipy setuptools matplotlib pillow pytest pytest-cov coverage seaborn sphinx_rtd_theme memory_profiler $CONDA_PKGS"
+    export CONDA_PKGS="python=$PYTHON_VERSION pip numpy scipy setuptools matplotlib pillow pytest pytest-cov coverage seaborn memory_profiler $CONDA_PKGS"
     conda create -yn testenv $CONDA_PKGS
     source activate testenv
     if [[ ! -z "$PIP_PKGS" ]]; then
         pip install -q $PIP_PKGS
     fi
     # The 3.4 on is quite old
-    if [ "$PYTHON_VERSION" == "3.4" ]; then
+    if [ "$PYTHON_VERSION" == "3.5" ]; then
         conda remove -y memory_profiler
     fi
     if [ "$SPHINX_VERSION" != "dev" ]; then
@@ -34,7 +34,7 @@ if [ "$DISTRIB" == "conda" ]; then
     python setup.py install
 elif [ "$PYTHON_VERSION" == "nightly" ]; then
     # Python nightly requires to use the virtual env provided by travis.
-    pip install . numpy sphinx==1.5.5 "six>=1.10.0" pytest-cov
+    pip install . numpy sphinx pytest-cov
 elif [ "$DISTRIB" == "minimal" ]; then
     pip install . pytest pytest-cov
 elif [ "$DISTRIB" == "ubuntu" ]; then

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -16,12 +16,10 @@ if [ "$DISTRIB" == "conda" ]; then
     conda update -y conda
 
     # Force conda to think about other dependencies that can break
-    export CONDA_PKGS="python=$PYTHON_VERSION pip numpy scipy setuptools matplotlib pillow pytest pytest-cov coverage seaborn memory_profiler $CONDA_PKGS"
+    export CONDA_PKGS="python=$PYTHON_VERSION pip numpy scipy setuptools matplotlib pillow pytest pytest-cov coverage seaborn memory_profiler flake8 $CONDA_PKGS"
     conda create -yn testenv $CONDA_PKGS
     source activate testenv
-    if [[ ! -z "$PIP_PKGS" ]]; then
-        pip install -q $PIP_PKGS
-    fi
+    pip install -q $PIP_PKGS sphinx_rtd_theme
     # The 3.4 on is quite old
     if [ "$PYTHON_VERSION" == "3.5" ]; then
         conda remove -y memory_profiler
@@ -42,11 +40,10 @@ elif [ "$DISTRIB" == "ubuntu" ]; then
     # Travis because it contains numpy and we want to use numpy
     # from apt-get
     deactivate
-    virtualenv --system-site-packages testvenv
+    virtualenv --system-site-packages -p python$PYTHON_VERSION testvenv
     source testvenv/bin/activate
     pip install --upgrade pip setuptools wheel pyopenssl
     pip install -U requests[security]  # ensure SSL certificate works
-    pip install "tornado<5"
     # The pipe just gets rid of the progress bars
     pip install -r requirements.txt | cat
     # test show_memory=True without memory_profiler by not installing it (not in req)

--- a/continuous_integration/travis/test_script.sh
+++ b/continuous_integration/travis/test_script.sh
@@ -11,4 +11,5 @@ cd doc
 if [ "$DISTRIB" != "minimal" ] && [ "$PYTHON_VERSION" != "nightly" ]; then
     make SPHINXOPTS= html-noplot
     make SPHINXOPTS=${SPHINXOPTS} html -j 2
+    flake8 sphinx_gallery
 fi

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -142,10 +142,7 @@ else:
 
 
 def setup(app):
-    try:
-        app.add_css_file('theme_override.css')
-    except AttributeError:
-        app.add_stylesheet('theme_override.css')
+    app.add_css_file('theme_override.css')
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -139,10 +139,10 @@ else:
     html_theme = 'default'
 
 
-
-
 def setup(app):
+    """Sphinx setup function."""
     app.add_css_file('theme_override.css')
+
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -429,9 +429,6 @@ setting::
 
     # sphinx_gallery_line_numbers = True
 
-Note that for Sphinx < 1.3, the line numbers will not be consistent with the
-original file.
-
 .. _removing_config_comments:
 
 Removing config comments

--- a/doc/maintainers.rst
+++ b/doc/maintainers.rst
@@ -97,7 +97,7 @@ Finalize the release
 
    * Go to the `Draft a new release <https://github.com/sphinx-gallery/sphinx-gallery/releases/new>`_ page.
    * The **tag version** is whatever the version is in ``__init__.py`` prepended with ``v``. E.g., ``v0.3.0``.
-   * The **release title** is ``Release: << tag-version >>``.
+   * The **release title** is ``Release << tag-version >>``.
    * The **description** should contain the markdown changelog
      you generated above (in the ``CHANGELOG.md`` file). Make sure to update any links to point
      to the tag that will be created for this release (e.g., change ``HEAD`` to ``v0.3.0``).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 setuptools
 matplotlib
 pillow
-sphinx
+sphinx>=1.8.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,8 +5,11 @@ norecursedirs = build _build auto_examples gen_modules
                 sphinx_gallery/tests/tinybuild
 filterwarnings =
     ignore:.*HasTraits.trait_.*:DeprecationWarning
+    ignore:.*importing the ABCs.*:DeprecationWarning
     ignore:np.loads is deprecated, use pickle.loads instead:DeprecationWarning
     ignore:'U' mode is deprecated:DeprecationWarning
+markers =
+    conf_file:Configuration file.
 
 [build_sphinx]
 source-dir = doc/

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     author="Óscar Nájera",
     author_email='najera.oscar@gmail.com',
     install_requires=install_requires,
+    python_requires='>=3.5',
     license='3-clause BSD',
     classifiers=['Intended Audience :: Developers',
                  'Development Status :: 4 - Beta',

--- a/sphinx_gallery/__init__.py
+++ b/sphinx_gallery/__init__.py
@@ -4,7 +4,7 @@ Sphinx Gallery
 
 """
 import os
-__version__ = '0.4.0'
+__version__ = '0.5.0.dev0'
 
 
 def glr_path_static():

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -12,27 +12,14 @@ from __future__ import print_function, unicode_literals
 import ast
 import codecs
 import collections
+from html import escape
+import pickle
 import os
 import re
 
 from . import sphinx_compatibility
 from .scrapers import _find_image_ext
 from .utils import _replace_md5
-
-# Try Python 2 first, otherwise load from Python 3
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
-# Try Python 3 first, otherwise load from Python 2
-try:
-    from html import escape
-except ImportError:
-    from functools import partial
-    from xml.sax.saxutils import escape
-
-    escape = partial(escape, entities={'"': '&quot;'})
-
 from .py_source_parser import parse_source_file, split_code_and_text_blocks
 
 

--- a/sphinx_gallery/binder.py
+++ b/sphinx_gallery/binder.py
@@ -18,12 +18,6 @@ change in the future.
 import shutil
 import os
 
-try:
-    basestring
-except NameError:
-    basestring = str
-    unicode = str
-
 from .utils import replace_py_ipynb
 from . import sphinx_compatibility
 
@@ -88,16 +82,16 @@ def gen_binder_rst(fpath, binder_conf, gallery_conf):
     binder_conf: dict or None
         If a dictionary it must have the following keys:
 
-        'binderhub_url': The URL of the BinderHub instance that's running a Binder
-            service.
-        'org': The GitHub organization to which the documentation will be
-            pushed.
-        'repo': The GitHub repository to which the documentation will be
-            pushed.
-        'branch': The Git branch on which the documentation exists (e.g.,
-            gh-pages).
-        'dependencies': A list of paths to dependency files that match the
-            Binderspec.
+        'binderhub_url'
+            The URL of the BinderHub instance that's running a Binder service.
+        'org'
+            The GitHub organization to which the documentation will be pushed.
+        'repo'
+            The GitHub repository to which the documentation will be pushed.
+        'branch'
+            The Git branch on which the documentation exists (e.g., gh-pages).
+        'dependencies'
+            A list of paths to dependency files that match the Binderspec.
 
     Returns
     -------
@@ -140,8 +134,9 @@ def _copy_binder_reqs(app, binder_conf):
     path_reqs = binder_conf.get('dependencies')
     for path in path_reqs:
         if not os.path.exists(os.path.join(app.srcdir, path)):
-            raise ValueError(("Couldn't find the Binder requirements file: {}, "
-                              "did you specify the path correctly?".format(path)))
+            raise ValueError(("Couldn't find the Binder requirements file: {},"
+                              " did you specify the path correctly?"
+                              .format(path)))
 
     binder_folder = os.path.join(app.outdir, 'binder')
     if not os.path.isdir(binder_folder):
@@ -205,13 +200,6 @@ def check_binder_conf(binder_conf):
     if len(binder_conf) == 0:
         return binder_conf
 
-    if binder_conf.get('url') and not binder_conf.get('binderhub_url'):
-        logger.warning(
-            'Found old BinderHub URL keyword ("url"). Please update your '
-            'configuration to use the new keyword ("binderhub_url"). "url" will be '
-            'deprecated in sphinx-gallery v0.4')
-        binder_conf['binderhub_url'] = binderhub_conf.get('url')
-
     # Ensure all fields are populated
     req_values = ['binderhub_url', 'org', 'repo', 'branch', 'dependencies']
     optional_values = ['filepath_prefix', 'notebooks_dir', 'use_jupyter_lab']
@@ -232,13 +220,14 @@ def check_binder_conf(binder_conf):
     if not any(binder_conf['binderhub_url'].startswith(ii)
                for ii in ['http://', 'https://']):
         raise ValueError('did not supply a valid url, '
-                         'gave binderhub_url: {}'.format(binder_conf['binderhub_url']))
+                         'gave binderhub_url: {}'
+                         .format(binder_conf['binderhub_url']))
 
     # Ensure we have at least one dependency file
     # Need at least one of these three files
     required_reqs_files = ['requirements.txt', 'environment.yml', 'Dockerfile']
     path_reqs = binder_conf['dependencies']
-    if isinstance(path_reqs, basestring):
+    if isinstance(path_reqs, str):
         path_reqs = [path_reqs]
         binder_conf['dependencies'] = path_reqs
     elif not isinstance(path_reqs, (list, tuple)):

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -8,27 +8,16 @@ Link resolver objects
 from __future__ import print_function
 import codecs
 import gzip
+from io import BytesIO
 import os
+import pickle
 import posixpath
 import re
 import shelve
 import sys
-
-# Try Python 2 first, otherwise load from Python 3
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
-try:
-    import urllib2 as urllib_request
-    from urllib2 import HTTPError, URLError
-    import urlparse as urllib_parse
-except ImportError:
-    import urllib.request as urllib_request
-    import urllib.parse as urllib_parse
-    from urllib.error import HTTPError, URLError
-
-from io import BytesIO
+import urllib.request as urllib_request
+import urllib.parse as urllib_parse
+from urllib.error import HTTPError, URLError
 
 from sphinx.search import js_index
 

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -5,7 +5,7 @@
 Link resolver objects
 =====================
 """
-from __future__ import print_function
+
 import codecs
 import gzip
 from io import BytesIO
@@ -358,9 +358,9 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
                 return str_repl[match.group()]
 
             if len(str_repl) > 0:
-                with open(full_fname, 'r') as fid:
+                with codecs.open(full_fname, 'r', 'utf-8') as fid:
                     lines_in = fid.readlines()
-                with open(full_fname, 'w') as fid:
+                with codecs.open(full_fname, 'w', 'utf-8') as fid:
                     for line in lines_in:
                         fid.write(regex.sub(substitute_link, line))
 

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -28,18 +28,16 @@ logger = sphinx_compatibility.getLogger('sphinx-gallery')
 
 
 def _get_data(url):
-    """Helper function to get data over http(s) or from a local file"""
+    """Get data over http(s) or from a local file."""
     if urllib_parse.urlparse(url).scheme in ('http', 'https'):
         resp = urllib_request.urlopen(url)
         encoding = resp.headers.get('content-encoding', 'plain')
         data = resp.read()
-        if encoding == 'plain':
-            data = data.decode('utf-8')
-        elif encoding == 'gzip':
-            data = BytesIO(data)
-            data = gzip.GzipFile(fileobj=data).read().decode('utf-8')
-        else:
-            raise RuntimeError('unknown encoding')
+        if encoding == 'gzip':
+            data = gzip.GzipFile(fileobj=BytesIO(data)).read()
+        elif encoding != 'plain':
+            raise RuntimeError('unknown encoding %r' % (encoding,))
+        data = data.decode('utf-8')
     else:
         with codecs.open(url, mode='r', encoding='utf-8') as fid:
             data = fid.read()
@@ -49,9 +47,8 @@ def _get_data(url):
 
 def get_data(url, gallery_dir):
     """Persistent dictionary usage to retrieve the search indexes"""
-
     # shelve keys need to be str in python 2
-    if sys.version_info[0] == 2 and isinstance(url, unicode):
+    if sys.version_info[0] == 2 and isinstance(url, str):
         url = url.encode('utf-8')
 
     cached_file = os.path.join(gallery_dir, 'searchindex')
@@ -148,7 +145,8 @@ class SphinxDocLinkResolver(object):
         else:
             index_url = os.path.join(doc_url, 'index.html')
             searchindex_url = os.path.join(doc_url, 'searchindex.js')
-            docopts_url = os.path.join(doc_url, '_static', 'documentation_options.js')
+            docopts_url = os.path.join(
+                doc_url, '_static', 'documentation_options.js')
 
         # detect if we are using relative links on a Windows system
         if (os.name.lower() == 'nt' and
@@ -163,9 +161,10 @@ class SphinxDocLinkResolver(object):
         # Download and find documentation options. As of Sphinx 1.7, these
         # options are now kept in a standalone file called
         # 'documentation_options.js'. Since SphinxDocLinkResolver can be called
-        # not only for the documentation which is being built but also ones that
-        # are being referenced, we need to try and get the index page first and
-        # if that doesn't work, check for the documentation_options.js file.
+        # not only for the documentation which is being built but also ones
+        # that are being referenced, we need to try and get the index page
+        # first and if that doesn't work, check for the
+        # documentation_options.js file.
         index = get_data(index_url, gallery_dir)
         if 'var DOCUMENTATION_OPTIONS' in index:
             self._docopts = parse_sphinx_docopts(index)
@@ -359,13 +358,11 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
                 return str_repl[match.group()]
 
             if len(str_repl) > 0:
-                with open(full_fname, 'rb') as fid:
+                with open(full_fname, 'r') as fid:
                     lines_in = fid.readlines()
-                with open(full_fname, 'wb') as fid:
+                with open(full_fname, 'w') as fid:
                     for line in lines_in:
-                        line = line.decode('utf-8')
-                        line = regex.sub(substitute_link, line)
-                        fid.write(line.encode('utf-8'))
+                        fid.write(regex.sub(substitute_link, line))
 
 
 def embed_code_links(app, exception):

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -14,7 +14,6 @@ from __future__ import division, print_function, absolute_import
 import codecs
 import copy
 from datetime import timedelta, datetime
-from distutils.version import LooseVersion
 from importlib import import_module
 import re
 import os
@@ -33,12 +32,6 @@ from .docs_resolv import embed_code_links
 from .downloads import generate_zipfiles
 from .sorting import NumberOfCodeLinesSortKey
 from .binder import copy_binder_files
-
-try:
-    basestring
-except NameError:
-    basestring = str
-    unicode = str
 
 DEFAULT_GALLERY_CONF = {
     'filename_pattern': re.escape(os.sep) + 'plot',
@@ -111,10 +104,6 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
     gallery_conf.update(plot_gallery=plot_gallery)
     gallery_conf.update(abort_on_example_error=abort_on_example_error)
     gallery_conf['src_dir'] = src_dir
-    # Old Sphinx can't handle pickling app, so let's just expose the one
-    # thing we need internally
-    if LooseVersion(sphinx.__version__) < LooseVersion('1.8'):
-        app = Bunch(config=app.config) if app is not None else app
     gallery_conf['app'] = app
 
     if gallery_conf.get("mod_example_dir", False):
@@ -147,7 +136,7 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
         scrapers = [scrapers]
     scrapers = list(scrapers)
     for si, scraper in enumerate(scrapers):
-        if isinstance(scraper, basestring):
+        if isinstance(scraper, str):
             if scraper in _scraper_dict:
                 scraper = _scraper_dict[scraper]
             else:
@@ -171,7 +160,7 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
         resetters = [resetters]
     resetters = list(resetters)
     for ri, resetter in enumerate(resetters):
-        if isinstance(resetter, basestring):
+        if isinstance(resetter, str):
             if resetter not in _reset_dict:
                 raise ValueError('Unknown module resetter named %r'
                                  % (resetter,))
@@ -187,7 +176,7 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
 
     # Ensure the first cell text is a string if we have it
     first_cell = gallery_conf.get("first_notebook_cell")
-    if (not isinstance(first_cell, basestring)) and (first_cell is not None):
+    if (not isinstance(first_cell, str)) and (first_cell is not None):
         raise ValueError("The 'first_notebook_cell' parameter must be type str"
                          "or None, found type %s" % type(first_cell))
     gallery_conf['first_notebook_cell'] = first_cell
@@ -568,15 +557,9 @@ def setup(app):
     for key in ['plot_gallery', 'abort_on_example_error']:
         app.add_config_value(key, get_default_config_value(key), 'html')
 
-    try:
-        app.add_css_file('gallery.css')
-    except AttributeError:  # Sphinx < 1.8
-        app.add_stylesheet('gallery.css')
+    app.add_css_file('gallery.css')
 
-    # Sphinx < 1.6 calls it `_extensions`, >= 1.6 is `extensions`.
-    extensions_attr = '_extensions' if hasattr(
-        app, '_extensions') else 'extensions'
-    if 'sphinx.ext.autodoc' in getattr(app, extensions_attr):
+    if 'sphinx.ext.autodoc' in app.extensions:
         app.connect('autodoc-process-docstring', touch_empty_backreferences)
 
     app.connect('builder-inited', generate_gallery_rst)

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -19,10 +19,9 @@ import re
 import os
 from xml.sax.saxutils import quoteattr, escape
 
-import sphinx
 from sphinx.util.console import red
 from . import sphinx_compatibility, glr_path_static, __version__ as _sg_version
-from .utils import _replace_md5, Bunch
+from .utils import _replace_md5
 from .backreferences import finalize_backreferences
 from .gen_rst import (generate_dir_rst, SPHX_GLR_SIG, _get_memory_base,
                       extract_intro_and_title, get_docstring_and_rest,

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -19,48 +19,22 @@ import contextlib
 import ast
 import codecs
 import gc
+from io import StringIO
 import os
 import re
+from textwrap import indent
 import warnings
 from shutil import copyfile
 import subprocess
 import sys
 import traceback
 import codeop
-from io import StringIO
-from distutils.version import LooseVersion
+
+import sphinx
 
 from .scrapers import (save_figures, ImagePathIterator, clean_modules,
                        _find_image_ext)
 from .utils import replace_py_ipynb, scale_image, get_md5sum, _replace_md5
-
-# Try Python 2 first, otherwise load from Python 3
-try:
-    # textwrap indent only exists in python 3
-    from textwrap import indent
-except ImportError:
-    def indent(text, prefix, predicate=None):
-        """Add 'prefix' to the beginning of selected lines in 'text'.
-
-        If 'predicate' is provided, 'prefix' will only be added to the lines
-        where 'predicate(line)' is True. If 'predicate' is not provided,
-        it will default to adding 'prefix' to all non-empty lines that do not
-        consist solely of whitespace characters.
-        """
-        if predicate is None:
-            def predicate(line):
-                return line.strip()
-
-        def prefixed_lines():
-            for line in text.splitlines(True):
-                yield (prefix + line if predicate(line) else line)
-        return ''.join(prefixed_lines())
-
-    FileNotFoundError = IOError
-
-
-import sphinx
-
 from . import glr_path_static
 from . import sphinx_compatibility
 from .backreferences import write_backreferences, _thumbnail_div
@@ -70,12 +44,6 @@ from .py_source_parser import (split_code_and_text_blocks,
 
 from .notebook import jupyter_notebook, save_notebook
 from .binder import check_binder_conf, gen_binder_rst
-
-try:
-    basestring
-except NameError:
-    basestring = str
-    unicode = str
 
 logger = sphinx_compatibility.getLogger('sphinx-gallery')
 
@@ -123,15 +91,6 @@ class LoggingTee(object):
     # When called from a local terminal seaborn needs it in Python3
     def isatty(self):
         return self.output_file.isatty()
-
-
-class MixedEncodingStringIO(StringIO):
-    """Helper when both ASCII and unicode strings will be written"""
-
-    def write(self, data):
-        if not isinstance(data, unicode):
-            data = data.decode('utf-8')
-        StringIO.write(self, data)
 
 
 ###############################################################################
@@ -183,12 +142,9 @@ SPHX_GLR_SIG = """\n
 def codestr2rst(codestr, lang='python', lineno=None):
     """Return reStructuredText code block from code string"""
     if lineno is not None:
-        if LooseVersion(sphinx.__version__) >= '1.3':
-            # Sphinx only starts numbering from the first non-empty line.
-            blank_lines = codestr.count('\n', 0, -len(codestr.lstrip()))
-            lineno = '   :lineno-start: {0}\n'.format(lineno + blank_lines)
-        else:
-            lineno = '   :linenos:\n'
+        # Sphinx only starts numbering from the first non-empty line.
+        blank_lines = codestr.count('\n', 0, -len(codestr.lstrip()))
+        lineno = '   :lineno-start: {0}\n'.format(lineno + blank_lines)
     else:
         lineno = ''
     code_directive = "\n.. code-block:: {0}\n{1}\n".format(lang, lineno)
@@ -520,7 +476,7 @@ def execute_code_block(compiler, block, example_globals,
     # First cd in the original example dir, so that any file
     # created by the example get created in this directory
 
-    captured_std = MixedEncodingStringIO()
+    captured_std = StringIO()
     os.chdir(os.path.dirname(src_file))
 
     sys_path = copy.deepcopy(sys.path)
@@ -532,8 +488,6 @@ def execute_code_block(compiler, block, example_globals,
         code_ast = compile(bcontent, src_file, 'exec',
                            ast.PyCF_ONLY_AST | compiler.flags, dont_inherit)
         ast.increment_lineno(code_ast, lineno - 1)
-        # don't use unicode_literals at the top of this file or you get
-        # nasty errors here on Py2.7
         _, mem = _memory_usage(_exec_once(
             compiler(code_ast, src_file, 'exec'), example_globals),
             gallery_conf)
@@ -543,13 +497,6 @@ def execute_code_block(compiler, block, example_globals,
         sys.stdout, sys.stderr = orig_stdout, orig_stderr
         except_rst = handle_exception(sys.exc_info(), src_file, script_vars,
                                       gallery_conf)
-        # python2.7: Code was read in bytes needs decoding to utf-8
-        # unless future unicode_literals is imported in source which
-        # make ast output unicode strings
-        if hasattr(except_rst, 'decode') and not \
-                isinstance(except_rst, unicode):
-            except_rst = except_rst.decode('utf-8')
-
         code_output = u"\n{0}\n\n\n\n".format(except_rst)
         # still call this even though we won't use the images so that
         # figures are closed

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -30,8 +30,6 @@ import sys
 import traceback
 import codeop
 
-import sphinx
-
 from .scrapers import (save_figures, ImagePathIterator, clean_modules,
                        _find_image_ext)
 from .utils import replace_py_ipynb, scale_image, get_md5sum, _replace_md5

--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -114,7 +114,6 @@ def get_docstring_and_rest(filename):
         # this block can be removed when python 3.6 support is dropped
         docstring_node = node.body[0]
         docstring = docstring_node.value.s
-        docstring = docstring.decode('utf-8')
         lineno = docstring_node.lineno  # The last line of the string.
 
     # This get the content of the file after the docstring last line

--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -7,6 +7,8 @@ Parser for python source files
 # Author: Óscar Nájera
 
 from __future__ import division, absolute_import, print_function
+
+import codecs
 import ast
 from distutils.version import LooseVersion
 from io import BytesIO
@@ -42,7 +44,7 @@ INFILE_CONFIG_PATTERN = re.compile(
 
 
 def parse_source_file(filename):
-    """Parse source file into AST node
+    """Parse source file into AST node.
 
     Parameters
     ----------
@@ -54,29 +56,20 @@ def parse_source_file(filename):
     node : AST node
     content : utf-8 encoded string
     """
-
-    # can't use codecs.open(filename, 'r', 'utf-8') here b/c ast doesn't
-    # work with unicode strings in Python2.7 "SyntaxError: encoding
-    # declaration in Unicode string" In python 2.7 the string can't be
-    # encoded and have information about its encoding. That is particularly
-    # problematic since source files include in their header information
-    # about the file encoding.
-    # Minimal example to fail: ast.parse(u'# -*- coding: utf-8 -*-')
-
-    with open(filename, 'rb') as fid:
+    with codecs.open(filename, 'r', 'utf-8') as fid:
         content = fid.read()
     # change from Windows format to UNIX for uniformity
-    content = content.replace(b'\r\n', b'\n')
+    content = content.replace('\r\n', '\n')
 
     try:
         node = ast.parse(content)
-        return node, content.decode('utf-8')
+        return node, content
     except SyntaxError:
-        return None, content.decode('utf-8')
+        return None, content
 
 
 def get_docstring_and_rest(filename):
-    """Separate ``filename`` content between docstring and the rest
+    """Separate ``filename`` content between docstring and the rest.
 
     Strongly inspired from ast.get_docstring.
 
@@ -121,11 +114,7 @@ def get_docstring_and_rest(filename):
         # this block can be removed when python 3.6 support is dropped
         docstring_node = node.body[0]
         docstring = docstring_node.value.s
-        # python2.7: Code was read in bytes needs decoding to utf-8
-        # unless future unicode_literals is imported in source which
-        # make ast output unicode strings
-        if hasattr(docstring, 'decode') and not isinstance(docstring, unicode):
-            docstring = docstring.decode('utf-8')
+        docstring = docstring.decode('utf-8')
         lineno = docstring_node.lineno  # The last line of the string.
 
     # This get the content of the file after the docstring last line

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -19,12 +19,6 @@ from .utils import scale_image
 __all__ = ['save_figures', 'figure_rst', 'ImagePathIterator', 'clean_modules',
            'matplotlib_scraper', 'mayavi_scraper']
 
-try:
-    basestring
-except NameError:
-    basestring = str
-    unicode = str
-
 
 ###############################################################################
 # Scrapers
@@ -236,7 +230,7 @@ def save_figures(block, block_vars, gallery_conf):
     prev_count = len(image_path_iterator)
     for scraper in gallery_conf['image_scrapers']:
         rst = scraper(block, block_vars, gallery_conf)
-        if not isinstance(rst, basestring):
+        if not isinstance(rst, str):
             raise TypeError('rst from scraper %r was not a string, '
                             'got type %s:\n%r'
                             % (scraper, type(rst), rst))
@@ -329,7 +323,7 @@ def _reset_seaborn(gallery_conf, fname):
 _reset_dict = {
     'matplotlib': _reset_matplotlib,
     'seaborn': _reset_seaborn,
-    }
+}
 
 
 def clean_modules(gallery_conf, fname):

--- a/sphinx_gallery/sphinx_compatibility.py
+++ b/sphinx_gallery/sphinx_compatibility.py
@@ -6,8 +6,6 @@ Backwards-compatility shims for Sphinx
 """
 from __future__ import division, absolute_import, print_function
 
-from distutils.version import LooseVersion
-
 import sphinx
 import sphinx.util
 
@@ -69,9 +67,5 @@ def _app_status_iterator(iterable, summary, **kwargs):
         yield item
 
 
-if LooseVersion(sphinx.__version__) >= '1.6':
-    getLogger = sphinx.util.logging.getLogger
-    status_iterator = sphinx.util.status_iterator
-else:
-    getLogger = _app_get_logger
-    status_iterator = _app_status_iterator
+getLogger = sphinx.util.logging.getLogger
+status_iterator = sphinx.util.status_iterator

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -9,9 +9,8 @@ import collections
 import pytest
 
 import sphinx
-import sphinx_gallery.docs_resolv
-import sphinx_gallery.gen_gallery
-import sphinx_gallery.gen_rst
+from sphinx_gallery import (docs_resolv, gen_gallery, gen_rst, utils,
+                            sphinx_compatibility)
 
 
 def pytest_report_header(config, startdir):
@@ -48,30 +47,41 @@ class FakeSphinxApp:
 
 
 @pytest.fixture
+def gallery_conf(tmpdir):
+    """Set up a test sphinx-gallery configuration."""
+    app = utils.Bunch()
+    app.config = dict(source_suffix={'.rst': None})
+    gallery_conf = gen_gallery._complete_gallery_conf(
+        {}, str(tmpdir), True, False, app=app)
+    gallery_conf.update(examples_dir=str(tmpdir), gallery_dir=str(tmpdir))
+    return gallery_conf
+
+
+@pytest.fixture
 def fakesphinxapp():
-    orig_app = sphinx_gallery.sphinx_compatibility._app
-    sphinx_gallery.sphinx_compatibility._app = app = FakeSphinxApp()
+    orig_app = sphinx_compatibility._app
+    sphinx_compatibility._app = app = FakeSphinxApp()
     try:
         yield app
     finally:
-        sphinx_gallery.sphinx_compatibility._app = orig_app
+        sphinx_compatibility._app = orig_app
 
 
 @pytest.fixture
 def log_collector():
-    orig_dr_logger = sphinx_gallery.docs_resolv.logger
-    orig_gg_logger = sphinx_gallery.gen_gallery.logger
-    orig_gr_logger = sphinx_gallery.gen_rst.logger
+    orig_dr_logger = docs_resolv.logger
+    orig_gg_logger = gen_gallery.logger
+    orig_gr_logger = gen_rst.logger
     app = FakeSphinxApp()
-    sphinx_gallery.docs_resolv.logger = app
-    sphinx_gallery.gen_gallery.logger = app
-    sphinx_gallery.gen_rst.logger = app
+    docs_resolv.logger = app
+    gen_gallery.logger = app
+    gen_rst.logger = app
     try:
         yield app
     finally:
-        sphinx_gallery.docs_resolv.logger = orig_dr_logger
-        sphinx_gallery.gen_gallery.logger = orig_gg_logger
-        sphinx_gallery.gen_rst.logger = orig_gr_logger
+        docs_resolv.logger = orig_dr_logger
+        gen_gallery.logger = orig_gg_logger
+        gen_rst.logger = orig_gr_logger
 
 
 @pytest.fixture

--- a/sphinx_gallery/tests/test_docs_resolv.py
+++ b/sphinx_gallery/tests/test_docs_resolv.py
@@ -12,7 +12,6 @@ import sys
 import pytest
 
 import sphinx_gallery.docs_resolv as sg
-from sphinx_gallery.utils import _TempDir
 
 
 def test_embed_code_links_get_data():
@@ -21,11 +20,11 @@ def test_embed_code_links_get_data():
     sg._get_data('http://scikit-learn.org/stable/')  # GZip
 
 
-def test_shelve():
+def test_shelve(tmpdir):
     """Test if shelve can be caches information
     retrieved after file is deleted"""
     test_string = 'test information'
-    tmp_cache = _TempDir()
+    tmp_cache = str(tmpdir)
     with tempfile.NamedTemporaryFile('w', delete=False) as f:
         f.write(test_string)
     try:
@@ -41,8 +40,7 @@ def test_shelve():
 
     # shelve keys need to be str in python 2, deal with unicode input
     if sys.version_info[0] == 2:
-        unicode_name = unicode(f.name)
-        assert sg.get_data(unicode_name, tmp_cache) == test_string
+        assert sg.get_data(f.name, tmp_cache) == test_string
 
 
 def test_parse_sphinx_docopts():

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -18,7 +18,6 @@ import time
 import numpy as np
 from numpy.testing import assert_allclose
 
-import sphinx
 from sphinx.application import Sphinx
 from sphinx.util.docutils import docutils_namespace
 

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -9,6 +9,7 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 import codecs
 from contextlib import contextmanager
+from io import StringIO
 import os
 import sys
 import re
@@ -20,11 +21,9 @@ from sphinx.application import Sphinx
 from sphinx.errors import ExtensionError
 from sphinx.util.docutils import docutils_namespace
 
-from sphinx_gallery.gen_rst import MixedEncodingStringIO
 from sphinx_gallery import sphinx_compatibility
 from sphinx_gallery.gen_gallery import (check_duplicate_filenames,
                                         collect_gallery_files)
-from sphinx_gallery.utils import _TempDir
 
 
 @pytest.fixture
@@ -40,15 +39,6 @@ def conf_file(request):
     result.update(kwargs)
 
     return result
-
-
-@pytest.fixture
-def tempdir():
-    """
-    temporary directory that wrapped with `path` class.
-    this fixture is for compat with old test implementation.
-    """
-    return _TempDir()
 
 
 class SphinxAppWrapper(object):
@@ -93,12 +83,12 @@ class SphinxAppWrapper(object):
 
 
 @pytest.fixture
-def sphinx_app_wrapper(tempdir, conf_file):
+def sphinx_app_wrapper(tmpdir, conf_file):
     _fixturedir = os.path.join(os.path.dirname(__file__), 'testconfs')
-    srcdir = os.path.join(tempdir, "config_test")
+    srcdir = os.path.join(str(tmpdir), "config_test")
     shutil.copytree(_fixturedir, srcdir)
     shutil.copytree(os.path.join(_fixturedir, "src"),
-                    os.path.join(tempdir, "examples"))
+                    os.path.join(str(tmpdir), "examples"))
 
     base_config = """
 import os
@@ -115,8 +105,7 @@ project = u'Sphinx-Gallery <Tests>'\n\n
 
     return SphinxAppWrapper(
         srcdir, srcdir, os.path.join(srcdir, "_build"),
-        os.path.join(srcdir, "_build", "toctree"),
-        "html", warning=MixedEncodingStringIO())
+        os.path.join(srcdir, "_build", "toctree"), "html", warning=StringIO())
 
 
 def test_default_config(sphinx_app_wrapper):
@@ -329,7 +318,7 @@ def test_binder_copy_files(sphinx_app_wrapper, tmpdir):
     for i_file in ['plot_1', 'plot_2', 'plot_3']:
         assert os.path.exists(os.path.join(
             sphinx_app.outdir, 'ntbk_folder', gallery_conf['gallery_dirs'][0],
-            i_file+'.ipynb'))
+            i_file + '.ipynb'))
 
 
 @pytest.mark.conf_file(content="""

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -21,7 +21,7 @@ import pytest
 import sphinx_gallery.gen_rst as sg
 from sphinx_gallery import downloads
 from sphinx_gallery.gen_gallery import generate_dir_rst, _complete_gallery_conf
-from sphinx_gallery.utils import _TempDir, Bunch
+from sphinx_gallery.utils import Bunch
 from sphinx_gallery.scrapers import ImagePathIterator
 
 try:
@@ -257,7 +257,7 @@ def gallery_conf(tmpdir):
     app.config = dict(source_suffix={'.rst': None})
     gallery_conf = _complete_gallery_conf({}, str(tmpdir), True, False,
                                           app=app)
-    gallery_conf.update(examples_dir=_TempDir(), gallery_dir=str(tmpdir))
+    gallery_conf.update(examples_dir=str(tmpdir), gallery_dir=str(tmpdir))
     return gallery_conf
 
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -20,15 +20,8 @@ import pytest
 
 import sphinx_gallery.gen_rst as sg
 from sphinx_gallery import downloads
-from sphinx_gallery.gen_gallery import generate_dir_rst, _complete_gallery_conf
-from sphinx_gallery.utils import Bunch
+from sphinx_gallery.gen_gallery import generate_dir_rst
 from sphinx_gallery.scrapers import ImagePathIterator
-
-try:
-    FileNotFoundError
-except NameError:
-    # Python2
-    FileNotFoundError = IOError
 
 CONTENT = [
     '"""',
@@ -129,9 +122,8 @@ def test_rst_block_after_docstring(gallery_conf, tmpdir):
 
     script_vars = {'execute_script': ''}
 
-    output_blocks, time_elapsed = sg.execute_script(blocks,
-                                                    script_vars,
-                                                    gallery_conf)
+    output_blocks, time_elapsed = sg.execute_script(
+        blocks, script_vars, gallery_conf)
 
     example_rst = sg.rst_blocks(blocks, output_blocks, file_conf, gallery_conf)
     assert example_rst == '\n'.join([
@@ -166,9 +158,8 @@ b = 'foo'
     script_vars = {'execute_script': True, 'src_file': filename,
                    'image_path_iterator': [],
                    'target_file': filename}
-    output_blocks, time_elapsed = sg.execute_script(blocks,
-                                                    script_vars,
-                                                    gallery_conf)
+    output_blocks, time_elapsed = sg.execute_script(
+        blocks, script_vars, gallery_conf)
     assert 'example_globals' in script_vars
     assert script_vars['example_globals']['a'] == 1.
     assert script_vars['example_globals']['b'] == 'foo'
@@ -248,17 +239,6 @@ def test_md5sums():
             os.remove(f.name + '.md5')
     finally:
         os.remove(f.name)
-
-
-@pytest.fixture
-def gallery_conf(tmpdir):
-    """Set up a test sphinx-gallery configuration."""
-    app = Bunch()
-    app.config = dict(source_suffix={'.rst': None})
-    gallery_conf = _complete_gallery_conf({}, str(tmpdir), True, False,
-                                          app=app)
-    gallery_conf.update(examples_dir=str(tmpdir), gallery_dir=str(tmpdir))
-    return gallery_conf
 
 
 def test_fail_example(gallery_conf, log_collector):

--- a/sphinx_gallery/tests/test_notebook.py
+++ b/sphinx_gallery/tests/test_notebook.py
@@ -14,13 +14,6 @@ import pytest
 import sphinx_gallery.gen_rst as sg
 from sphinx_gallery.notebook import (rst2md, jupyter_notebook, save_notebook,
                                      python_to_jupyter_cli)
-from sphinx_gallery.tests.test_gen_rst import gallery_conf  # noqa
-
-try:
-    FileNotFoundError
-except NameError:
-    # Python2
-    FileNotFoundError = IOError
 
 
 def test_latex_conversion():
@@ -81,8 +74,9 @@ For more details on interpolation see the page `channel_interpolation`.
 
 
 def test_jupyter_notebook(gallery_conf):
-    """Test that written ipython notebook file corresponds to python object"""
-    file_conf, blocks = sg.split_code_and_text_blocks('tutorials/plot_parse.py')
+    """Test that written ipython notebook file corresponds to python object."""
+    file_conf, blocks = sg.split_code_and_text_blocks(
+        'tutorials/plot_parse.py')
     example_nb = jupyter_notebook(blocks, gallery_conf)
 
     with tempfile.NamedTemporaryFile('w', delete=False) as f:
@@ -104,7 +98,8 @@ def test_jupyter_notebook(gallery_conf):
     test_text = None
     gallery_conf['first_notebook_cell'] = test_text
     example_nb = jupyter_notebook(blocks, gallery_conf)
-    assert example_nb.get('cells')[0]['source'][0].startswith('\nThe Header Docstring')
+    cell_src = example_nb.get('cells')[0]['source'][0]
+    assert cell_src.startswith('\nThe Header Docstring')
 
 ###############################################################################
 # Notebook shell utility

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -9,14 +9,13 @@ from sphinx_gallery.gen_gallery import _complete_gallery_conf
 from sphinx_gallery.scrapers import (figure_rst, mayavi_scraper, SINGLE_IMAGE,
                                      matplotlib_scraper, ImagePathIterator,
                                      save_figures, _KNOWN_IMG_EXTS)
-from sphinx_gallery.utils import _TempDir
 
 
 @pytest.fixture(scope='function')
 def gallery_conf(tmpdir):
     """Sets up a test sphinx-gallery configuration"""
     gallery_conf = _complete_gallery_conf({}, str(tmpdir), True, False)
-    gallery_conf.update(examples_dir=_TempDir(), gallery_dir=str(tmpdir))
+    gallery_conf.update(examples_dir=str(tmpdir), gallery_dir=str(tmpdir))
     return gallery_conf
 
 

--- a/sphinx_gallery/tests/test_sorting.py
+++ b/sphinx_gallery/tests/test_sorting.py
@@ -16,12 +16,6 @@ from sphinx_gallery.sorting import (ExplicitOrder, NumberOfCodeLinesSortKey,
                                     ExampleTitleSortKey)
 
 
-try:
-    basestring
-except NameError:
-    basestring = str
-
-
 def test_ExplicitOrder_sorting_key():
     """Test ExplicitOrder"""
 
@@ -47,9 +41,9 @@ def test_ExplicitOrder_sorting_key():
     assert str(key) != str(ExplicitOrder(explicit_folders[::-1]))
     src_dir = op.dirname(__file__)
     for klass, type_ in ((NumberOfCodeLinesSortKey, int),
-                         (FileNameSortKey, basestring),
+                         (FileNameSortKey, str),
                          (FileSizeSortKey, int),
-                         (ExampleTitleSortKey, basestring)):
+                         (ExampleTitleSortKey, str)):
         sorter = klass(src_dir)
         assert str(sorter) == '<%s>' % (klass.__name__,)
         out = sorter(op.basename(__file__))

--- a/sphinx_gallery/tests/test_utils.py
+++ b/sphinx_gallery/tests/test_utils.py
@@ -12,13 +12,12 @@ from __future__ import division, absolute_import, print_function
 import sphinx_gallery.utils as utils
 import pytest
 
-def test_replace_py_ipynb():
+
+@pytest.mark.parametrize('file_name', ('some/file/name', '/corner.pycase'))
+def test_replace_py_ipynb(file_name):
     # Test behavior of function with expected input:
-    for file_name in ['some/file/name', '/corner.pycase']:
-        assert utils.replace_py_ipynb(file_name+'.py') == file_name+'.ipynb'
+    assert utils.replace_py_ipynb(file_name + '.py') == file_name + '.ipynb'
 
     # Test behavior of function with unexpected input:
-    with pytest.raises(ValueError) as expected_exception:
-        utils.replace_py_ipynb(file_name+'.txt')
-
-    assert 'Unrecognized file extension' in str(expected_exception.value)
+    with pytest.raises(ValueError, match='Unrecognized file extension'):
+        utils.replace_py_ipynb(file_name + '.txt')

--- a/sphinx_gallery/utils.py
+++ b/sphinx_gallery/utils.py
@@ -16,30 +16,6 @@ from shutil import rmtree, move, copyfile
 import tempfile
 
 
-class _TempDir(str):
-    """Create and auto-destroy temp dir.
-
-    This is designed to be used with testing modules. Instances should be
-    defined inside test functions. Instances defined at module level can not
-    guarantee proper destruction of the temporary directory.
-
-    When used at module level, the current use of the __del__() method for
-    cleanup can fail because the rmtree function may be cleaned up before this
-    object (an alternative could be using the atexit module instead).
-    """
-    # adapted from MNE-Python
-
-    def __new__(self):  # noqa: D105
-        new = str.__new__(self, tempfile.mkdtemp(prefix='tmp_sg_tempdir_'))
-        return new
-
-    def __init__(self):  # noqa: D102
-        self._path = self.__str__()
-
-    def __del__(self):  # noqa: D105
-        rmtree(self._path, ignore_errors=True)
-
-
 def scale_image(in_fname, out_fname, max_width, max_height):
     """Scales an image with the same aspect ratio centered in an
        image box with the given max_width and max_height

--- a/sphinx_gallery/utils.py
+++ b/sphinx_gallery/utils.py
@@ -12,8 +12,7 @@ from __future__ import division, absolute_import, print_function
 
 import hashlib
 import os
-from shutil import rmtree, move, copyfile
-import tempfile
+from shutil import move, copyfile
 
 
 def scale_image(in_fname, out_fname, max_width, max_height):


### PR DESCRIPTION
Closes #405.
Closes #407.

Bumps minimums to Sphinx 1.8.3 (~1.5 years old) and Python 3.5, removing associated code. Also adds `flake8` testing.