### PR TITLE
Remove duplicate doc_solver entry in the API reference structure

### DIFF
--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -27,6 +27,5 @@ every module.
    docs_resolv
    notebook
    downloads
-   docs_resolv
    sorting
    binder


### PR DESCRIPTION
I just started looking at this project today and noticed that `docs_resolv` is in the API Reference list twice.  This is just a 1-line PR to remove the second entry. 

![image](https://user-images.githubusercontent.com/57452607/72026044-635f4700-3237-11ea-814e-4710bec9aa5b.png)