### PR TITLE
DOC: Fix typos in documentation files.

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -48,10 +48,10 @@ Know your Gallery files
 
 The Gallery has been built, now you and all of your project's users
 can already start enjoying it. All the temporary files needed to
-generate the gallery(rst files, images, chache objects, etc) are
+generate the gallery (rst files, images, cache objects, etc) are
 stored where you configured in ``gallery_dirs``. The final files that go
 into the HTML version of your documentation have a particular
-namespace, to avoid colisions with your own files and images.
+namespace, to avoid collisions with your own files and images.
 
 Our namespace convention is to prefix everything with ``sphx_glr`` and
 change path separators with underscores. This is valid for
@@ -154,7 +154,7 @@ index page thumbnails. PNG images are scaled using Pillow, and
 SVG images are copied.
 
 .. warning:: SVG images do not work with ``latex`` build modes, thus will not
-             work while building a PDF vesion of your documentation.
+             work while building a PDF version of your documentation.
 
 Example 1: a Matplotlib and Mayavi-style scraper
 ------------------------------------------------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -114,7 +114,7 @@ entries, which have the default values::
 
 To omit some files from the gallery entirely (i.e., not execute, parse, or
 add them), you can change the ``ignore_pattern`` option.
-To choose which of the parsed and added Python scripts are actualy
+To choose which of the parsed and added Python scripts are actually
 executed, you can modify ``filename_pattern``. For example::
 
     sphinx_gallery_conf = {
@@ -560,7 +560,7 @@ default, the following first cell is added to each notebook::
    %matplotlib inline
 
 Adding a last cell can be useful for performing a desired action such as
-reporting on the user's evironment. By default no last cell is added.
+reporting on the user's environment. By default no last cell is added.
 
 You can choose whatever text you like by modifying the ``first_notebook_cell``
 and ``last_notebook_cell`` configuration parameters. For example, the gallery
@@ -855,7 +855,7 @@ to scrape both matplotlib and Mayavi images you can do::
       }
 
 The default value is ``'image_scrapers': ('matplotlib',)`` which only scrapes
-Matplotlib images. Note that this includes any images produced by pacakges that
+Matplotlib images. Note that this includes any images produced by packages that
 are based on Matplotlib, for example Seaborn or Yellowbrick.
 
 The following scrapers are supported:

--- a/doc/maintainers.rst
+++ b/doc/maintainers.rst
@@ -23,7 +23,7 @@ To create a new release of Sphinx Gallery, you need to do these things:
 You should double-check a few things to make sure that you can create
 a new release for Sphinx Gallery.
 
-1. Ensure that you **registered an acccount** on `the PyPI index <https://pypi.org/account/register/>`_.
+1. Ensure that you **registered an account** on `the PyPI index <https://pypi.org/account/register/>`_.
 2. Ensure you have **push access** to the
    `Sphinx Gallery pypi repository <https://pypi.org/project/sphinx-gallery/>`_.
    Ask one of the Sphinx Gallery core developers if you do not.


### PR DESCRIPTION
As I was using the documentation I noticed a couple typos, so I figured I would fix them. 

Updates are some typo fixes for rst files in /doc. 

