### PR TITLE
mention literalinclude in the doc

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -64,6 +64,20 @@ its reference
 it generated has the name ``sphx_glr_plot_0_sin_001.png``
 and its thumbnail is ``sphx_glr_plot_0_sin_thumb.png``
 
+You can also include part of a gallery script elsewhere in your documentation
+using the `literalinclude directive <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-literalinclude>`_, in order to limit code duplication::
+
+   .. literalinclude:: ../examples/plot_0_sin.py
+      :language: python
+      :lines: 43-53
+
+The above directive inserts the following block:
+
+.. literalinclude:: ../examples/plot_0_sin.py
+    :language: python
+    :lines: 43-51
+
+
 .. _custom_scraper:
 
 Write a custom image scraper

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -69,7 +69,8 @@ using the `literalinclude directive <https://www.sphinx-doc.org/en/master/usage/
 
    .. literalinclude:: ../examples/plot_0_sin.py
       :language: python
-      :lines: 43-53
+      :start-after: # License: BSD 3 clause
+      :end-before: # To avoid matplotlib
 
 The above directive inserts the following block:
 
@@ -77,6 +78,12 @@ The above directive inserts the following block:
     :language: python
     :lines: 43-51
 
+.. warning::
+
+   Using literalinclude is fragile and can break easily when examples are
+   changed (all the more when line numbers are used instead of ``start-after``
+   and  ``end-before``). Use with caution: linking directly to examples is
+   a more robust alternative.
 
 .. _custom_scraper:
 

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -65,7 +65,7 @@ it generated has the name ``sphx_glr_plot_0_sin_001.png``
 and its thumbnail is ``sphx_glr_plot_0_sin_thumb.png``
 
 You can also include part of a gallery script elsewhere in your documentation
-using the `literalinclude directive <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-literalinclude>`_, in order to limit code duplication::
+using the :rst:dir:`literalinclude` directive, in order to limit code duplication::
 
    .. literalinclude:: ../examples/plot_0_sin.py
       :language: python
@@ -76,7 +76,8 @@ The above directive inserts the following block:
 
 .. literalinclude:: ../examples/plot_0_sin.py
     :language: python
-    :lines: 43-51
+    :start-after: # License: BSD 3 clause
+    :end-before: # To avoid matplotlib
 
 .. warning::
 


### PR DESCRIPTION
Limiting code duplication makes documentation more robust, so I added an example of `literalinclude` in the doc, I hope this is the right place.