### PR TITLE
CSS: Restrict thumbnail height to 112 px

### DIFF
--- a/sphinx_gallery/_static/gallery.css
+++ b/sphinx_gallery/_static/gallery.css
@@ -44,8 +44,8 @@ thumbnail with its default link Background color */
 }
 .sphx-glr-thumbcontainer img {
   display: inline;
-  max-height: 160px;
-  width: 160px;
+  max-height: 112px;
+  max-width: 160px;
 }
 .sphx-glr-thumbcontainer[tooltip]:hover:after {
   background: rgba(0, 0, 0, 0.8);


### PR DESCRIPTION
When using an SVG plot in "portrait" mode (i.e. height larger than width), the thumbnail can collide with the title text.

It looks like SVG thumbnails are currently assumed to be in "landscape" mode, this PR avoids this assumption.

I'm not very good at CSS, so this is very likely to have unintended side effects!