### PR TITLE
Remove the note link to downloads from pdf output

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -857,12 +857,13 @@ def save_rst_example(example_rst, example_file, time_elapsed,
 
     binder_text = (" or to run this example in your browser via Binder"
                    if len(binder_conf) else "")
-    example_rst = (".. note::\n"
-                   "    :class: sphx-glr-download-link-note\n\n"
-                   "    Click :ref:`here <sphx_glr_download_{0}>` "
-                   "to download the full example code{1}\n"
-                   ".. rst-class:: sphx-glr-example-title\n\n"
-                   ".. _sphx_glr_{0}:\n\n"
+    example_rst = (".. only:: html\n\n"
+                   "    .. note::\n"
+                   "        :class: sphx-glr-download-link-note\n\n"
+                   "        Click :ref:`here <sphx_glr_download_{0}>` "
+                   "    to download the full example code{1}\n"
+                   "    .. rst-class:: sphx-glr-example-title\n\n"
+                   "    .. _sphx_glr_{0}:\n\n"
                    ).format(ref_fname, binder_text) + example_rst
 
     if time_elapsed >= gallery_conf["min_reported_time"]:

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -417,6 +417,16 @@ def test_remove_config_comments(gallery_conf):
     assert '# sphinx_gallery_thumbnail_number = 1' not in rst
 
 
+def test_download_link_note_only_html(gallery_conf):
+    """Test if the download_link."""
+    rst = _generate_rst(gallery_conf, 'test.py', CONTENT)
+    download_link_note = (".. only:: html\n\n"
+                          "    .. note::\n"
+                          "        :class: sphx-glr-download-link-note\n\n"
+                          )
+    assert download_link_note in rst
+
+
 @pytest.mark.parametrize('ext', ('.txt', '.rst', '.bad'))
 def test_gen_dir_rst(gallery_conf, fakesphinxapp, ext):
     """Test gen_dir_rst."""

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -418,7 +418,7 @@ def test_remove_config_comments(gallery_conf):
 
 
 def test_download_link_note_only_html(gallery_conf):
-    """Test if the download_link."""
+    """Test html only directive for download_link."""
     rst = _generate_rst(gallery_conf, 'test.py', CONTENT)
     download_link_note = (".. only:: html\n\n"
                           "    .. note::\n"


### PR DESCRIPTION
- wrap the note with a `.. only:: html` directive
- add a test

closes #572 