### PR TITLE
Mark sphinx extension as parallel-safe for writing

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -598,7 +598,7 @@ def setup(app):
     app.connect('build-finished', summarize_failing_examples)
     app.connect('build-finished', embed_code_links)
     metadata = {'parallel_read_safe': True,
-                'parallel_write_safe': False,
+                'parallel_write_safe': True,
                 'version': _sg_version}
     return metadata
 


### PR DESCRIPTION
I tested this with the astropy docs and everything seems to work fine when building in parallel

Fixes https://github.com/sphinx-gallery/sphinx-gallery/issues/560