### PR TITLE
ENH: Add live object refs and methods

### DIFF
--- a/continuous_integration/travis/test_script.sh
+++ b/continuous_integration/travis/test_script.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-pytest sphinx_gallery
+pytest sphinx_gallery -vv
 cd doc
 if [ "$DISTRIB" != "minimal" ] && [ "$PYTHON_VERSION" != "nightly" ]; then
     make SPHINXOPTS= html-noplot

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -22,7 +22,7 @@ file:
 - ``subsection_order`` (:ref:`sub_gallery_order`)
 - ``within_subsection_order`` (:ref:`within_gallery_order`)
 - ``reference_url`` (:ref:`link_to_documentation`)
-- ``backreferences_dir`` and ``doc_module`` (:ref:`references_to_examples`)
+- ``backreferences_dir``, ``doc_module``, and ``inspect_global_variables`` (:ref:`references_to_examples`)
 - ``default_thumb_file`` (:ref:`custom_default_thumb`)
 - ``thumbnail_size`` (:ref:`setting_thumbnail_size`)
 - ``line_numbers`` (:ref:`adding_line_numbers`)
@@ -394,6 +394,36 @@ configuration option setup for Sphinx-Gallery.
     :emphasize-lines: 12-22, 32-42
     :linenos:
 
+.. note::
+   By default, Sphinx-gallery will inspect global variables (and code objects)
+   at the end of each code block to try to find classes of variables and
+   method calls. It also tries to find methods called on classes.
+   For example, this code::
+
+       lst = [1, 2]
+       fig, ax = plt.subplots()
+       ax.plot(lst)
+
+   should end up with the following links (assuming intersphinx is set up
+   properly):
+
+   - :class:`lst <python:list>`
+   - :func:`plt.subplots <matplotlib.pyplot.subplots>`
+   - :class:`fig  <matplotlib.figure.Figure>`
+   - :class:`ax <matplotlib.axes.Axes>`
+   - :meth:`ax.plot <matplotlib.axes.Axes.plot>`
+
+   However, this feature is might not work properly in all instances.
+   Moreover, if variable names get reused in the same script to refer to
+   different classes, it will break.
+
+   To disable this global variable introspection, you can use the configuration
+   key::
+
+       sphinx_gallery_conf = {
+           ...
+           'inspect_global_variables'  : False,
+        }
 
 .. _custom_default_thumb:
 

--- a/examples/plot_function_identifier.py
+++ b/examples/plot_function_identifier.py
@@ -13,9 +13,11 @@ which functions are called in the script and to which module do they belong.
 import os  # noqa, analysis:ignore
 import matplotlib.pyplot as plt
 from sphinx_gallery.backreferences import identify_names
+from sphinx_gallery.py_source_parser import split_code_and_text_blocks
 
 filename = os.__file__.replace('.pyc', '.py')
-names = identify_names(filename)
+_, script_blocks = split_code_and_text_blocks(filename)
+names = identify_names(script_blocks)
 figheight = len(names) + .5
 
 fontsize = 20
@@ -28,6 +30,9 @@ fontsize = 20
 # they are not explicitly used in the code. This is useful in particular when
 # functions return classes -- if you add them to the documented blocks of
 # examples that use them, they will be shown in the backreferences.
+#
+# Also note that global variables of the script have intersphinx references
+# added to them automatically (e.g., ``fig`` and ``fig.text`` below).
 
 fig = plt.figure(figsize=(7.5, 8))
 

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -204,14 +204,12 @@ def _thumbnail_div(target_dir, src_dir, fname, snippet, is_backref=False,
                            thumbnail=thumb, ref_name=ref_name)
 
 
-def write_backreferences(seen_backrefs, gallery_conf,
-                         target_dir, fname, snippet):
+def _write_backreferences(backrefs, seen_backrefs, gallery_conf,
+                          target_dir, fname, snippet):
     """Write backreference file including a thumbnail list of examples."""
     if gallery_conf['backreferences_dir'] is None:
         return
 
-    example_file = os.path.join(target_dir, fname)
-    backrefs = _scan_used_functions(example_file, gallery_conf)
     for backref in backrefs:
         include_path = os.path.join(gallery_conf['src_dir'],
                                     gallery_conf['backreferences_dir'],
@@ -228,7 +226,7 @@ def write_backreferences(seen_backrefs, gallery_conf,
             seen_backrefs.add(backref)
 
 
-def finalize_backreferences(seen_backrefs, gallery_conf):
+def _finalize_backreferences(seen_backrefs, gallery_conf):
     """Replace backref files only if necessary."""
     logger = sphinx_compatibility.getLogger('sphinx-gallery')
     if gallery_conf['backreferences_dir'] is None:

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -24,7 +24,7 @@ from .py_source_parser import parse_source_file, split_code_and_text_blocks
 
 
 class NameFinder(ast.NodeVisitor):
-    """Finds the longest form of variable names and their imports in code
+    """Finds the longest form of variable names and their imports in code.
 
     Only retains names from imported modules.
     """
@@ -69,8 +69,8 @@ class NameFinder(ast.NodeVisitor):
                 yield name, full_name
 
 
-def get_short_module_name(module_name, obj_name):
-    """ Get the shortest possible module name """
+def _get_short_module_name(module_name, obj_name):
+    """Get the shortest possible module name."""
     scope = {}
     try:
         # Find out what the real object is supposed to be.
@@ -95,8 +95,8 @@ def get_short_module_name(module_name, obj_name):
     return short_name
 
 
-def extract_object_names_from_docs(filename):
-    """Add matches from the text blocks (must be full names!)"""
+def _extract_object_names_from_docs(filename):
+    """Add matches from the text blocks (must be full names!)."""
     text = split_code_and_text_blocks(filename)[1]
     text = '\n'.join(t[1] for t in text if t[0] == 'text')
     regex = re.compile(r':(?:'
@@ -109,8 +109,8 @@ def extract_object_names_from_docs(filename):
     return [(x, x) for x in re.findall(regex, text)]
 
 
-def identify_names(filename):
-    """Builds a codeobj summary by identifying and resolving used names."""
+def _identify_names(filename):
+    """Build a codeobj summary by identifying and resolving used names."""
     node, _ = parse_source_file(filename)
     if node is None:
         return {}
@@ -119,7 +119,7 @@ def identify_names(filename):
     finder = NameFinder()
     finder.visit(node)
     names = list(finder.get_mapping())
-    names += extract_object_names_from_docs(filename)
+    names += _extract_object_names_from_docs(filename)
 
     example_code_obj = collections.OrderedDict()
     for name, full_name in names:
@@ -135,16 +135,16 @@ def identify_names(filename):
 
         module, attribute = splitted
         # get shortened module name
-        module_short = get_short_module_name(module, attribute)
+        module_short = _get_short_module_name(module, attribute)
         cobj = {'name': attribute, 'module': module,
                 'module_short': module_short}
         example_code_obj[name] = cobj
     return example_code_obj
 
 
-def scan_used_functions(example_file, gallery_conf):
-    """save variables so we can later add links to the documentation"""
-    example_code_obj = identify_names(example_file)
+def _scan_used_functions(example_file, gallery_conf):
+    """Save variables so we can later add links to the documentation."""
+    example_code_obj = _identify_names(example_file)
     if example_code_obj:
         codeobj_fname = example_file[:-3] + '_codeobj.pickle.new'
         with open(codeobj_fname, 'wb') as fid:
@@ -206,13 +206,12 @@ def _thumbnail_div(target_dir, src_dir, fname, snippet, is_backref=False,
 
 def write_backreferences(seen_backrefs, gallery_conf,
                          target_dir, fname, snippet):
-    """Writes down back reference files, which include a thumbnail list
-    of examples using a certain module"""
+    """Write backreference file including a thumbnail list of examples."""
     if gallery_conf['backreferences_dir'] is None:
         return
 
     example_file = os.path.join(target_dir, fname)
-    backrefs = scan_used_functions(example_file, gallery_conf)
+    backrefs = _scan_used_functions(example_file, gallery_conf)
     for backref in backrefs:
         include_path = os.path.join(gallery_conf['src_dir'],
                                     gallery_conf['backreferences_dir'],

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -11,7 +11,6 @@ from __future__ import print_function, unicode_literals
 
 import ast
 import codecs
-import collections
 from html import escape
 import os
 import re
@@ -19,7 +18,6 @@ import re
 from . import sphinx_compatibility
 from .scrapers import _find_image_ext
 from .utils import _replace_md5
-from .py_source_parser import parse_source_file, split_code_and_text_blocks
 
 
 class NameFinder(ast.NodeVisitor):
@@ -103,9 +101,10 @@ _regex = re.compile(r':(?:'
                     )
 
 
-def _identify_names(script_blocks):
+def _identify_names(script_blocks, example_code_obj, finder=None):
     """Build a codeobj summary by identifying and resolving used names."""
-    finder = NameFinder()
+    if finder is None:
+        finder = NameFinder()
     names = list()
     for script_block in script_blocks:
         kind, txt, _ = script_block
@@ -118,8 +117,6 @@ def _identify_names(script_blocks):
             assert script_block[0] == 'text'
             names.extend((x, x) for x in re.findall(_regex, script_block[1]))
     names.extend(list(finder.get_mapping()))
-
-    example_code_obj = collections.OrderedDict()
     for name, full_name in names:
         if name in example_code_obj:
             continue  # if someone puts it in the docstring and code

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -340,8 +340,8 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
                             want = cname
                         else:
                             want = '%s.%s' % (modname, cname)
-                        for value in inv.values():
-                            if want in value:
+                        for key, value in inv.items():  # only python domain
+                            if key.startswith('py') and want in value:
                                 link = value[want][2]
                                 break
 

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -177,8 +177,7 @@ class SphinxDocLinkResolver(object):
         self._searchindex = js_index.loads(sindex)
 
     def _get_link(self, cobj):
-        """Get a valid link, False if not found"""
-
+        """Get a valid link, False if not found."""
         fullname = cobj['module_short'] + '.' + cobj['name']
         try:
             value = self._searchindex['objects'][cobj['module_short']]
@@ -332,7 +331,8 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
                             want = cname
                         else:
                             want = '%s.%s' % (modname, cname)
-                        for key, value in inv.items():  # only python domain
+                        for key, value in inv.items():
+                            # only python domain
                             if key.startswith('py') and want in value:
                                 link = value[want][2]
                                 break

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -22,7 +22,7 @@ from xml.sax.saxutils import quoteattr, escape
 from sphinx.util.console import red
 from . import sphinx_compatibility, glr_path_static, __version__ as _sg_version
 from .utils import _replace_md5
-from .backreferences import finalize_backreferences
+from .backreferences import _finalize_backreferences
 from .gen_rst import (generate_dir_rst, SPHX_GLR_SIG, _get_memory_base,
                       extract_intro_and_title, get_docstring_and_rest,
                       _get_readme)
@@ -290,7 +290,7 @@ def generate_gallery_rst(app):
 
             fhindex.write(SPHX_GLR_SIG)
         _replace_md5(index_rst_new)
-    finalize_backreferences(seen_backrefs, gallery_conf)
+    _finalize_backreferences(seen_backrefs, gallery_conf)
 
     if gallery_conf['plot_gallery']:
         logger.info("computation time summary:", color='white')

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -24,7 +24,6 @@ from . import sphinx_compatibility, glr_path_static, __version__ as _sg_version
 from .utils import _replace_md5
 from .backreferences import _finalize_backreferences
 from .gen_rst import (generate_dir_rst, SPHX_GLR_SIG, _get_memory_base,
-                      extract_intro_and_title, get_docstring_and_rest,
                       _get_readme)
 from .scrapers import _scraper_dict, _reset_dict
 from .docs_resolv import embed_code_links
@@ -181,6 +180,7 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
     gallery_conf['first_notebook_cell'] = first_cell
     # Make it easy to know which builder we're in
     gallery_conf['builder_name'] = builder_name
+    gallery_conf['titles'] = {}
     return gallery_conf
 
 
@@ -400,8 +400,7 @@ def write_junit_xml(gallery_conf, target_dir, costs):
                                         failing_as_expected,
                                         passing_unexpectedly)):
             continue  # not subselected by our regex
-        _, title = extract_intro_and_title(
-            fname, get_docstring_and_rest(fname)[0])
+        title = gallery_conf['titles'][fname]
         output += (
             u'<testcase classname={0!s} file={1!s} line="1" '
             u'name={2!s} time="{3!r}">'

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -63,6 +63,7 @@ DEFAULT_GALLERY_CONF = {
     'show_memory': False,
     'junit': '',
     'log_level': {'backreference_missing': 'warning'},
+    'inspect_global_variables': True,
 }
 
 logger = sphinx_compatibility.getLogger('sphinx-gallery')

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -698,8 +698,11 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
     _replace_md5(ipy_fname)
 
     # Write names
-    example_code_obj = identify_names(
-        script_blocks, script_vars['example_globals'], node)
+    if gallery_conf['inspect_global_variables']:
+        global_variables = script_vars['example_globals']
+    else:
+        global_variables = None
+    example_code_obj = identify_names(script_blocks, global_variables, node)
     if example_code_obj:
         codeobj_fname = target_file[:-3] + '_codeobj.pickle.new'
         with open(codeobj_fname, 'wb') as fid:

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -14,6 +14,7 @@ Files that generate images should start with 'plot'.
 # tricky errors come up with exec(code_blocks, ...) calls
 from __future__ import division, print_function, absolute_import
 from time import time
+import collections
 import copy
 import contextlib
 import ast
@@ -37,9 +38,9 @@ from .utils import replace_py_ipynb, scale_image, get_md5sum, _replace_md5
 from . import glr_path_static
 from . import sphinx_compatibility
 from .backreferences import (_write_backreferences, _thumbnail_div,
-                             _identify_names)
+                             _identify_names, NameFinder)
 from .downloads import CODE_DOWNLOAD
-from .py_source_parser import (split_code_and_text_blocks, parse_source_file,
+from .py_source_parser import (split_code_and_text_blocks,
                                get_docstring_and_rest, remove_config_comments)
 
 from .notebook import jupyter_notebook, save_notebook
@@ -610,6 +611,9 @@ def execute_script(script_blocks, script_vars, gallery_conf):
             file_checksum.write(get_md5sum(script_vars['target_file']))
         gallery_conf['passing_examples'].append(script_vars['src_file'])
 
+    _identify_names(
+        script_blocks, script_vars['example_code_obj'], script_vars['finder'])
+
     return output_blocks, time_elapsed
 
 
@@ -664,7 +668,10 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
         'execute_script': executable,
         'image_path_iterator': ImagePathIterator(image_path_template),
         'src_file': src_file,
-        'target_file': target_file}
+        'target_file': target_file,
+        'example_code_obj': collections.OrderedDict(),  # ordered is important
+        'finder': NameFinder(),
+    }
 
     file_conf, script_blocks = split_code_and_text_blocks(src_file)
 
@@ -698,15 +705,14 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
     _replace_md5(ipy_fname)
 
     # Write names
-    node, _ = parse_source_file(target_file)
-    example_code_obj = _identify_names(script_blocks)
-    if example_code_obj:
+    if script_vars['example_code_obj']:
         codeobj_fname = target_file[:-3] + '_codeobj.pickle.new'
         with open(codeobj_fname, 'wb') as fid:
-            pickle.dump(example_code_obj, fid, pickle.HIGHEST_PROTOCOL)
+            pickle.dump(script_vars['example_code_obj'],
+                        fid, pickle.HIGHEST_PROTOCOL)
         _replace_md5(codeobj_fname)
     backrefs = set('{module_short}.{name}'.format(**entry)
-                   for entry in example_code_obj.values()
+                   for entry in script_vars['example_code_obj'].values()
                    if entry['module'].startswith(gallery_conf['doc_module']))
     # Write backreferences
     _write_backreferences(backrefs, seen_backrefs, gallery_conf, target_dir,

--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -135,7 +135,6 @@ def extract_file_config(content):
     for match in re.finditer(INFILE_CONFIG_PATTERN, content):
         name = match.group(1)
         value = match.group(2)
-        print(name, value)
         try:
             value = ast.literal_eval(value)
         except (SyntaxError, ValueError):

--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -135,6 +135,7 @@ def extract_file_config(content):
     for match in re.finditer(INFILE_CONFIG_PATTERN, content):
         name = match.group(1)
         value = match.group(2)
+        print(name, value)
         try:
             value = ast.literal_eval(value)
         except (SyntaxError, ValueError):

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 
 import sphinx
 from sphinx_gallery import (docs_resolv, gen_gallery, gen_rst, utils,
-                            sphinx_compatibility)
+                            sphinx_compatibility, py_source_parser)
 
 
 def pytest_report_header(config, startdir):
@@ -72,9 +72,11 @@ def log_collector():
     orig_dr_logger = docs_resolv.logger
     orig_gg_logger = gen_gallery.logger
     orig_gr_logger = gen_rst.logger
+    orig_ps_logger = py_source_parser.logger
     app = FakeSphinxApp()
     docs_resolv.logger = app
     gen_gallery.logger = app
+    py_source_parser.logger = app
     gen_rst.logger = app
     try:
         yield app
@@ -82,6 +84,7 @@ def log_collector():
         docs_resolv.logger = orig_dr_logger
         gen_gallery.logger = orig_gg_logger
         gen_rst.logger = orig_gr_logger
+        py_source_parser.logger = orig_ps_logger
 
 
 @pytest.fixture

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -78,7 +78,7 @@ def test_identify_names(unicode_sample):
              'module_short': 'sphinx_gallery.back_references'}
     }
     _, script_blocks = split_code_and_text_blocks(unicode_sample)
-    res = sg._identify_names(script_blocks)
+    res = sg.identify_names(script_blocks)
     assert expected == res
 
 
@@ -106,7 +106,7 @@ e.HelloWorld().f.g
     fname.write(code_str, 'wb')
 
     _, script_blocks = split_code_and_text_blocks(fname.strpath)
-    res = sg._identify_names(script_blocks)
+    res = sg.identify_names(script_blocks)
 
     assert expected == res
 
@@ -123,6 +123,6 @@ This example uses :func:`h.i`.
     fname = tmpdir.join("indentify_names.py")
     fname.write(code_str, 'wb')
     _, script_blocks = split_code_and_text_blocks(fname.strpath)
-    res = sg._identify_names(script_blocks)
+    res = sg.identify_names(script_blocks)
 
     assert expected == res

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -76,7 +76,7 @@ def test_identify_names(unicode_sample):
              'module_short': 'sphinx_gallery.back_references'}
     }
 
-    res = sg.identify_names(unicode_sample)
+    res = sg._identify_names(unicode_sample)
     assert expected == res
 
 
@@ -103,7 +103,7 @@ e.HelloWorld().f.g
     fname = tmpdir.join("indentify_names.py")
     fname.write(code_str, 'wb')
 
-    res = sg.identify_names(fname.strpath)
+    res = sg._identify_names(fname.strpath)
 
     assert expected == res
 
@@ -120,6 +120,6 @@ This example uses :func:`h.i`.
     fname = tmpdir.join("indentify_names.py")
     fname.write(code_str, 'wb')
 
-    res = sg.identify_names(fname.strpath)
+    res = sg._identify_names(fname.strpath)
 
     assert expected == res

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -8,6 +8,8 @@ from __future__ import division, absolute_import, print_function
 
 import pytest
 import sphinx_gallery.backreferences as sg
+from sphinx_gallery.py_source_parser import (split_code_and_text_blocks,
+                                             parse_source_file)
 from sphinx_gallery.gen_rst import _sanitize_rst
 
 
@@ -75,8 +77,8 @@ def test_identify_names(unicode_sample):
              'module': 'sphinx_gallery.back_references',
              'module_short': 'sphinx_gallery.back_references'}
     }
-
-    res = sg._identify_names(unicode_sample)
+    _, script_blocks = split_code_and_text_blocks(unicode_sample)
+    res = sg._identify_names(script_blocks)
     assert expected == res
 
 
@@ -103,7 +105,8 @@ e.HelloWorld().f.g
     fname = tmpdir.join("indentify_names.py")
     fname.write(code_str, 'wb')
 
-    res = sg._identify_names(fname.strpath)
+    _, script_blocks = split_code_and_text_blocks(fname.strpath)
+    res = sg._identify_names(script_blocks)
 
     assert expected == res
 
@@ -119,7 +122,7 @@ This example uses :func:`h.i`.
 
     fname = tmpdir.join("indentify_names.py")
     fname.write(code_str, 'wb')
-
-    res = sg._identify_names(fname.strpath)
+    _, script_blocks = split_code_and_text_blocks(fname.strpath)
+    res = sg._identify_names(script_blocks)
 
     assert expected == res

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -78,7 +78,7 @@ def test_identify_names(unicode_sample):
              'module_short': 'sphinx_gallery.back_references'}
     }
     _, script_blocks = split_code_and_text_blocks(unicode_sample)
-    res = sg._identify_names(script_blocks)
+    res = sg._identify_names(script_blocks, {})
     assert expected == res
 
 
@@ -106,7 +106,7 @@ e.HelloWorld().f.g
     fname.write(code_str, 'wb')
 
     _, script_blocks = split_code_and_text_blocks(fname.strpath)
-    res = sg._identify_names(script_blocks)
+    res = sg._identify_names(script_blocks, {})
 
     assert expected == res
 
@@ -123,6 +123,6 @@ This example uses :func:`h.i`.
     fname = tmpdir.join("indentify_names.py")
     fname.write(code_str, 'wb')
     _, script_blocks = split_code_and_text_blocks(fname.strpath)
-    res = sg._identify_names(script_blocks)
+    res = sg._identify_names(script_blocks, {})
 
     assert expected == res

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -78,7 +78,7 @@ def test_identify_names(unicode_sample):
              'module_short': 'sphinx_gallery.back_references'}
     }
     _, script_blocks = split_code_and_text_blocks(unicode_sample)
-    res = sg._identify_names(script_blocks, {})
+    res = sg._identify_names(script_blocks)
     assert expected == res
 
 
@@ -106,7 +106,7 @@ e.HelloWorld().f.g
     fname.write(code_str, 'wb')
 
     _, script_blocks = split_code_and_text_blocks(fname.strpath)
-    res = sg._identify_names(script_blocks, {})
+    res = sg._identify_names(script_blocks)
 
     assert expected == res
 
@@ -123,6 +123,6 @@ This example uses :func:`h.i`.
     fname = tmpdir.join("indentify_names.py")
     fname.write(code_str, 'wb')
     _, script_blocks = split_code_and_text_blocks(fname.strpath)
-    res = sg._identify_names(script_blocks, {})
+    res = sg._identify_names(script_blocks)
 
     assert expected == res

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -139,8 +139,8 @@ def test_run_sphinx(sphinx_app):
     assert 'after excluding 0' in status
     # intentionally have a bad URL in references
     warning = sphinx_app._warning.getvalue()
-    assert re.match('.*fetching .*wrong_url.*404.*', warning) is not None, \
-        warning
+    want = '.*fetching .*wrong_url.*404.*'
+    assert re.match(want, warning, re.DOTALL) is not None, warning
 
 
 def test_image_formats(sphinx_app):

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -182,6 +182,11 @@ def test_embed_links_and_styles(sphinx_app):
     assert 'numpy.arange.html' in lines
     assert '#module-matplotlib.pyplot' in lines
     assert 'pyplot.html' in lines
+    assert 'matplotlib.figure.Figure.html#matplotlib.figure.Figure.tight_layout' in lines  # noqa
+    assert 'matplotlib.axes.Axes.plot.html#matplotlib.axes.Axes.plot' in lines
+    assert 'matplotlib_configuration_api.html#matplotlib.rcParams' in lines
+    assert 'stdtypes.html#list' in lines
+
     try:
         import memory_profiler  # noqa, analysis:ignore
     except ImportError:
@@ -201,7 +206,7 @@ def test_embed_links_and_styles(sphinx_app):
     assert '.. code-block:: python3\n' in rst
 
     # warnings
-    want_warn = ('plot_numpy_matplotlib.py:31: RuntimeWarning: This'
+    want_warn = ('plot_numpy_matplotlib.py:33: RuntimeWarning: This'
                  ' warning should show up in the output')
     assert want_warn in lines
     sys.stdout.write(lines)

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -49,7 +49,8 @@ def sphinx_app(tmpdir_factory):
     # https://github.com/sphinx-doc/sphinx/issues/5038
     with docutils_namespace():
         app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
-                     buildername='html', status=StringIO())
+                     buildername='html', status=StringIO(),
+                     warning=StringIO())
         # need to build within the context manager
         # for automodule and backrefs to work
         app.build(False, [])
@@ -136,6 +137,10 @@ def test_run_sphinx(sphinx_app):
     status = sphinx_app._status.getvalue()
     assert 'executed %d out of %d' % (N_GOOD, N_TOT) in status
     assert 'after excluding 0' in status
+    # intentionally have a bad URL in references
+    warning = sphinx_app._warning.getvalue()
+    assert re.match('.*fetching .*wrong_url.*404.*', warning) is not None, \
+        warning
 
 
 def test_image_formats(sphinx_app):

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -221,7 +221,7 @@ def test_backreferences(sphinx_app):
                        'sphinx_gallery.backreferences.html')
     with codecs.open(mod_file, 'r', 'utf-8') as fid:
         lines = fid.read()
-    assert 'identify_names' in lines  # in API doc
+    assert 'NameFinder' in lines  # in API doc
     assert 'plot_future_imports.html' in lines  # backref via doc block
 
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -125,7 +125,8 @@ def test_rst_block_after_docstring(gallery_conf, tmpdir):
     assert blocks[2][0] == 'text'
     assert blocks[3][0] == 'text'
 
-    script_vars = {'execute_script': ''}
+    script_vars = {'execute_script': '', 'example_code_obj': {},
+                   'finder': None}
 
     output_blocks, time_elapsed = sg.execute_script(
         blocks, script_vars, gallery_conf)
@@ -163,13 +164,14 @@ b = 'foo'
     assert blocks[1][0] == 'code'
     assert file_conf == {}
     script_vars = {'execute_script': True, 'src_file': filename,
-                   'image_path_iterator': [],
-                   'target_file': filename}
+                   'image_path_iterator': [], 'example_code_obj': {},
+                   'target_file': filename, 'finder': None}
     output_blocks, time_elapsed = sg.execute_script(
         blocks, script_vars, gallery_conf)
     assert 'example_globals' in script_vars
     assert script_vars['example_globals']['a'] == 1.
     assert script_vars['example_globals']['b'] == 'foo'
+    assert len(script_vars['example_code_obj']) == 0
 
 
 def test_codestr2rst():

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -125,8 +125,7 @@ def test_rst_block_after_docstring(gallery_conf, tmpdir):
     assert blocks[2][0] == 'text'
     assert blocks[3][0] == 'text'
 
-    script_vars = {'execute_script': '', 'example_code_obj': {},
-                   'finder': None}
+    script_vars = {'execute_script': ''}
 
     output_blocks, time_elapsed = sg.execute_script(
         blocks, script_vars, gallery_conf)
@@ -164,14 +163,13 @@ b = 'foo'
     assert blocks[1][0] == 'code'
     assert file_conf == {}
     script_vars = {'execute_script': True, 'src_file': filename,
-                   'image_path_iterator': [], 'example_code_obj': {},
-                   'target_file': filename, 'finder': None}
+                   'image_path_iterator': [],
+                   'target_file': filename}
     output_blocks, time_elapsed = sg.execute_script(
         blocks, script_vars, gallery_conf)
     assert 'example_globals' in script_vars
     assert script_vars['example_globals']['a'] == 1.
     assert script_vars['example_globals']['b'] == 'foo'
-    assert len(script_vars['example_code_obj']) == 0
 
 
 def test_codestr2rst():

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -67,7 +67,7 @@ def test_split_code_and_text_blocks():
 
 def test_bug_cases_of_notebook_syntax():
     """Test over the known requirements of supported syntax in the
-    notebook styled comments. Use both '#'s' and '# %%' as cell 
+    notebook styled comments. Use both '#'s' and '# %%' as cell
     separators"""
 
     with open('sphinx_gallery/tests/reference_parse.txt') as reference:

--- a/sphinx_gallery/tests/test_py_source_parser.py
+++ b/sphinx_gallery/tests/test_py_source_parser.py
@@ -16,7 +16,7 @@ import sphinx_gallery.py_source_parser as sg
 
 
 def test_get_docstring_and_rest(unicode_sample, tmpdir):
-    docstring, rest, lineno = sg.get_docstring_and_rest(unicode_sample)
+    docstring, rest, lineno, _ = sg._get_docstring_and_rest(unicode_sample)
     assert u'Únicode' in docstring
     assert u'heiß' in rest
     # degenerate
@@ -24,7 +24,7 @@ def test_get_docstring_and_rest(unicode_sample, tmpdir):
     with open(fname, 'w') as fid:
         fid.write('print("hello")\n')
     with pytest.raises(ValueError, match='Could not find docstring'):
-        sg.get_docstring_and_rest(fname)
+        sg._get_docstring_and_rest(fname)
 
 
 @pytest.mark.parametrize('content, file_conf', [

--- a/sphinx_gallery/tests/test_py_source_parser.py
+++ b/sphinx_gallery/tests/test_py_source_parser.py
@@ -15,7 +15,7 @@ import pytest
 import sphinx_gallery.py_source_parser as sg
 
 
-def test_get_docstring_and_rest(unicode_sample, tmpdir):
+def test_get_docstring_and_rest(unicode_sample, tmpdir, monkeypatch):
     docstring, rest, lineno, _ = sg._get_docstring_and_rest(unicode_sample)
     assert u'Únicode' in docstring
     assert u'heiß' in rest
@@ -25,6 +25,12 @@ def test_get_docstring_and_rest(unicode_sample, tmpdir):
         fid.write('print("hello")\n')
     with pytest.raises(ValueError, match='Could not find docstring'):
         sg._get_docstring_and_rest(fname)
+    with open(fname, 'w') as fid:
+        fid.write('print hello\n')
+    assert sg._get_docstring_and_rest(fname)[0] == sg.SYNTAX_ERROR_DOCSTRING
+    monkeypatch.setattr(sg, 'parse_source_file', lambda x: ('', None))
+    with pytest.raises(TypeError, match='only supports modules'):
+        sg._get_docstring_and_rest('')
 
 
 @pytest.mark.parametrize('content, file_conf', [
@@ -38,9 +44,17 @@ def test_get_docstring_and_rest(unicode_sample, tmpdir):
      {'line_numbers': True}),
     ("#sphinx_gallery_thumbnail_number\n=\n5",
      {'thumbnail_number': 5}),
+    ('#sphinx_gallery_thumbnail_number=1foo', None),
 ])
-def test_extract_file_config(content, file_conf):
-    assert sg.extract_file_config(content) == file_conf
+def test_extract_file_config(content, file_conf, log_collector):
+    if file_conf is None:
+        assert sg.extract_file_config(content) == {}
+        assert len(log_collector.calls['warning']) == 1
+        assert '1foo' == log_collector.calls['warning'][0].args[2]
+    else:
+        assert sg.extract_file_config(content) == file_conf
+        assert len(log_collector.calls['warning']) == 0
+
 
 
 @pytest.mark.parametrize('contents, result', [

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -38,6 +38,7 @@ sphinx_gallery_conf = {
     'doc_module': ('sphinx_gallery',),
     'reference_url': {
         'sphinx_gallery': None,
+        'scipy': 'http://docs.scipy.org/doc/scipy/wrong_url',  # bad one
     },
     'examples_dirs': ['examples/'],
     'gallery_dirs': ['auto_examples'],

--- a/sphinx_gallery/tests/tinybuild/examples/future/plot_future_imports.py
+++ b/sphinx_gallery/tests/tinybuild/examples/future/plot_future_imports.py
@@ -10,7 +10,7 @@ from __future__ import print_function
 import matplotlib
 
 ####################
-# Dummy section, with :func:`sphinx_gallery.backreferences.identify_names` ref.
+# Dummy section, with :func:`sphinx_gallery.backreferences.NameFinder` ref.
 
 assert 3/2 == 1.5
 print(3/2, end='')

--- a/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
@@ -21,11 +21,13 @@ from local_module import N  # N = 1000
 t = np.arange(N) / float(N)
 win = np.hanning(N)
 print(is_color_like('r'))
-plt.figure()
-plt.plot(t, win, color='r')
-plt.text(0, 1, 'png', size=40, va='top')
+fig, ax = plt.subplots()
+ax.plot(t, win, color='r')
+ax.text(0, 1, 'png', size=40, va='top')
+fig.tight_layout()
 orig_dpi = 80. if matplotlib.__version__[0] < '2' else 100.
 assert plt.rcParams['figure.dpi'] == orig_dpi
 plt.rcParams['figure.dpi'] = 70.
 assert plt.rcParams['figure.dpi'] == 70.
+listy = [0, 1]
 warn('This warning should show up in the output', RuntimeWarning)


### PR DESCRIPTION
This adds resolution of (most/many) runtime objects using intersphinx. In `master` we only inspected the AST and imports to look for function calls from imported modules. This PR looks at the runtime objects in `globals` to see if they (or their subclasses) are documented somewhere in intersphinx. It greatly increases the number of things in the code snippets that become links. I'll paste a link to an updated example once CircleCI renders so that people can see what I mean.

It's not perfect but it gets us at least some of the way. For example:

1. It does not handle subclasses properly in all cases. ~~For `mne.io.Raw` for example, it properly documents `raw.plot_psd` calls, but does not get `raw.filter` (despite there being documentation for `mne.io.Raw.filter`).~~
2. If objects are overwritten with the same names, e.g. `raw = ...` at the beginning then later `raw = ... <some other class>` then whichever is first ~~last in the global namespace at the end of the script~~ will be used.

But we can probably handle this sort of thing in a subsequent PR -- the links here are already a good improvement IMO. (1) can be addressed by improving the logic that is in `backreferences.rst`. (2) can be addressed by a much larger PR (that is probably not worth it) refactoring when the objects are inspected and replacements made/set up. To do it properly, the code would need to be executed one line at a time, and name substitutions queued on a line-by-line-within-example basis instead of a per-example basis.

Closes #402.