### PR TITLE
Fix JPEG thumbnail generation

### DIFF
--- a/sphinx_gallery/utils.py
+++ b/sphinx_gallery/utils.py
@@ -53,7 +53,11 @@ def scale_image(in_fname, out_fname, max_width, max_height):
     pos_insert = ((max_width - width_sc) // 2, (max_height - height_sc) // 2)
     thumb.paste(img, pos_insert)
 
-    thumb.save(out_fname)
+    try:
+        thumb.save(out_fname)
+    except IOError:
+        # try again, without the alpha channel (e.g., for JPEG)
+        thumb.convert('RGB').save(out_fname)
 
 
 def replace_py_ipynb(fname):


### PR DESCRIPTION
Since Pillow 4.2, an exception is thrown when trying to save an image with an alpha channel to JPEG (because it cannot store this channel).

This simply checks for an exception and tries again without the alpha channel. Unfortunately Pillow just uses IOError instead of a specific exception type, and I think that checking the exception message is fragile. If the IOError has another cause, such as the disk being full, then the second save will probably fail the same way.