### PR TITLE
[MRG][FIX] Remove output box from print(__doc__)

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -508,7 +508,7 @@ def execute_code_block(compiler, block, example_globals,
         os.chdir(cwd)
 
         captured_std = captured_std.getvalue().expandtabs()
-        if captured_std:
+        if captured_std and not captured_std.isspace():
             captured_std = CODE_OUTPUT.format(indent(captured_std, u' ' * 4))
         else:
             captured_std = ''

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -448,6 +448,27 @@ def test_output_indentation(gallery_conf):
     assert output_test_string == test_string.replace(r"\n", "\n")
 
 
+def test_empty_output_box(gallery_conf):
+    """Tests that `print(__doc__)` doesn't produce an empty output box."""
+    compiler = codeop.Compile()
+    
+    code_block = ("code", "print(__doc__)", 1)
+
+    script_vars = {
+        "execute_script": True,
+        "image_path_iterator": ImagePathIterator("temp.png"),
+        "src_file": __file__,
+        "memory_delta": [],
+    }
+
+    example_globals = {'__doc__': ''}
+
+    output = sg.execute_code_block(
+        compiler, code_block, example_globals, script_vars, gallery_conf
+    )
+    assert output.isspace() == True
+
+
 class TestLoggingTee:
     def setup(self):
         self.output_file = io.StringIO()


### PR DESCRIPTION
Closes #528 

Prevents output box if `captured_std.isspace()`.
Test to ensure `execute_code_block` does not generate a code block for `print(__doc__)`.

(also tested locally on [plot_kernal_pca.py](https://scikit-learn.org/dev/auto_examples/decomposition/plot_kernel_pca.html#sphx-glr-auto-examples-decomposition-plot-kernel-pca-py) and does not produce the output box)