### PR TITLE
FIX: Fix spurious failures

### DIFF
--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -315,7 +315,7 @@ def test_rebuild(tmpdir_factory, sphinx_app):
         new_app.build(False, [])
     status = new_app._status.getvalue()
     lines = [line for line in status.split('\n') if '0 removed' in line]
-    assert re.match('.*0 added, [1|2|3|6|7|8] changed, 0 removed$.*',
+    assert re.match('.*[0|1] added, [1|2|3|6|7|8] changed, 0 removed$.*',
                     status, re.MULTILINE | re.DOTALL) is not None, lines
     want = ('.*executed 0 out of 1.*after excluding %s files.*based on MD5.*'
             % (N_GOOD,))


### PR DESCRIPTION
AppVeyor occasionally has spurious failures, seemingly because Sphinx sometimes gets modification times wrong:

https://ci.appveyor.com/project/sphinx-gallery/sphinx-gallery/builds/28174649/job/ybbpvrd90nrwxbs5

This PR is designed to help fix it. I'll try restarting AppVeyor a few times before merging.