### PR TITLE
[MRG] Release v0.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,4 +102,4 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^Release.*$/
+              only: /^v\d+\.\d+\.\d+$/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Change Log
 ==========
 
-v0.5.0.stable.0
+v0.5.0
 ---------------
 
 Developer changes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,23 +1,91 @@
 Change Log
 ==========
 
-v0.5.0
-------
+v0.5.0.stable.0
+---------------
 
 Developer changes
 '''''''''''''''''
 
-- N/A
+- Separated 'dev' documentation, which tracks master and 'stable' documentation,
+  which follows releases.
+- Added official jpeg support.
 
 Incompatible changes
 ''''''''''''''''''''
 
 - Dropped support for Sphinx < 1.8.3.
 - Dropped support for Python < 3.5.
+- Added ``capture_repr`` configuration with the default setting 
+  ``('_repr_html_', __repr__')``. This may result the capturing of unwanted output
+  in existing projects. Set ``capture_repr: ()`` to return to behaviour prior
+  to this release.
 
 **Implemented enhancements:**
 
--  ENH: Support ``#%%`` cell separator `#370 <https://github.com/sphinx-gallery/sphinx-gallery/pull/518>`__ (`lucyleeow <https://github.com/lucyleeow>`_)
+-  Explain the inputs of the image scrapers `#472 <https://github.com/sphinx-gallery/sphinx-gallery/issues/472>`__
+-  Capture HTML output as in Jupyter `#396 <https://github.com/sphinx-gallery/sphinx-gallery/issues/396>`__
+-  Feature request: Add an option for different cell separations `#370 <https://github.com/sphinx-gallery/sphinx-gallery/issues/370>`__
+-  Mark sphinx extension as parallel-safe for writing `#561 <https://github.com/sphinx-gallery/sphinx-gallery/pull/561>`__ (`astrofrog <https://github.com/astrofrog>`__)
+-  ENH: Support linking to builtin modules `#558 <https://github.com/sphinx-gallery/sphinx-gallery/pull/558>`__ (`larsoner <https://github.com/larsoner>`__)
+-  ENH: Add official JPG support and better tests `#557 <https://github.com/sphinx-gallery/sphinx-gallery/pull/557>`__ (`larsoner <https://github.com/larsoner>`__)
+-  [MRG] ENH: Capture ’repr’s of last expression `#541 <https://github.com/sphinx-gallery/sphinx-gallery/pull/541>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
+-  look for both ‘README’ and ‘readme’ `#535 <https://github.com/sphinx-gallery/sphinx-gallery/pull/535>`__ (`revesansparole <https://github.com/revesansparole>`__)
+-  ENH: Speed up builds `#526 <https://github.com/sphinx-gallery/sphinx-gallery/pull/526>`__ (`larsoner <https://github.com/larsoner>`__)
+-  ENH: Add live object refs and methods `#525 <https://github.com/sphinx-gallery/sphinx-gallery/pull/525>`__ (`larsoner <https://github.com/larsoner>`__)
+-  ENH: Show memory usage, too `#523 <https://github.com/sphinx-gallery/sphinx-gallery/pull/523>`__ (`larsoner <https://github.com/larsoner>`__)
+-  [MRG] EHN support #%% cell separators `#518 <https://github.com/sphinx-gallery/sphinx-gallery/pull/518>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
+-  MAINT: Remove support for old Python and Sphinx `#513 <https://github.com/sphinx-gallery/sphinx-gallery/pull/513>`__ (`larsoner <https://github.com/larsoner>`__)
+
+**Fixed bugs:**
+
+-  Documentation is ahead of current release `#559 <https://github.com/sphinx-gallery/sphinx-gallery/issues/559>`__
+-  Fix JPEG thumbnail generation `#556 <https://github.com/sphinx-gallery/sphinx-gallery/pull/556>`__ (`rgov <https://github.com/rgov>`__)
+-  [MRG] Fix terminal rst block last word `#548 <https://github.com/sphinx-gallery/sphinx-gallery/pull/548>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
+-  [MRG][FIX] Remove output box from print(__doc__) `#529 <https://github.com/sphinx-gallery/sphinx-gallery/pull/529>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
+-  BUG: Fix kwargs modification in loop `#527 <https://github.com/sphinx-gallery/sphinx-gallery/pull/527>`__ (`larsoner <https://github.com/larsoner>`__)
+-  MAINT: Fix AppVeyor `#524 <https://github.com/sphinx-gallery/sphinx-gallery/pull/524>`__ (`larsoner <https://github.com/larsoner>`__)
+
+**Closed issues:**
+
+-  Making sphinx-gallery parallel_write_safe `#560 <https://github.com/sphinx-gallery/sphinx-gallery/issues/560>`__
+-  Mayavi example cannot run in binder `#554 <https://github.com/sphinx-gallery/sphinx-gallery/issues/554>`__
+-  Support pyqtgraph plots `#553 <https://github.com/sphinx-gallery/sphinx-gallery/issues/553>`__
+-  Last word in rst used as code `#546 <https://github.com/sphinx-gallery/sphinx-gallery/issues/546>`__
+-  ENH capture ’repr’s of last expression `#540 <https://github.com/sphinx-gallery/sphinx-gallery/issues/540>`__
+-  Mention list of projects using sphinx-gallery in a documentation page `#536 <https://github.com/sphinx-gallery/sphinx-gallery/issues/536>`__
+-  consider looking also for ‘readme.\*’ instead of only ‘README.\*’ `#534 <https://github.com/sphinx-gallery/sphinx-gallery/issues/534>`__
+-  Small regression in 0.4.1: print(__doc__) creates empty output block `#528 <https://github.com/sphinx-gallery/sphinx-gallery/issues/528>`__
+-  Show memory usage in build output `#522 <https://github.com/sphinx-gallery/sphinx-gallery/issues/522>`__
+-  Linking to external examples `#519 <https://github.com/sphinx-gallery/sphinx-gallery/issues/519>`__
+-  Intro text gets truncated on ‘-’ character `#517 <https://github.com/sphinx-gallery/sphinx-gallery/issues/517>`__
+-  REL: New release `#507 <https://github.com/sphinx-gallery/sphinx-gallery/issues/507>`__
+-  Matplotlib raises warning when ‘pyplot.show()’ is called `#488 <https://github.com/sphinx-gallery/sphinx-gallery/issues/488>`__
+-  Only support the latest 2 or 3 Sphinx versions `#407 <https://github.com/sphinx-gallery/sphinx-gallery/issues/407>`__
+-  Drop Python 2.X support `#405 <https://github.com/sphinx-gallery/sphinx-gallery/issues/405>`__
+-  Inspiration from new gallery package for sphinx: sphinx-exhibit `#402 <https://github.com/sphinx-gallery/sphinx-gallery/issues/402>`__
+-  DOC: each example should start by explaining why it’s there `#143 <https://github.com/sphinx-gallery/sphinx-gallery/issues/143>`__
+
+**Merged pull requests:**
+
+-  [MRG] DOC: Add warning filter note in doc `#564 <https://github.com/sphinx-gallery/sphinx-gallery/pull/564>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
+-  [MRG] DOC: Explain each example `#563 <https://github.com/sphinx-gallery/sphinx-gallery/pull/563>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
+-  ENH: Add dev/stable distinction `#562 <https://github.com/sphinx-gallery/sphinx-gallery/pull/562>`__ (`larsoner <https://github.com/larsoner>`__)
+-  DOC update example capture_repr `#552 <https://github.com/sphinx-gallery/sphinx-gallery/pull/552>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
+-  BUG: Fix index check `#551 <https://github.com/sphinx-gallery/sphinx-gallery/pull/551>`__ (`larsoner <https://github.com/larsoner>`__)
+-  FIX: Fix spurious failures `#550 <https://github.com/sphinx-gallery/sphinx-gallery/pull/550>`__ (`larsoner <https://github.com/larsoner>`__)
+-  MAINT: Update CIs `#549 <https://github.com/sphinx-gallery/sphinx-gallery/pull/549>`__ (`larsoner <https://github.com/larsoner>`__)
+-  list of projects using sphinx-gallery `#547 <https://github.com/sphinx-gallery/sphinx-gallery/pull/547>`__ (`emmanuelle <https://github.com/emmanuelle>`__)
+-  [MRG] DOC typos and clarifications `#545 <https://github.com/sphinx-gallery/sphinx-gallery/pull/545>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
+-  add class to clear tag `#543 <https://github.com/sphinx-gallery/sphinx-gallery/pull/543>`__ (`dorafc <https://github.com/dorafc>`__)
+-  MAINT: Fix for 3.8 `#542 <https://github.com/sphinx-gallery/sphinx-gallery/pull/542>`__ (`larsoner <https://github.com/larsoner>`__)
+-  [MRG] DOC: Explain image scraper inputs `#539 <https://github.com/sphinx-gallery/sphinx-gallery/pull/539>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
+-  [MRG] Allow punctuation marks in title `#537 <https://github.com/sphinx-gallery/sphinx-gallery/pull/537>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
+-  Improve documentation `#533 <https://github.com/sphinx-gallery/sphinx-gallery/pull/533>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
+-  ENH: Add direct link to artifact `#532 <https://github.com/sphinx-gallery/sphinx-gallery/pull/532>`__ (`larsoner <https://github.com/larsoner>`__)
+-  [MRG] Remove matplotlib agg backend + plt.show warnings from doc `#521 <https://github.com/sphinx-gallery/sphinx-gallery/pull/521>`__ (`lesteve <https://github.com/lesteve>`__)
+-  MAINT: Fixes for latest pytest `#516 <https://github.com/sphinx-gallery/sphinx-gallery/pull/516>`__ (`larsoner <https://github.com/larsoner>`__)
+-  Add FURY to the sphinx-gallery users list `#515 <https://github.com/sphinx-gallery/sphinx-gallery/pull/515>`__ (`skoudoro <https://github.com/skoudoro>`__)
 
 v0.4.0
 ------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -971,8 +971,8 @@ Controlling what output is captured
 
 .. note::
 
-    To return to the behaviour of Sphinx-Gallery prior to v0.5.0, configure
-    ``capture_repr`` to be an empty tuple (i.e.,``capture_repr: ()``).
+    Configure ``capture_repr`` to be an empty tuple (i.e.,``capture_repr: ()``)
+    to return to the output capturing behaviour prior to release v0.5.0.
 
 The ``capture_repr`` configuration allows the user to control what output
 is captured, while executing the example ``.py`` files, and subsequently

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -969,6 +969,11 @@ you can do::
 Controlling what output is captured
 ===================================
 
+.. note::
+
+    To return to the behaviour of Sphinx-Gallery prior to v0.5.0, configure
+    ``capture_repr`` to be an empty tuple (i.e.,``capture_repr: ()``).
+
 The ``capture_repr`` configuration allows the user to control what output
 is captured, while executing the example ``.py`` files, and subsequently
 incorporated into the built documentation. Data directed to standard output

--- a/doc/maintainers.rst
+++ b/doc/maintainers.rst
@@ -66,9 +66,9 @@ Prepare for release
 
 4. Update version
 
-     Update the version in ``sphinx_gallery/__init__.py``. It should end in
-     ``dev0``. You should remove this text, and the remaining number will become
-     the version for this release.
+     Update the version in ``sphinx_gallery/__init__.py``, which should end in
+     ``.dev0``. You should remove ``.dev0``, and the remaining numbers will 
+     become the version for this release.
 
 5. Open a Pull Request that contains the two changes we've made above
 

--- a/doc/maintainers.rst
+++ b/doc/maintainers.rst
@@ -41,10 +41,12 @@ Prepare for release
     1. Use `github_changelog_generator
        <https://github.com/skywinder/github-changelog-generator#installation>`_ to
        gather all merged pull requests and closed issues during the development
-       cycle. We do this because our failing discipline of writing in the
-       CHANGES.rst all relevant changes, this helps our memory. ::
+       cycle. You will likely need to `generate a Github token <https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token>`_
+       as Github only allows 50 unauthenticated requests per hour. We do this
+       because our failing discipline of writing in the CHANGES.rst all relevant
+       changes, this helps our memory. ::
 
-          github_changelog_generator sphinx-gallery/sphinx-gallery --between-tags v0.3.0,v0.4.0
+          github_changelog_generator sphinx-gallery/sphinx-gallery --since-tag=v0.5.0 --token <your-40-digit-token>
 
     2. Edit CHANGELOG.md to look reasonable (it will be used later)
 

--- a/sphinx_gallery/__init__.py
+++ b/sphinx_gallery/__init__.py
@@ -6,7 +6,7 @@ Sphinx Gallery
 import os
 # dev versions should have "dev" in them, stable should not.
 # doc/conf.py makes use of this to set the version drop-down.
-__version__ = '0.5.0.dev0'
+__version__ = '0.5.0.'
 
 
 def glr_path_static():

--- a/sphinx_gallery/__init__.py
+++ b/sphinx_gallery/__init__.py
@@ -6,7 +6,7 @@ Sphinx Gallery
 import os
 # dev versions should have "dev" in them, stable should not.
 # doc/conf.py makes use of this to set the version drop-down.
-__version__ = '0.5.0.'
+__version__ = '0.5.0'
 
 
 def glr_path_static():


### PR DESCRIPTION
- Updated changelog
- Updated maintainers documentation (there is no `between-tags` parameter for `github_changelog_generator` anymore)
- Added tl;dr note to `configuration.rst` advising how to revert capturing behaviour

Wasn't sure about:

> Update the version in `sphinx_gallery/__init__.py`. It should end in dev0. You should remove this text, and the remaining number will become the version for this release.

I removed the 'dev0'. If this is correct, I will amend this note to:

> Update the version in `sphinx_gallery/__init__.py`, which should end in dev0. You should remove 'dev0', and the remaining number will become the version for this release.

