### PR TITLE
[MRG] Remove matplotlib agg backend + plt.show warnings from doc

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,8 +15,9 @@
 import sys
 import os
 from datetime import date
+import warnings
+
 import sphinx_gallery
-from sphinx_gallery.scrapers import matplotlib_scraper
 from sphinx_gallery.sorting import ExplicitOrder, NumberOfCodeLinesSortKey
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -364,3 +365,8 @@ sphinx_gallery_conf = {
     'show_memory': True,
     'junit': os.path.join('sphinx-gallery', 'junit-results.xml'),
 }
+
+# Remove matplotlib agg warnings from generated doc when using plt.show
+warnings.filterwarnings("ignore", category=UserWarning,
+                        message='Matplotlib is currently using agg, which is a'
+                                ' non-GUI backend, so cannot show the figure.')


### PR DESCRIPTION
The warnings happen when using agg backend and using plt.show(). This was taken from scikit-learn. This is related to https://github.com/sphinx-gallery/sphinx-gallery/issues/488. This PR only removes the warnings from our documentation and does not add any documentation from a sphinx-gallery user perspective.

See for example https://sphinx-gallery.github.io/auto_examples/plot_exp.html#sphx-glr-auto-examples-plot-exp-py.

![image](https://user-images.githubusercontent.com/1680079/62130475-5da12500-b2d9-11e9-85ec-0c80854c7a8a.png)

