### PR TITLE
BUG: Longer timeout on macOS

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -469,7 +469,10 @@ def _get_memory_base(gallery_conf):
     else:
         # There might be a cleaner way to do this at some point
         from memory_profiler import memory_usage
-        sleep, timeout = (1, 2) if sys.platform == 'win32' else (0.5, 1)
+        if sys.platform in ('win32', 'darwin'):
+            sleep, timeout = (1, 2)
+        else:
+            sleep, timeout = (0.5, 1)
         proc = subprocess.Popen(
             [sys.executable, '-c',
              'import time, sys; time.sleep(%s); sys.exit(0)' % sleep],

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -464,7 +464,7 @@ def _memory_usage(func, gallery_conf):
 
 def _get_memory_base(gallery_conf):
     """Get the base amount of memory used by running a Python process."""
-    if not gallery_conf['show_memory']:
+    if not gallery_conf['show_memory'] or not gallery_conf['plot_gallery']:
         memory_base = 0
     else:
         # There might be a cleaner way to do this at some point


### PR DESCRIPTION
On macOS with `memory_profiler` during builds I frequently get:
```
  File "/Users/larsoner/python/sphinx-gallery/sphinx_gallery/gen_rst.py", line 469, in _get_memory_base
    memories = memory_usage(proc, interval=1e-3, timeout=timeout)
  File "/Users/larsoner/anaconda3/lib/python3.7/site-packages/memory_profiler.py", line 371, in memory_usage
    include_children=include_children)
...
  File "/Users/larsoner/anaconda3/lib/python3.7/site-packages/psutil/_psosx.py", line 363, in catch_zombie
    raise ZombieProcess(proc.pid, proc._name, proc._ppid)
psutil.ZombieProcess: psutil.ZombieProcess process still exists but it's a zombie (pid=62842)

Exception occurred:
  File "/Users/larsoner/anaconda3/lib/python3.7/site-packages/psutil/_psosx.py", line 363, in catch_zombie
    raise ZombieProcess(proc.pid, proc._name, proc._ppid)
psutil.ZombieProcess: psutil.ZombieProcess process still exists but it's a zombie (pid=62842)
```
Bumping up the times to the Windows numbers (2x as long) seems to fix it for me.