### PR TITLE
add class to clear tag

### DIFF
--- a/doc/_templates/module.rst
+++ b/doc/_templates/module.rst
@@ -20,7 +20,7 @@
 
    .. raw:: html
 
-	       <div style='clear:both'></div>
+	       <div class="sphx-glr-clear"></div>
 
    {%- endfor %}
    {% endif %}
@@ -40,7 +40,7 @@
 
    .. raw:: html
 
-	       <div style='clear:both'></div>
+	       <div class="sphx-glr-clear"></div>
 
    {%- endfor %}
    {% endif %}

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -300,7 +300,7 @@ refer to :obj:`numpy.exp`, which looks like this:
 .. include:: gen_modules/backreferences/numpy.exp.examples
 .. raw:: html
 
-        <div style='clear:both'></div>
+        <div class="sphx-glr-clear"></div>
 
 For such behavior to be available, you have to activate it in
 your Sphinx-Gallery configuration ``conf.py`` file with::
@@ -329,7 +329,7 @@ examples in use of a specific function, in this case ``numpy.exp``::
     .. include:: gen_modules/backreferences/numpy.exp.examples
     .. raw:: html
 
-        <div style='clear:both'></div>
+        <div class="sphx-glr-clear"></div>
 
 The ``include`` directive takes a path **relative** to the ``rst``
 file it is called from. In the case of this documentation file (which

--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -190,3 +190,7 @@ p.sphx-glr-signature a.reference.external {
   margin-left: auto;
   display: table;
 }
+
+.sphx-glr-clear{
+  clear: both;
+}

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -334,7 +334,7 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
 
     # clear at the end of the section
     fhindex += """.. raw:: html\n
-    <div style='clear:both'></div>\n\n"""
+    <div class="sphx-glr-clear"></div>\n\n"""
 
     return fhindex, costs
 

--- a/sphinx_gallery/tests/tinybuild/_templates/module.rst
+++ b/sphinx_gallery/tests/tinybuild/_templates/module.rst
@@ -20,7 +20,7 @@
 
    .. raw:: html
 
-	       <div style='clear:both'></div>
+	       <div class="sphx-glr-clear"></div>
 
    {%- endfor %}
    {% endif %}
@@ -40,7 +40,7 @@
 
    .. raw:: html
 
-      <div style='clear:both'></div>
+      <div class="sphx-glr-clear"></div>
 
    {%- endfor %}
    {% endif %}


### PR DESCRIPTION
Removed inline CSS style from clear <div>
Replaced it with a class with a correspoinding style in gallery.css
This change has been made so the new class can be used in a selector to fix a
bug on the matplotlib website where a tooltip display is cut off by
a related overflow:hidden