### PR TITLE
[MRG] Fix backreferences for functions not directly imported

### DIFF
--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -66,10 +66,10 @@ class NameFinder(ast.NodeVisitor):
         # ensure that max is at least one
         max_import_splits = len(max(imported_names_split + [''], key=len))
         for name in self.accessed_names:
-            # ensures self.imported_names with '.' are not missed by adding
-            # consecutive '.' split names to local_name
             for split_level in range(max_import_splits):
                 local_name_split = name.split('.')
+                # add the next '.' split to local_name
+                # ensures self.imported names with '.' are not missed
                 local_name = '.'.join(local_name_split[:split_level+1])
                 remainder = name[len(local_name):]
                 class_attr = False

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -62,8 +62,12 @@ class NameFinder(ast.NodeVisitor):
     def get_mapping(self):
         imported_names_split = \
             [key.split('.') for key in self.imported_names.keys()]
+        if imported_names_split:
+            max_import_splits = len(max(imported_names_split, key=len))
+        else:
+            max_import_splits = 1
         for name in self.accessed_names:
-            for i in range(len(max(imported_names_split, key=len))):
+            for i in range(max_import_splits):
                 local_name_split = name.split('.')
                 local_name = '.'.join(local_name_split[:i+1])
                 remainder = name[len(local_name):]

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -111,7 +111,6 @@ class NameFinder(ast.NodeVisitor):
                             full_name = '.'.join(
                                 module[:depth] + [class_name] + method)
                             yield name, full_name, class_attr, is_class
-                    break
 
 
 def _from_import(a, b):

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -62,9 +62,6 @@ class NameFinder(ast.NodeVisitor):
     def get_mapping(self):
         imported_names_split = \
             [key.split('.') for key in self.imported_names.keys()]
-        print('accessed names')
-        print(self.accessed_names)
-        print(self.global_variables)
         for name in self.accessed_names:
             for i in range(len(max(imported_names_split, key=len))):
                 local_name_split = name.split('.')
@@ -195,7 +192,6 @@ def identify_names(script_blocks, global_variables=None, node=''):
     for key, value in fill_guess.items():
         if key not in example_code_obj:
             example_code_obj[key] = value
-    print(example_code_obj)
     return example_code_obj
 
 

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -63,9 +63,11 @@ class NameFinder(ast.NodeVisitor):
     def get_mapping(self):
         imported_names_split = \
             [key.split('.') for key in self.imported_names]
-        # ensure that max is at least one here
+        # ensure that max is at least one
         max_import_splits = len(max(imported_names_split + [''], key=len))
         for name in self.accessed_names:
+            # ensures self.imported_names with '.' are not missed by adding
+            # consecutive '.' split names to local_name
             for split_level in range(max_import_splits):
                 local_name_split = name.split('.')
                 local_name = '.'.join(local_name_split[:split_level+1])
@@ -109,7 +111,6 @@ class NameFinder(ast.NodeVisitor):
                             full_name = '.'.join(
                                 module[:depth] + [class_name] + method)
                             yield name, full_name, class_attr, is_class
-                            break
 
 
 def _from_import(a, b):

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -62,15 +62,13 @@ class NameFinder(ast.NodeVisitor):
 
     def get_mapping(self):
         imported_names_split = \
-            [key.split('.') for key in self.imported_names.keys()]
-        if imported_names_split:
-            max_import_splits = len(max(imported_names_split, key=len))
-        else:
-            max_import_splits = 1
+            [key.split('.') for key in self.imported_names]
+        # ensure that max is at least one here
+        max_import_splits = len(max(imported_names_split + [''], key=len))
         for name in self.accessed_names:
-            for i in range(max_import_splits):
+            for split_level in range(max_import_splits):
                 local_name_split = name.split('.')
-                local_name = '.'.join(local_name_split[:i+1])
+                local_name = '.'.join(local_name_split[:split_level+1])
                 remainder = name[len(local_name):]
                 class_attr = False
                 if local_name in self.imported_names:
@@ -111,6 +109,7 @@ class NameFinder(ast.NodeVisitor):
                             full_name = '.'.join(
                                 module[:depth] + [class_name] + method)
                             yield name, full_name, class_attr, is_class
+                            break
 
 
 def _from_import(a, b):

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -111,6 +111,7 @@ class NameFinder(ast.NodeVisitor):
                             full_name = '.'.join(
                                 module[:depth] + [class_name] + method)
                             yield name, full_name, class_attr, is_class
+                    break
 
 
 def _from_import(a, b):

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -95,12 +95,15 @@ This is an example.
 # \xc3\x9f
 from a.b import c
 import d as e
+import h.i
 print(c)
 e.HelloWorld().f.g
+h.i.j()
 """
     expected = {'c': {'name': 'c', 'module': 'a.b', 'module_short': 'a.b'},
                 'e.HelloWorld': {'name': 'HelloWorld', 'module': 'd',
-                                 'module_short': 'd'}}
+                                 'module_short': 'd'},
+                'h.i.j': {'name': 'j', 'module': 'h.i', 'module_short': 'h.i'}}
 
     fname = tmpdir.join("indentify_names.py")
     fname.write(code_str, 'wb')
@@ -115,10 +118,10 @@ e.HelloWorld().f.g
 Title
 -----
 
-This example uses :func:`h.i`.
+This example uses :func:`k.l`.
 '''
 """ + code_str.split(b"'''")[-1]
-    expected['h.i'] = {u'module': u'h', u'module_short': u'h', u'name': u'i'}
+    expected['k.l'] = {u'module': u'k', u'module_short': u'k', u'name': u'l'}
 
     fname = tmpdir.join("indentify_names.py")
     fname.write(code_str, 'wb')

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -243,6 +243,21 @@ def test_backreferences(sphinx_app):
     assert 'plot_future_imports.html' in lines  # backref via doc block
 
 
+@pytest.mark.parametrize('rst_file, example_used_in', [
+    ('sphinx_gallery.backreferences.identify_names.examples', 'plot_numpy_matplotlib'),
+    ('sphinx_gallery.sorting.ExplicitOrder.examples', 'plot_second_future_imports'),
+])
+def test_backreferences_examples(sphinx_app, rst_file, example_used_in):
+    """Test linking to mini-galleries using backreferences_dir."""
+    backref_dir = sphinx_app.srcdir
+    examples_rst = op.join(backref_dir, 'gen_modules', 'backreferences',
+                           rst_file)
+    print(examples_rst)
+    with codecs.open(examples_rst, 'r', 'utf-8') as fid:
+        lines = fid.read()
+    assert example_used_in in lines
+
+
 def _assert_mtimes(list_orig, list_new, different=(), ignore=()):
     assert ([op.basename(x) for x in list_orig] ==
             [op.basename(x) for x in list_new])

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -253,7 +253,6 @@ def test_backreferences_examples(sphinx_app, rst_file, example_used_in):
     backref_dir = sphinx_app.srcdir
     examples_rst = op.join(backref_dir, 'gen_modules', 'backreferences',
                            rst_file)
-    print(examples_rst)
     with codecs.open(examples_rst, 'r', 'utf-8') as fid:
         lines = fid.read()
     assert example_used_in in lines

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -196,6 +196,7 @@ def test_embed_links_and_styles(sphinx_app):
     assert 'warnings.html#warnings.warn' in lines
     assert 'itertools.html#itertools.compress' in lines
     assert 'numpy.ndarray.html' in lines
+    assert 'sphinx_gallery.backreferences.html#sphinx_gallery.backreferences.identify_names' in lines
     # instances have an extra CSS class
     assert 'class="sphx-glr-backref-module-matplotlib-figure sphx-glr-backref-type-py-class sphx-glr-backref-instance"><span class="n">x</span></a>' in lines  # noqa
     assert 'class="sphx-glr-backref-module-matplotlib-figure sphx-glr-backref-type-py-class"><span class="n">Figure</span></a>' in lines  # noqa

--- a/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
@@ -17,6 +17,7 @@ from matplotlib.figure import Figure
 from itertools import compress  # noqa
 import matplotlib
 import matplotlib.pyplot as plt
+import sphinx_gallery.backreferences
 
 from local_module import N  # N = 1000
 
@@ -38,3 +39,5 @@ x = Figure()  # plt.Figure should be decorated (class), x shouldn't (inst)
 # should not crash, nested resolution, but doesn't resolve because
 # NumPy intersphinx looks to numpy.random.mtrand.RandomState (?)
 np.random.RandomState(0)
+# test Issue 583
+sphinx_gallery.backreferences.identify_names([('text', 'Text block', 1)])


### PR DESCRIPTION
closes #583 

If an example uses a function like this:
```
import h.i

h.i.j()
```
[`get_mapping`](https://github.com/sphinx-gallery/sphinx-gallery/blob/44ed8000930a8b8cea70dcfda40a799750edee7d/sphinx_gallery/backreferences.py#L62) will check if `local_name`, in this case `h`, is in the `self.imported_names` dict. The key for this import would be `h.i` so it doesn't match.

I've added a for loop which will run for 'n' times, where 'n' is the max number of splits (`split('.')`) of all keys in `self.imported_names`. In each loop another split of the locally used name is added onto `local_name` which is checked to see if it exists in `self.imported_names`. e.g., for the above example the loop would run twice, first time `local_name` would be `h` and second time `local_name` would be `h.i`.

Not very elegant - open to changes @larsoner 

To remind myself, classes worked (as noted in #583) because when creating a class instance `local_name` existed in `self.global_variables` ([this line](https://github.com/sphinx-gallery/sphinx-gallery/blob/44ed8000930a8b8cea70dcfda40a799750edee7d/sphinx_gallery/backreferences.py#L71))

(thanks to @glemaitre for your help)