### PR TITLE
MRG, ENH: Provide sub-extension sphinx_gallery.load_style

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -330,3 +330,13 @@ the ``reset_modules`` configuration key. For the function defined above::
           standard behavior that users will experience when manually running
           examples themselves is discouraged due to the inconsistency
           that results between the rendered examples and local outputs.
+
+Using (only) Sphinx-gallery styles
+==================================
+
+If you just want to make use of sphinx-gallery CSS files, instead of using
+the ``sphinx_gallery.gen_gallery`` extension, you can use in ``conf.py``::
+
+    extensions = ['sphinx_gallery.load_style']
+
+This will only cause the ``gallery.css`` file to be added to your build.

--- a/sphinx_gallery/load_style.py
+++ b/sphinx_gallery/load_style.py
@@ -1,0 +1,24 @@
+"""
+Only load CSS and modify html_static_path
+=========================================
+
+This should not be used at the same time as sphinx_gallery.gen_gallery.
+
+"""
+from . import __version__, glr_path_static
+
+
+def config_inited(app, config):
+    path = glr_path_static()
+    if path not in config.html_static_path:
+        config.html_static_path.append(path)
+    app.add_css_file('gallery.css')
+
+
+def setup(app):
+    app.require_sphinx('1.8')
+    app.connect('config-inited', config_inited)
+    return {
+        'parallel_read_safe': True,
+        'version': __version__,
+    }

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -179,7 +179,7 @@ def conf_file(request):
 class SphinxAppWrapper(object):
     """Wrapper for sphinx.application.Application.
 
-    This allows to control when the sphinx application is initialized, since
+    This allows control over when the sphinx application is initialized, since
     part of the sphinx-gallery build is done in
     sphinx.application.Application.__init__ and the remainder is done in
     sphinx.application.Application.build.

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -5,10 +5,16 @@ Pytest fixtures
 from __future__ import division, absolute_import, print_function
 
 import collections
+from contextlib import contextmanager
+from io import StringIO
+import os
+import shutil
 
 import pytest
 
 import sphinx
+from sphinx.application import Sphinx
+from sphinx.util.docutils import docutils_namespace
 from sphinx_gallery import (docs_resolv, gen_gallery, gen_rst, utils,
                             sphinx_compatibility, py_source_parser)
 from sphinx_gallery.scrapers import _import_matplotlib
@@ -152,3 +158,86 @@ def req_pil():
         _get_image()
     except RuntimeError:
         pytest.skip('Test requires pillow')
+
+
+@pytest.fixture
+def conf_file(request):
+    try:
+        env = request.node.get_closest_marker('conf_file')
+    except AttributeError:  # old pytest
+        env = request.node.get_marker('conf_file')
+    kwargs = env.kwargs if env else {}
+    result = {
+        'content': "",
+        'extensions': ['sphinx_gallery.gen_gallery'],
+    }
+    result.update(kwargs)
+
+    return result
+
+
+class SphinxAppWrapper(object):
+    """Wrapper for sphinx.application.Application.
+
+    This allows to control when the sphinx application is initialized, since
+    part of the sphinx-gallery build is done in
+    sphinx.application.Application.__init__ and the remainder is done in
+    sphinx.application.Application.build.
+
+    """
+
+    def __init__(self, srcdir, confdir, outdir, doctreedir, buildername,
+                 **kwargs):
+        self.srcdir = srcdir
+        self.confdir = confdir
+        self.outdir = outdir
+        self.doctreedir = doctreedir
+        self.buildername = buildername
+        self.kwargs = kwargs
+
+    def create_sphinx_app(self):
+        # Avoid warnings about re-registration, see:
+        # https://github.com/sphinx-doc/sphinx/issues/5038
+        with self.create_sphinx_app_context() as app:
+            pass
+        return app
+
+    @contextmanager
+    def create_sphinx_app_context(self):
+        with docutils_namespace():
+            app = Sphinx(self.srcdir, self.confdir, self.outdir,
+                         self.doctreedir, self.buildername, **self.kwargs)
+            sphinx_compatibility._app = app
+            yield app
+
+    def build_sphinx_app(self, *args, **kwargs):
+        with self.create_sphinx_app_context() as app:
+            # building should be done in the same docutils_namespace context
+            app.build(*args, **kwargs)
+        return app
+
+
+@pytest.fixture
+def sphinx_app_wrapper(tmpdir, conf_file, req_mpl, req_pil):
+    _fixturedir = os.path.join(os.path.dirname(__file__), 'testconfs')
+    srcdir = os.path.join(str(tmpdir), "config_test")
+    shutil.copytree(_fixturedir, srcdir)
+    shutil.copytree(os.path.join(_fixturedir, "src"),
+                    os.path.join(str(tmpdir), "examples"))
+
+    base_config = """
+import os
+import sphinx_gallery
+extensions = %r
+exclude_patterns = ['_build']
+source_suffix = '.rst'
+master_doc = 'index'
+# General information about the project.
+project = u'Sphinx-Gallery <Tests>'\n\n
+""" % (conf_file['extensions'],)
+    with open(os.path.join(srcdir, "conf.py"), "w") as conffile:
+        conffile.write(base_config + conf_file['content'])
+
+    return SphinxAppWrapper(
+        srcdir, srcdir, os.path.join(srcdir, "_build"),
+        os.path.join(srcdir, "_build", "toctree"), "html", warning=StringIO())

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -8,105 +8,16 @@ Test Sphinx-Gallery
 from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 import codecs
-from contextlib import contextmanager
-from io import StringIO
 import os
 import sys
 import re
-import shutil
 
 import pytest
 
-from sphinx.application import Sphinx
 from sphinx.errors import ExtensionError
-from sphinx.util.docutils import docutils_namespace
-
-from sphinx_gallery import sphinx_compatibility
 from sphinx_gallery.gen_gallery import (check_duplicate_filenames,
                                         collect_gallery_files,
                                         write_computation_times)
-
-
-@pytest.fixture
-def conf_file(request):
-    try:
-        env = request.node.get_closest_marker('conf_file')
-    except AttributeError:  # old pytest
-        env = request.node.get_marker('conf_file')
-    kwargs = env.kwargs if env else {}
-    result = {
-        'content': "",
-    }
-    result.update(kwargs)
-
-    return result
-
-
-class SphinxAppWrapper(object):
-    """Wrapper for sphinx.application.Application.
-
-    This allows to control when the sphinx application is initialized, since
-    part of the sphinx-gallery build is done in
-    sphinx.application.Application.__init__ and the remainder is done in
-    sphinx.application.Application.build.
-
-    """
-
-    def __init__(self, srcdir, confdir, outdir, doctreedir, buildername,
-                 **kwargs):
-        self.srcdir = srcdir
-        self.confdir = confdir
-        self.outdir = outdir
-        self.doctreedir = doctreedir
-        self.buildername = buildername
-        self.kwargs = kwargs
-
-    def create_sphinx_app(self):
-        # Avoid warnings about re-registration, see:
-        # https://github.com/sphinx-doc/sphinx/issues/5038
-        with self.create_sphinx_app_context() as app:
-            pass
-        return app
-
-    @contextmanager
-    def create_sphinx_app_context(self):
-        with docutils_namespace():
-            app = Sphinx(self.srcdir, self.confdir, self.outdir,
-                         self.doctreedir, self.buildername, **self.kwargs)
-            sphinx_compatibility._app = app
-            yield app
-
-    def build_sphinx_app(self, *args, **kwargs):
-        with self.create_sphinx_app_context() as app:
-            # building should be done in the same docutils_namespace context
-            app.build(*args, **kwargs)
-        return app
-
-
-@pytest.fixture
-def sphinx_app_wrapper(tmpdir, conf_file, req_mpl, req_pil):
-    _fixturedir = os.path.join(os.path.dirname(__file__), 'testconfs')
-    srcdir = os.path.join(str(tmpdir), "config_test")
-    shutil.copytree(_fixturedir, srcdir)
-    shutil.copytree(os.path.join(_fixturedir, "src"),
-                    os.path.join(str(tmpdir), "examples"))
-
-    base_config = """
-import os
-import sphinx_gallery
-extensions = ['sphinx_gallery.gen_gallery']
-exclude_patterns = ['_build']
-source_suffix = '.rst'
-master_doc = 'index'
-# General information about the project.
-project = u'Sphinx-Gallery <Tests>'\n\n
-"""
-    with open(os.path.join(srcdir, "conf.py"), "w") as conffile:
-        conffile.write(base_config + conf_file['content'])
-
-    return SphinxAppWrapper(
-        srcdir, srcdir, os.path.join(srcdir, "_build"),
-        os.path.join(srcdir, "_build", "toctree"), "html", warning=StringIO())
 
 
 def test_default_config(sphinx_app_wrapper):

--- a/sphinx_gallery/tests/test_load_style.py
+++ b/sphinx_gallery/tests/test_load_style.py
@@ -1,0 +1,18 @@
+import os
+import pytest
+
+
+@pytest.mark.conf_file(extensions=['sphinx_gallery.load_style'])
+def test_load_style(sphinx_app_wrapper):
+    """Testing that style loads properly."""
+    sphinx_app = sphinx_app_wrapper.build_sphinx_app()
+    cfg = sphinx_app.config
+    assert cfg.project == "Sphinx-Gallery <Tests>"
+    build_warn = sphinx_app._warning.getvalue()
+    assert build_warn == ''
+    index_html = os.path.join(
+        sphinx_app_wrapper.outdir, 'index.html')
+    assert os.path.isfile(index_html)
+    with open(index_html, 'r') as fid:
+        content = fid.read()
+    assert 'link rel="stylesheet" type="text/css" href="_static/gallery.css"' in content  # noqa: E501


### PR DESCRIPTION
As discussed in https://github.com/sphinx-gallery/sphinx-gallery/pull/599#issuecomment-576200916, this enables following usage in `conf.py`:

```python
extensions = [
    'sphinx_gallery.load_style',
]
```

... which only loads the CSS style and sets the corresponding static directory. Nothing else.

For now, this provides a minimal solution without any configuration options.

@larsoner suggested in https://github.com/sphinx-gallery/sphinx-gallery/pull/599#issuecomment-576750591 to add configurability:

> Even in the case where you want to load SG style(s), we'd still want a way to say which styles to load.

I think we don't need that yet, because for now there aren't even multiple styles, there's only one.
I think configurability can be added later (when needed), an example for a possible implementation is in 2d654451ca8ff1fec8dd705c9dfb827dd6f41c38.

In case anyone is wondering what's the use case for this, here's some explanations: https://github.com/sphinx-gallery/sphinx-gallery/issues/317#issuecomment-575692356.

The "normal" use of SG should not be affected by this in any way.