### PR TITLE
ENH Allow backrefences_dir to be pathlib object

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -331,9 +331,9 @@ The path you specify in ``backreferences_dir`` (here we choose
 ``gen_modules/backreferences``) will be populated with
 ReStructuredText files. Each will contain a reduced version of the
 gallery specific to every function used across all the examples
-galleries and belonging to the modules listed in ``doc_module``. Keep
-in mind that the path set in ``backreferences_dir`` is **relative** to the
-``conf.py`` file.
+galleries and belonging to the modules listed in ``doc_module``.
+``backreferences_dir` should be a string or ``pathlib.Path`` object that is
+**relative** to the ``conf.py`` file, or ``None``. It is ``None`` by default.
 
 Then within your sphinx documentation ``.rst`` files you write these
 lines to include this reduced version of the Gallery, which has

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -17,6 +17,7 @@ from datetime import timedelta, datetime
 from importlib import import_module
 import re
 import os
+import pathlib
 from xml.sax.saxutils import quoteattr, escape
 
 from sphinx.util.console import red
@@ -208,9 +209,10 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
     gallery_conf['titles'] = {}
     # Ensure 'backreferences_dir' is str or None
     backref = gallery_conf['backreferences_dir']
-    if (not isinstance(backref, str)) and (backref is not None):
+    if (not isinstance(backref, (str, pathlib.Path))) and (backref is not None):
         raise ValueError("The 'backreferences_dir' parameter must be of type "
-                         "str or None, found type %s" % type(backref))
+                         "str, pathlib.Path or None, "
+                         "found type %s" % type(backref))
 
     if not isinstance(gallery_conf['css'], (list, tuple)):
         raise TypeError('gallery_conf["css"] must be list or tuple, got %r'

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -207,12 +207,15 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
     # Make it easy to know which builder we're in
     gallery_conf['builder_name'] = builder_name
     gallery_conf['titles'] = {}
-    # Ensure 'backreferences_dir' is str or None
+    # Ensure 'backreferences_dir' is str, pathlib.Path or None
     backref = gallery_conf['backreferences_dir']
     if (not isinstance(backref, (str, pathlib.Path))) and (backref is not None):
         raise ValueError("The 'backreferences_dir' parameter must be of type "
                          "str, pathlib.Path or None, "
                          "found type %s" % type(backref))
+    # if 'backreferences_dir' is pathlib.Path, make str for Python <=3.5
+    if isinstance(backref, pathlib.Path):
+        gallery_conf['backreferences_dir'] = str(backref)
 
     if not isinstance(gallery_conf['css'], (list, tuple)):
         raise TypeError('gallery_conf["css"] must be list or tuple, got %r'

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -214,6 +214,7 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
                          "str, pathlib.Path or None, "
                          "found type %s" % type(backref))
     # if 'backreferences_dir' is pathlib.Path, make str for Python <=3.5
+    # compatibility
     if isinstance(backref, pathlib.Path):
         gallery_conf['backreferences_dir'] = str(backref)
 

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -11,6 +11,7 @@ import codecs
 import os
 import sys
 import re
+import pathlib
 
 import pytest
 
@@ -379,6 +380,18 @@ def test_backreferences_dir_config(sphinx_app_wrapper):
     with pytest.raises(ValueError,
                        match="The 'backreferences_dir' parameter must be of"):
         parse_config(sphinx_app_wrapper.create_sphinx_app())
+
+
+@pytest.mark.conf_file(content="""
+import pathlib
+
+sphinx_gallery_conf = {
+    'backreferences_dir': pathlib.Path('.'),
+}""")
+def test_backreferences_dir_pathlib_config(sphinx_app_wrapper):
+    """Tests pathlib.Path does not raise exception."""
+    from sphinx_gallery.gen_gallery import parse_config
+    parse_config(sphinx_app_wrapper.create_sphinx_app())
 
 
 def test_write_computation_times_noop():


### PR DESCRIPTION
closes #635 

(I didn't know how to parameterize `test_backreferences_dir_pathlib_config` with `test_backreferences_dir_config` but maybe that would have been overboard)