### PR TITLE
DOC update example capture_repr

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -971,7 +971,7 @@ are:
 * ``__str__`` - returns a string containing a nicely printable representation
   of an object. This is what is used when you ``print()`` an object or pass it
   to ``format()``.
-* ``_repr_html__`` - returns a HTML version of the object. This method is only
+* ``_repr_html_`` - returns a HTML version of the object. This method is only
   present in some objects, for example, pandas dataframes.
 
 The default setting is::
@@ -981,15 +981,16 @@ The default setting is::
             'capture_repr': ('_repr_html_', '__repr__'),
         }
 
-With this setting, for every code block, if the last statement is an expression,
-Sphinx-Gallery would first attempt to capture the ``_repr_html_``. If this
-method does not exist for the expression, the second 'representation' method
-in the tuple, ``__repr__``, would be captured. If the ``__repr__`` also does not
-exist (unlikely for non-user defined objects), nothing would be captured. Data
-directed to standard output is **always** captured.
+With the default setting Sphinx-Gallery would first attempt to capture the
+``_repr_html_`` of the last statement of a code block, *if* it is an
+expression. If this method does not exist for the expression, the second
+'representation' method in the tuple, ``__repr__``, would be captured. If the
+``__repr__`` also does not exist (unlikely for non-user defined objects),
+nothing would be captured. Data directed to standard output is **always**
+captured.
 
 To capture only data directed to standard output, configure ``'capture_repr'``
-to be an empty tuple (``'capture_repr': ()``). This will imitate the behaviour
+to be an empty tuple: ``'capture_repr': ()``. This will imitate the behaviour
 of Sphinx-Gallery prior to v0.5.0.
 
 From another perspective, take for example the following code block::
@@ -1004,36 +1005,36 @@ is directed to standard output. Further,
 * if ``capture_repr`` is an empty tuple, nothing else would be
   captured.
 * if ``capture_repr`` is ``('__repr__')``, ``2`` would also be captured.
-* if ``capture_repr`` is ``('_repr_html_', '__repr__')``, the default,
+* if ``capture_repr`` is ``('_repr_html_', '__repr__')`` (the default)
   Sphinx-Gallery would first attempt to capture ``_repr_html_``. Since this
   does not exist for ``a``, it will then attempt to capture ``__repr__``.
   The ``__repr__`` method does exist for ``a``, thus ``2`` would be also
   captured in this case.
 
 **Matplotlib note**: if the ``'capture_repr'`` tuple includes ``'__repr__'``
-and the last expression is a Matplotlib function call, there will generally be
-a yellow output box produced in the built documentation, as well as the figure.
-This is because matplotlib function calls usually return something as well as
-creating/amending the plot in standard output. For example,
-``matplotlib.plot()`` returns a list of ``Line2D`` objects representing the
-plotted data. The ``__repr__`` of this list would thus be captured. You can
-prevent this by:
+and/or ``'__str__'``, code blocks which have a Matplotlib function call as the
+last expression will generally produce a yellow output box in the built
+documentation, as well as the figure. This is because matplotlib function calls
+usually return something as well as creating/amending the plot in standard
+output. For example, ``matplotlib.plot()`` returns a list of ``Line2D`` objects
+representing the plotted data. This list has a ``__repr__`` and a ``__str__``
+method which would thus be captured. You can prevent this by:
 
 * assigning the (last) plotting function to a temporary variable. For example::
 
-    import matplotlib as plt
+    import matplotlib.pyplot as plt
 
     _ = plt.plot([1, 2, 3, 4], [1, 4, 9, 16])
 
 * add ``plt.show()`` (which does not return anything) to the end of your
   code block. For example::
   
-    import matplotlib as plt
+    import matplotlib.pyplot as plt
 
     plt.plot([1, 2, 3, 4], [1, 4, 9, 16])
     plt.show()
 
-The unwanted string output does not occur if ``'capture_repr'`` is an empty
-tuple, as only data directed to standard output is captured.
+The unwanted string output will not occur if ``'capture_repr'`` is an empty
+tuple or does not contain ``__repr__`` or ``__str__``.
 
 .. _regular expressions: https://docs.python.org/2/library/re.html

--- a/examples/plot_capture_repr.py
+++ b/examples/plot_capture_repr.py
@@ -4,14 +4,14 @@ Capturing output representations
 ================================
 
 This example demonstrates how the configuration ``capture_repr``
-(:ref:`capture_repr`) works. The setting used to build this Sphinx-Gallery
-documentation is ``capture_repr: ('_repr_html_', '__repr__')``. The output that
-is captured with this setting can be observed in this example. Differences in
-outputs that would be captured with other ``capture_repr`` tuples is also
-explained.
+(:ref:`capture_repr`) works. The default ``capture_repr`` setting is
+``capture_repr: ('_repr_html_', '__repr__')`` and this was used to build this
+documentation. The output that is captured with this setting can be observed in
+this example. Differences in outputs that would be captured with other
+``capture_repr`` settings is also explained.
 """
 #%%
-# Nothing is captured for the code block above because no data is directed to
+# Nothing is captured for the code block below because no data is directed to
 # standard output and the last statement is not an expression.
 
 # example 1
@@ -27,11 +27,11 @@ b = 10
 b   # this is an expression
 
 #%%
-# Technically, Sphinx-Gallery first attempts to capture the ``_repr_html_``
-# of ``b`` as this is the first 'representation' method in the ``capture_repr``
-# tuple. As this method does not exist for ``b``, Sphinx-Gallery moves on to
-# try and capture the ``__repr__`` method, which is second in the tuple. This
-# does exist for ``b`` so it is captured and included above. 
+# Sphinx-Gallery first attempts to capture the ``_repr_html_`` of ``b`` as this
+# is the first 'representation' method in the ``capture_repr`` tuple. As this
+# method does not exist for ``b``, Sphinx-Gallery moves on and tries to capture
+# the ``__repr__`` method, which is second in the tuple. This does exist for
+# ``b`` so it is captured and the output is seen above. 
 # 
 # A pandas dataframe is used in the code block below to provide an example of
 # an expression with a ``_repr_html_`` method. 
@@ -45,10 +45,10 @@ df
 #%%
 # The pandas dataframe ``df`` has both a ``__repr__`` and ``_repr_html_``
 # method. As ``_repr_html_`` appears first in the ``capture_repr`` tuple, the
-# ``_repr_html_`` is captured in preference.
+# ``_repr_html_`` is captured in preference to ``__repr__``.
 #
-# For the example below, the last statement is an expression and there is
-# standard output data:
+# For the example below, there is data directed to standard output and the last
+# statement is an expression.
 
 # example 4
 print('Hello world')
@@ -57,26 +57,30 @@ a + b
 #%%
 # ``print()`` outputs to standard output, which is always captured. The
 # string ``'Hello world'`` is thus captured. A 'representation' of the last
-# expression is also captured. Again, since this expression does not have a
-# ``_repr_html_`` method, the ``__repr__`` method is captured.
+# expression is also captured. Again, since this expression ``a + b`` does not
+# have a ``_repr_html_`` method, the ``__repr__`` method is captured.
 #
 # The ``capture_repr`` configuration
 # ##################################
 #
-# The ``capture_repr`` configuration is an empty tuple by default. With this
-# setting, only data directed to standard output is captured. Thus, output
-# would only be captured for example 4.
+# The ``capture_repr`` configuration is ``('_repr_html_', '__repr__')`` by
+# default. This directs Sphinx-Gallery to capture 'representations' of the last
+# statement of a code block, if it is an expression. Sphinx-Gallery does
+# this according to the order 'representations' appear in the tuple. With the
+# default ``capture_repr`` setting, ``_repr_html_`` is attempted to be captured
+# first. If this method does not exist, the ``__repr__`` method would be
+# captured. If the ``__repr__`` also does not exist (unlikely for non-user
+# defined objects), nothing would be captured. For example, if the the
+# configuration was set to ``'capture_repr': ('_repr_html_')`` nothing would be
+# captured for example 2 as ``b`` does not have a ``_repr_html_``.
+# You can change the 'representations' in the ``capture_repr`` tuple to finely
+# tune what is captured in your example ``.py`` files.
 # 
-# Adding 'representations' to the ``capture_repr`` tuple would direct
-# Sphinx-Gallery to capture a 'representation' of the last statement, only if
-# it is an expression. In examples 2, 3 and 4, the last statement is an
-# expression. If the ``capture_repr`` configuration was *not* an empty tuple,
-# Sphinx-Gallery would attempt to capture a 'representation' of the last
-# expression for these examples. This would be performed according to the order
-# that the ' ' methods are given in the tuple, with
-# preference given to earlier methods.
-#
-# If no 'representation' in the ``capture_repr`` tuple is present for a last
-# expression, nothing would be captured. For example, if the the configuration
-# was set to ``'capture_repr': ('_repr_html_')`` nothing would be captured for
-# example 2 as ``b`` does not have a ``_repr_html_``.
+# To only capture data directed to standard output you can set ``capture_repr``
+# to be an empty tuple: ``capture_repr: ()``. With this setting, only data
+# directed to standard output is captured. For the examples above, output would
+# only be captured for example 4. Although the last statement is an expression
+# for examples 2, 3 and 4 no 'representation' of the last expression would be
+# output. You would need to add ``print()`` to the last expression to capture
+# a 'representation' of it. The empty tuple setting imitates the behaviour of
+# Sphinx-Gallery prior to v0.5.0, when this configuration was introduced.


### PR DESCRIPTION
I forgot to update the example gallery for `capture_repr` after we decided to change the default to `capture_repr: ('_repr_html_', '__repr__')`.

Also fixed some typos I made in configuration.