### PR TITLE
ENH: Add dev/stable distinction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           root: doc/_build/html
           paths: .
 
-  deploy_docs:
+  deploy_dev:
     docker:
       - image: circleci/python:3.6-stretch
     steps:
@@ -69,7 +69,19 @@ jobs:
             - "aa:70:d9:6b:35:74:50:d1:f7:73:fb:3d:3c:79:cd:5c"
       - attach_workspace:
           at: rtd_html
-      - run: ./docs_deploy.sh rtd_html
+      - run: ./.circleci/docs_deploy.sh rtd_html dev
+
+  deploy_stable:
+    docker:
+      - image: circleci/python:3.6-stretch
+    steps:
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "aa:70:d9:6b:35:74:50:d1:f7:73:fb:3d:3c:79:cd:5c"
+      - attach_workspace:
+          at: rtd_html
+      - run: ./.circleci/docs_deploy.sh rtd_html stable
 
 
 workflows:
@@ -77,9 +89,17 @@ workflows:
   default:
     jobs:
       - build_docs
-      - deploy_docs:
+      - deploy_dev:
           requires:
             - build_docs
           filters:
             branches:
               only: master
+      - deploy_stable:
+          requires:
+            - build_docs
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^Release.*$/

--- a/.circleci/docs_deploy.sh
+++ b/.circleci/docs_deploy.sh
@@ -8,10 +8,11 @@ set -e
 pwd
 
 siteSource="$1"
+destDir="$2"
 
-if [ ! -d "$siteSource" ]
+if [ ! -d "$siteSource" ] || [ ! -d "$destDir" ];
 then
-    echo "Usage: $0 <site source dir>"
+    echo "Usage: $0 <site source dir> <site dest dir>"
     exit 1
 fi
 
@@ -19,13 +20,12 @@ fi
 git config --global user.email "Circle CI" > /dev/null 2>&1
 git config --global user.name "bot@try.out" > /dev/null 2>&1
 git clone git@github.com:sphinx-gallery/sphinx-gallery.github.io.git
-cd sphinx-gallery.github.io/
+mkdir -p sphinx-gallery.github.io/${destDir}
+cd sphinx-gallery.github.io/${destDir}
 
 # copy over or recompile the new site
 git rm -rf .
 cp -a "../${siteSource}/." .
-# github nojekyll
-touch .nojekyll
 
 # stage any changes and new files
 git add -A

--- a/doc/_static/theme_override.css
+++ b/doc/_static/theme_override.css
@@ -13,3 +13,10 @@ div[class^="highlight"] a {
 div[class^="highlight"] a:hover {
     background-color: #ABECFC;
 }
+
+.rst-versions {
+    position: relative;
+}
+.rst-versions.shift-up {
+    overflow-y: visible;
+}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,0 +1,25 @@
+{% extends "!layout.html" %}
+
+  {% block menu %}
+
+  <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+      <span class="rst-current-version" data-toggle="rst-current-version">
+        <span class="fa fa-book"> Versions</span>
+        v: {{ current_version }}
+        <span class="fa fa-caret-down"></span>
+      </span>
+      <div class="rst-other-versions">
+        <dl>
+          <dt>{{ _('Versions') }}</dt>
+          {% for slug, url in versions %}
+            <dd><a href="{{ url }}">{{ slug }}</a></dd>
+          {% endfor %}
+        </dl>
+      </div>
+    </div>
+
+    {{ super() }}
+
+  {% endblock %}
+
+  {% block versions %}{% endblock %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,6 +19,7 @@ import warnings
 
 import sphinx_gallery
 from sphinx_gallery.sorting import ExplicitOrder, NumberOfCodeLinesSortKey
+import sphinx_rtd_theme
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -63,7 +64,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Sphinx-Gallery'
-copyright = u'2014-%s, Óscar Nájera' % date.today().year
+copyright = u'2014-%s, Sphinx-gallery developers' % date.today().year
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -128,16 +129,9 @@ html_theme = os.environ.get('SPHX_GLR_THEME', 'rtd')
 
 # on_rtd is whether we are on readthedocs.org, this line of code grabbed
 # from docs.readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-# only import rtd theme and set it if want to build docs locally
-if not on_rtd and html_theme == 'rtd':
-    import sphinx_rtd_theme
+if html_theme == 'rtd':
     html_theme = 'sphinx_rtd_theme'
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-else:
-    # otherwise, readthedocs.org uses their theme by default, so no need to
-    # specify it
-    html_theme = 'default'
 
 
 def setup(app):
@@ -148,7 +142,7 @@ def setup(app):
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
@@ -205,7 +199,7 @@ html_static_path = ['_static']
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True
@@ -374,3 +368,11 @@ sphinx_gallery_conf = {
 warnings.filterwarnings("ignore", category=UserWarning,
                         message='Matplotlib is currently using agg, which is a'
                                 ' non-GUI backend, so cannot show the figure.')
+
+html_context = {
+    'current_version': 'dev' if 'dev' in version else 'stable',
+    'versions': (
+        ('dev', 'https://sphinx-gallery.github.io/dev'),
+        ('stable', 'https://sphinx-gallery.github.io/stable'),
+    )
+}

--- a/sphinx_gallery/__init__.py
+++ b/sphinx_gallery/__init__.py
@@ -4,6 +4,8 @@ Sphinx Gallery
 
 """
 import os
+# dev versions should have "dev" in them, stable should not.
+# doc/conf.py makes use of this to set the version drop-down.
 __version__ = '0.5.0.dev0'
 
 


### PR DESCRIPTION
Closes #559.

[EDIT: I manually created] ~~Created~~:

https://sphinx-gallery.github.io/dev/
https://sphinx-gallery.github.io/stable/

Currently just copies of https://sphinx-gallery.github.io/. Steps:

1. Make sure people are happy with how CircleCI renders the version drop-down, then merge this PR
2. Make sure that CircleCI deploys to https://sphinx-gallery.github.io/dev/
3. Release a new version
4. Make sure that CircleCI deploys to https://sphinx-gallery.github.io/stable/ based on the tag
5. Overwrite `https://sphinx-gallery.github.io/index.html` with a URL redirect and remove all other files other than `dev`/`stable` dirs, `index.html`, and `.nojekyll`.