### PR TITLE
DOC: Fix PNGScraper example

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -223,14 +223,14 @@ package in a module called ``scraper``. Here is the scraper code::
        def __call__(self, block, block_vars, gallery_conf):
            # Find all PNG files in the directory of this example.
            path_current_example = os.path.dirname(block_vars['src_file'])
-           pngs = sorted(glob(os.path.join(os.getcwd(), '*.png'))
+           pngs = sorted(glob(os.path.join(path_current_example, '*.png')))
 
            # Iterate through PNGs, copy them to the sphinx-gallery output directory
            image_names = list()
            image_path_iterator = block_vars['image_path_iterator']
            for png in pngs:
-               if png not in seen:
-                   seen |= set(png)
+               if png not in self.seen:
+                   self.seen |= set(png)
                    this_image_path = image_path_iterator.next()
                    image_names.append(this_image_path)
                    shutil.move(png, this_image_path)


### PR DESCRIPTION
The `PNGScraper` example has some syntax errors that are fixed here. Also, the searched `pngs` should be checked within `path_current_example` instead of `os.getcwd()` for most use-cases.