### PR TITLE
ENH: Speed up builds

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -758,7 +758,7 @@ Often you wish to "reset" the behavior of your visualization packages in order
 to ensure that any changes made to plotting behavior in one example do not
 propagate to the other examples.
 
-By default, at the end of executing each example file, Sphinx-gallery will
+By default, at the end of executing each example file that executes, Sphinx-gallery will
 reset ``matplotlib`` (by using :func:`matplotlib.pyplot.rcdefaults`) and ``seaborn``
 (by trying to unload the module from ``sys.modules``). This is equivalent to the
 following configuration::

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -758,7 +758,7 @@ Often you wish to "reset" the behavior of your visualization packages in order
 to ensure that any changes made to plotting behavior in one example do not
 propagate to the other examples.
 
-By default, at the end of executing each example file that executes, Sphinx-gallery will
+By default, before each example file executes, Sphinx-gallery will
 reset ``matplotlib`` (by using :func:`matplotlib.pyplot.rcdefaults`) and ``seaborn``
 (by trying to unload the module from ``sys.modules``). This is equivalent to the
 following configuration::

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -165,9 +165,9 @@ THUMBNAIL_TEMPLATE = """
 
 .. only:: html
 
-    .. figure:: /{thumbnail}
+ .. figure:: /{thumbnail}
 
-        :ref:`sphx_glr_{ref_name}`
+     :ref:`sphx_glr_{ref_name}`
 
 .. raw:: html
 
@@ -177,7 +177,7 @@ THUMBNAIL_TEMPLATE = """
 BACKREF_THUMBNAIL_TEMPLATE = THUMBNAIL_TEMPLATE + """
 .. only:: not html
 
-    * :ref:`sphx_glr_{ref_name}`
+ * :ref:`sphx_glr_{ref_name}`
 """
 
 
@@ -221,8 +221,8 @@ def write_backreferences(seen_backrefs, gallery_conf,
         with codecs.open(include_path, 'a' if seen else 'w',
                          encoding='utf-8') as ex_file:
             if not seen:
-                heading = '\n\nExamples using ``%s``' % backref
-                ex_file.write(heading + '\n')
+                heading = 'Examples using ``%s``' % backref
+                ex_file.write('\n\n' + heading + '\n')
                 ex_file.write('^' * len(heading) + '\n')
             ex_file.write(_thumbnail_div(target_dir, gallery_conf['src_dir'],
                                          fname, snippet, is_backref=True))

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -18,9 +18,9 @@ REFERENCE = r"""
 
 .. only:: html
 
-    .. figure:: /fake_dir/images/thumb/sphx_glr_test_file_thumb.png
+ .. figure:: /fake_dir/images/thumb/sphx_glr_test_file_thumb.png
 
-        :ref:`sphx_glr_fake_dir_test_file.py`
+     :ref:`sphx_glr_fake_dir_test_file.py`
 
 .. raw:: html
 
@@ -54,7 +54,7 @@ def test_thumbnail_div(content, tooltip, is_backref):
 
 .. only:: not html
 
-    * :ref:`sphx_glr_fake_dir_test_file.py`"""
+ * :ref:`sphx_glr_fake_dir_test_file.py`"""
     else:
         extra = ''
     reference = REFERENCE.format(tooltip, extra)

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -424,8 +424,6 @@ def test_rebuild(tmpdir_factory, sphinx_app):
 
     # generated RST files
     different = (
-        # this one should get rewritten as we retried it
-        'plot_future_imports_broken.rst',
         'plot_numpy_matplotlib.rst',
     )
     ignore = (
@@ -433,6 +431,8 @@ def test_rebuild(tmpdir_factory, sphinx_app):
         # get extremely unlucky and have identical run times
         # on the one script above that changes...
         'sg_execution_times.rst',
+        # this one will not change even though it was retried
+        'plot_future_imports_broken.rst',
     )
     if not sys.platform.startswith('win'):  # not reliable on Windows
         _assert_mtimes(generated_rst_0, generated_rst_1, different, ignore)

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -301,7 +301,7 @@ def test_rebuild(tmpdir_factory, sphinx_app):
         new_app.build(False, [])
     status = new_app._status.getvalue()
     lines = [line for line in status.split('\n') if '0 removed' in line]
-    assert re.match('.*0 added, [2|3|6|7|8] changed, 0 removed$.*',
+    assert re.match('.*0 added, [1|2|3|6|7|8] changed, 0 removed$.*',
                     status, re.MULTILINE | re.DOTALL) is not None, lines
     want = ('.*executed 0 out of 1.*after excluding %s files.*based on MD5.*'
             % (N_GOOD,))

--- a/sphinx_gallery/tests/tinybuild/_templates/module.rst
+++ b/sphinx_gallery/tests/tinybuild/_templates/module.rst
@@ -38,6 +38,10 @@
 
    .. include:: backreferences/{{fullname}}.{{item}}.examples
 
+   .. raw:: html
+
+      <div style='clear:both'></div>
+
    {%- endfor %}
    {% endif %}
    {% endblock %}


### PR DESCRIPTION
When working on #525 I noticed that `make html_dev-noplot` builds for MNE-Python were spending a lot of time in the SG section. I profiled it and there was ~43 sec spent in `generate_gallery_rst` and things that it calls, even though nothing is executed.

Turns out most of this is due to unnecessary `clean_modules` and `_memory_usage` calls -- we only need to call those before actually executing files. I've changed the code to avoid unnecessary calls (i.e., only call them before attempting to actually execute a script). Now `generate_gallery_rst` takes ~3 sec.