### PR TITLE
BUG: Fix repr None

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -545,7 +545,7 @@ def execute_code_block(compiler, block, example_globals,
                 try:
                     last_repr = getattr(___, meth)()
                     # for case when last statement is print()
-                    if last_repr == 'None':
+                    if last_repr is None or last_repr == 'None':
                         repr_meth = None
                     else:
                         repr_meth = meth

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -620,6 +620,13 @@ class_inst = repr_and_html_class()
 class_inst
 """
 
+code_plt = """
+import matplotlib.pyplot as plt
+fig = plt.figure()
+plt.close('all')
+fig
+"""
+
 html_out = """.. only:: builder_html
 
     .. raw:: html
@@ -683,7 +690,8 @@ def _clean_output(output):
     pytest.param(('__repr__', '_repr_html_'), code_repr_and_html,
                  'This is the __repr__', id='repr_and_html,(repr,html)'),
     pytest.param(('_repr_html_', '__repr__'), code_repr_only,
-                 'This is the __repr__', id='repr_only,(html,repr)')
+                 'This is the __repr__', id='repr_only,(html,repr)'),
+    pytest.param(('_repr_html_',), code_plt, '', id='html_none'),
 ])
 def test_capture_repr(gallery_conf, capture_repr, code, expected_out):
     """Tests output capturing with various capture_repr settings."""


### PR DESCRIPTION
Fixes this bug:
```
  File "/home/larsoner/python/sphinx-gallery/sphinx_gallery/gen_rst.py", line 570, in execute_code_block
    captured_html = html_header.format(indent(last_repr, u' ' * 8))
  File "/usr/lib/python3.8/textwrap.py", line 480, in indent
    return ''.join(prefixed_lines())
  File "/usr/lib/python3.8/textwrap.py", line 478, in prefixed_lines
    for line in text.splitlines(True):
AttributeError: 'NoneType' object has no attribute 'splitlines'

Exception occurred:
  File "/usr/lib/python3.8/textwrap.py", line 478, in prefixed_lines
    for line in text.splitlines(True):
AttributeError: 'NoneType' object has no attribute 'splitlines'
```
Will merge once CIs are happy since this seems like a pretty clear bug, and it's going to hold up using `_repr_html_` in MNE.

@lucyleeow feel free to take a quick look when you get a chance.