### PR TITLE
[MRG] [ENH] Add css for pandas df

### DIFF
--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -206,6 +206,7 @@ table.dataframe table{
   border: none;
   border-collapse: collapse;
   border-spacing: 0;
+  border-color: transparent;
   color: black;
   font-size: 12px;
   table-layout: fixed;

--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -202,7 +202,7 @@ a.sphx-glr-backref-instance {
 /* Pandas dataframe css */
 /* Taken from: https://github.com/spatialaudio/nbsphinx/blob/fb3ba670fc1ba5f54d4c487573dbc1b4ecf7e9ff/src/nbsphinx.py#L587-L619 */
 
-table.dataframe table{
+table.dataframe {
   border: none !important;
   border-collapse: collapse;
   border-spacing: 0;

--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -203,7 +203,7 @@ a.sphx-glr-backref-instance {
 /* Taken from: https://github.com/spatialaudio/nbsphinx/blob/fb3ba670fc1ba5f54d4c487573dbc1b4ecf7e9ff/src/nbsphinx.py#L587-L619 */
 
 table.dataframe table{
-  border: none;
+  border: none !important;
   border-collapse: collapse;
   border-spacing: 0;
   border-color: transparent;

--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -198,3 +198,39 @@ p.sphx-glr-signature a.reference.external {
 a.sphx-glr-backref-instance {
   text-decoration: none;
 }
+
+/* Pandas dataframe css */
+/* Taken from: https://github.com/spatialaudio/nbsphinx/blob/fb3ba670fc1ba5f54d4c487573dbc1b4ecf7e9ff/src/nbsphinx.py#L587-L619 */
+
+table.dataframe table{
+  border: none;
+  border-collapse: collapse;
+  border-spacing: 0;
+  color: black;
+  font-size: 12px;
+  table-layout: fixed;
+}
+table.dataframe thead {
+  border-bottom: 1px solid black;
+  vertical-align: bottom;
+}
+table.dataframe tr,
+table.dataframe th,
+table.dataframe td {
+  text-align: right;
+  vertical-align: middle;
+  padding: 0.5em 0.5em;
+  line-height: normal;
+  white-space: normal;
+  max-width: none;
+  border: none;
+}
+table.dataframe th {
+  font-weight: bold;
+}
+table.dataframe tbody tr:nth-child(odd) {
+  background: #f5f5f5;
+}
+table.dataframe tbody tr:hover {
+  background: rgba(66, 165, 245, 0.2);
+}


### PR DESCRIPTION
closes #544 

Added CSS for pandas df, copied from nbsphinx (suggested here: https://github.com/sphinx-gallery/sphinx-gallery/issues/544#issuecomment-539992747).

I can include a border:
![bord](https://user-images.githubusercontent.com/23182829/72078012-90276300-32f8-11ea-9384-eed1b3b63e9a.png)

Or remove the black border:
![nobord](https://user-images.githubusercontent.com/23182829/72078035-99b0cb00-32f8-11ea-99c1-82d3dc4392e1.png)

The latter makes it look exactly like in jupyter notebook:
![image](https://user-images.githubusercontent.com/23182829/72078082-bbaa4d80-32f8-11ea-9ca4-9513826006a7.png)

Note that rows become highlighted in light blue on hover, just like in notebooks.


