### PR TITLE
MRG, ENH: Link to methods and properties properly

### DIFF
--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -178,11 +178,20 @@ class SphinxDocLinkResolver(object):
 
     def _get_link_type(self, cobj):
         """Get a valid link and type_, False if not found."""
-        fullname = cobj['module_short'] + '.' + cobj['name']
+        first, second = cobj['module_short'], cobj['name']
+        match = None
         try:
-            value = self._searchindex['objects'][cobj['module_short']]
-            match = value[cobj['name']]
+            match = self._searchindex['objects'][first][second]
         except KeyError:
+            pass
+        if match is None and '.' in second:  # possible class attribute
+            first, second = second.split('.', 1)
+            first = '.'.join([cobj['module_short'], first])
+            try:
+                match = self._searchindex['objects'][first][second]
+            except KeyError:
+                pass
+        if match is None:
             link = type_ = None
         else:
             fname_idx = match[0]
@@ -201,6 +210,7 @@ class SphinxDocLinkResolver(object):
             else:
                 link = posixpath.join(self.doc_url, fname)
 
+            fullname = '.'.join([first, second])
             if anchor == '':
                 anchor = fullname
             elif anchor == '-':

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -213,8 +213,9 @@ def test_embed_links_and_styles(sphinx_app):
     assert 'sphinx_gallery.backreferences.html#sphinx_gallery.backreferences.DummyClass" title="sphinx_gallery.backreferences.DummyClass" class="sphx-glr-backref-module-sphinx_gallery-backreferences sphx-glr-backref-type-py-class"><span class="n">sphinx_gallery</span><span class="o">.</span><span class="n">backreferences</span><span class="o">.</span><span class="n">DummyClass</span>' in lines  # noqa: E501
     # method
     assert 'sphinx_gallery.backreferences.html#sphinx_gallery.backreferences.DummyClass.run" title="sphinx_gallery.backreferences.DummyClass.run" class="sphx-glr-backref-module-sphinx_gallery-backreferences sphx-glr-backref-type-py-method"><span class="n">dc</span><span class="o">.</span><span class="n">run</span>' in lines  # noqa: E501
-    # property
-    assert 'sphinx_gallery.backreferences.html#sphinx_gallery.backreferences.DummyClass.prop" title="sphinx_gallery.backreferences.DummyClass.prop" class="sphx-glr-backref-module-sphinx_gallery-backreferences sphx-glr-backref-type-py-method"><span class="n">dc</span><span class="o">.</span><span class="n">prop</span>' in lines  # noqa: E501
+    # property (Sphinx 2+ calls it a method rather than attribute, so regex)
+    regex = re.compile('sphinx_gallery.backreferences.html#sphinx_gallery.backreferences.DummyClass.prop" title="sphinx_gallery.backreferences.DummyClass.prop" class="sphx-glr-backref-module-sphinx_gallery-backreferences sphx-glr-backref-type-py-(attribute|method)"><span class="n">dc</span><span class="o">.</span><span class="n">prop</span>')  # noqa: E501
+    assert regex.search(lines) is not None
 
     try:
         import memory_profiler  # noqa, analysis:ignore

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -191,7 +191,7 @@ def test_embed_links_and_styles(sphinx_app):
     assert 'pyplot.html' in lines
     assert 'matplotlib.figure.Figure.html#matplotlib.figure.Figure.tight_layout' in lines  # noqa: E501
     assert 'matplotlib.axes.Axes.plot.html#matplotlib.axes.Axes.plot' in lines
-    assert 'matplotlib_configuration_api.html#matplotlib.rcParams' in lines
+    assert 'matplotlib_configuration_api.html#matplotlib.RcParams' in lines
     assert 'stdtypes.html#list' in lines
     assert 'warnings.html#warnings.warn' in lines
     assert 'itertools.html#itertools.compress' in lines
@@ -206,6 +206,15 @@ def test_embed_links_and_styles(sphinx_app):
     # gh-587: np.random.RandomState links properly
     assert '.html#numpy.random.mtrand.RandomState" title="numpy.random.mtrand.RandomState" class="sphx-glr-backref-module-numpy-random-mtrand sphx-glr-backref-type-py-class"><span class="n">np</span>' in lines  # noqa: E501
     assert '.html#numpy.random.mtrand.RandomState" title="numpy.random.mtrand.RandomState" class="sphx-glr-backref-module-numpy-random-mtrand sphx-glr-backref-type-py-class sphx-glr-backref-instance"><span class="n">rng</span></a>' in lines  # noqa: E501
+    # gh-587: methods of classes in the module currently being documented
+    # instance
+    assert 'sphinx_gallery.backreferences.html#sphinx_gallery.backreferences.DummyClass" title="sphinx_gallery.backreferences.DummyClass" class="sphx-glr-backref-module-sphinx_gallery-backreferences sphx-glr-backref-type-py-class sphx-glr-backref-instance"><span class="n">dc</span>' in lines  # noqa: E501
+    # class
+    assert 'sphinx_gallery.backreferences.html#sphinx_gallery.backreferences.DummyClass" title="sphinx_gallery.backreferences.DummyClass" class="sphx-glr-backref-module-sphinx_gallery-backreferences sphx-glr-backref-type-py-class"><span class="n">sphinx_gallery</span><span class="o">.</span><span class="n">backreferences</span><span class="o">.</span><span class="n">DummyClass</span>' in lines  # noqa: E501
+    # method
+    assert 'sphinx_gallery.backreferences.html#sphinx_gallery.backreferences.DummyClass.run" title="sphinx_gallery.backreferences.DummyClass.run" class="sphx-glr-backref-module-sphinx_gallery-backreferences sphx-glr-backref-type-py-method"><span class="n">dc</span><span class="o">.</span><span class="n">run</span>' in lines  # noqa: E501
+    # property
+    assert 'sphinx_gallery.backreferences.html#sphinx_gallery.backreferences.DummyClass.prop" title="sphinx_gallery.backreferences.DummyClass.prop" class="sphx-glr-backref-module-sphinx_gallery-backreferences sphx-glr-backref-type-py-method"><span class="n">dc</span><span class="o">.</span><span class="n">prop</span>' in lines  # noqa: E501
 
     try:
         import memory_profiler  # noqa, analysis:ignore

--- a/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
@@ -40,3 +40,7 @@ x = Figure()  # plt.Figure should be decorated (class), x shouldn't (inst)
 rng = np.random.RandomState(0)
 # test Issue 583
 sphinx_gallery.backreferences.identify_names([('text', 'Text block', 1)])
+# 583: methods don't link properly
+dc = sphinx_gallery.backreferences.DummyClass()
+dc.run()
+print(dc.prop)


### PR DESCRIPTION
Link to methods and properties properly (part of #587).

Locally I can confirm that building MNE docs now produces links to things like `ica.plot_properties`, which is great.