### PR TITLE
URLError

### DIFF
--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -255,9 +255,11 @@ class SphinxDocLinkResolver(object):
 
 
 def _handle_http_url_error(e, msg='fetching'):
-    extra = e.code if isinstance(e, HTTPError) else e.reason
-    logger.warning('The following HTTP Error has occurred %s %s: %s (%s)',
-                   msg, e.url, extra, e.msg)
+    if isinstance(e, URLError):
+        error_msg = '%s: %s' % (msg, e.reason)
+    elif isinstance(e, HTTPError):
+        error_msg = '%s %s: %s (%s)' % (msg, e.url, e.code, e.msg)
+    logger.warning('The following HTTP Error has occurred %s' % error_msg)
 
 
 def _embed_code_links(app, gallery_conf, gallery_dir):

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -255,11 +255,12 @@ class SphinxDocLinkResolver(object):
 
 
 def _handle_http_url_error(e, msg='fetching'):
-    if isinstance(e, URLError):
-        error_msg = '%s: %s' % (msg, e.reason)
-    elif isinstance(e, HTTPError):
+    if isinstance(e, HTTPError):
         error_msg = '%s %s: %s (%s)' % (msg, e.url, e.code, e.msg)
-    logger.warning('The following HTTP Error has occurred %s' % error_msg)
+    elif isinstance(e, URLError):
+        error_msg = '%s: %s' % (msg, e.reason)
+    logger.warning('The following %s has occurred %s' % (
+        type(e).__name__, error_msg))
 
 
 def _embed_code_links(app, gallery_conf, gallery_dir):


### PR DESCRIPTION
The function [_handle_http_url_error](https://github.com/sphinx-gallery/sphinx-gallery/blob/master/sphinx_gallery/docs_resolv.py#L257) seems to be used for displaying an error message when there's url related issues. However, the function can either take URLError or HTTPError and the URLError doesn't have attributes `url` and `msg`.

closes #568