### PR TITLE
ENH: Use optipng when requested

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       # Get our data and merge with upstream
       - run: sudo apt-get update
-      - run: sudo apt-get --no-install-recommends install -y texlive texlive-latex-extra latexmk libxkbcommon-x11-0
+      - run: sudo apt-get --no-install-recommends install -y texlive texlive-latex-extra latexmk libxkbcommon-x11-0 optipng
       - checkout
       - run: echo $(git log -1 --pretty=%B) | tee gitlog.txt
       - run: echo ${CI_PULL_REQUEST//*pull\//} | tee merge.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: python
 
+os: linux
 dist: xenial
 sudo: false
-
 services:
   - xvfb # For mayavi headless
 
 matrix:
   include:
-    - os: linux
-      env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" SPHINXOPTS=""
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" SPHINXOPTS=""
       addons:
         apt:
           packages:
@@ -17,28 +16,28 @@ matrix:
             - python3-matplotlib
             - python3-pip
             - python3-coverage
-    - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="3.5" SPHINX_VERSION="==1.8.3"
-    - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="3.6"
-    - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="3.6" LOCALE=C
-    - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="3.7" LOCALE=C
+            - optipng
+    - env: DISTRIB="conda" PYTHON_VERSION="3.5" SPHINX_VERSION="==1.8.3"
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6"
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" LOCALE=C
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" LOCALE=C
            SPHINXOPTS="-nWT --keep-going"
-    - os: linux
-      env: DISTRIB="conda" PYTHON_VERSION="3.7" SPHINX_VERSION="dev"
+      addons:
+        apt:
+          packages:
+            - optipng
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" SPHINX_VERSION="dev"
     - python: 3.7
       env: DISTRIB="minimal"
     - python: "nightly"
       env: PYTHON_VERSION="nightly"
-      os: linux
       addons:
         apt:
           packages:
-            libblas-dev
-            liblapack-dev
-            gfortran
+            - libblas-dev
+            - liblapack-dev
+            - gfortran
+            - optipng
 
 before_install:
   # Make sure that things work even if the locale is set to C (which

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,9 @@ Sphinx-Gallery has also support for packages like:
 * Seaborn
 * Mayavi
 
-For much of this functionality, you will need `pillow`.
+For much of this functionality, you will need ``pillow``. We also recommend
+installing system ``optipng`` binaries to reduce the file sizes of the
+generated PNG files.
 
 Install as a Sphinx-gallery developer
 -------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -341,7 +341,7 @@ sphinx_gallery_conf = {
     'examples_dirs': examples_dirs,
     'gallery_dirs': gallery_dirs,
     'image_scrapers': image_scrapers,
-    'optimize_images': ('images', 'thumbnails'),
+    'compress_images': ('images', 'thumbnails'),
     # specify the order of examples to be according to filename
     'within_subsection_order': FileNameSortKey,
     'expected_failing_examples': ['../examples/no_output/plot_raise.py',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -337,10 +337,11 @@ sphinx_gallery_conf = {
     'doc_module': ('sphinx_gallery', 'numpy'),
     'reference_url': {
         'sphinx_gallery': None,
-        },
+    },
     'examples_dirs': examples_dirs,
     'gallery_dirs': gallery_dirs,
     'image_scrapers': image_scrapers,
+    'optimize_images': ('images', 'thumbnails'),
     # specify the order of examples to be according to filename
     'within_subsection_order': FileNameSortKey,
     'expected_failing_examples': ['../examples/no_output/plot_raise.py',

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -31,6 +31,7 @@ file:
 - ``plot_gallery`` (:ref:`without_execution`)
 - ``image_scrapers`` (and the deprecated ``find_mayavi_figures``)
   (:ref:`image_scrapers`)
+- ``optimize_images`` (:ref:`optimize_images`)
 - ``reset_modules`` (:ref:`reset_modules`)
 - ``abort_on_example_error`` (:ref:`abort_on_first`)
 - ``expected_failing_examples`` (:ref:`dont_fail_exit`)
@@ -854,6 +855,35 @@ a default::
 
 The highest precedence is always given to the `-D` flag of the
 ``sphinx-build`` command.
+
+
+.. _optimize_images:
+
+Optimizing images
+=================
+
+When writing PNG files (the default scraper format), sphinx-gallery can be
+configured to use ``optipng`` to optimize the PNG file sizes. Typically this
+yields roughly a 50% reduction in file sizes. However, it can increase build
+time. The allowed values are ``'images'`` and ``'thumbnails'``, or a
+tuple/list, such as (to optimize both)::
+
+    sphinx_gallery_conf = {
+        ...
+        'optimize_images': ('images', 'thumbnails'),
+    }
+
+The default is ``()`` (no optimization) and a warning will be emitted if
+optimization is requested but not available. You can also pass additional
+command-line options (starting with ``'-'``), for example to optimize less
+but speed up the build time you could do::
+
+    sphinx_gallery_conf = {
+        ...
+        'optimize_images': ('images', 'thumbnails', '-o1'),
+    }
+
+See ``$ optipng --help`` for a complete list of options.
 
 
 .. _image_scrapers:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -31,7 +31,7 @@ file:
 - ``plot_gallery`` (:ref:`without_execution`)
 - ``image_scrapers`` (and the deprecated ``find_mayavi_figures``)
   (:ref:`image_scrapers`)
-- ``optimize_images`` (:ref:`optimize_images`)
+- ``compress_images`` (:ref:`compress_images`)
 - ``reset_modules`` (:ref:`reset_modules`)
 - ``abort_on_example_error`` (:ref:`abort_on_first`)
 - ``expected_failing_examples`` (:ref:`dont_fail_exit`)
@@ -857,10 +857,10 @@ The highest precedence is always given to the `-D` flag of the
 ``sphinx-build`` command.
 
 
-.. _optimize_images:
+.. _compress_images:
 
-Optimizing images
-=================
+Compressing images
+==================
 
 When writing PNG files (the default scraper format), sphinx-gallery can be
 configured to use ``optipng`` to optimize the PNG file sizes. Typically this
@@ -870,7 +870,7 @@ tuple/list, such as (to optimize both)::
 
     sphinx_gallery_conf = {
         ...
-        'optimize_images': ('images', 'thumbnails'),
+        'compress_images': ('images', 'thumbnails'),
     }
 
 The default is ``()`` (no optimization) and a warning will be emitted if
@@ -880,7 +880,7 @@ but speed up the build time you could do::
 
     sphinx_gallery_conf = {
         ...
-        'optimize_images': ('images', 'thumbnails', '-o1'),
+        'compress_images': ('images', 'thumbnails', '-o1'),
     }
 
 See ``$ optipng --help`` for a complete list of options.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -867,7 +867,7 @@ configured to use ``optipng`` to optimize the PNG file sizes. Typically this
 yields roughly a 50% reduction in file sizes, thus reducing the loading time
 of galleries. However, it can increase build
 time. The allowed values are ``'images'`` and ``'thumbnails'``, or a
-tuple/list, such as (to optimize both)::
+tuple/list (to optimize both), such as::
 
     sphinx_gallery_conf = {
         ...

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -864,7 +864,8 @@ Compressing images
 
 When writing PNG files (the default scraper format), sphinx-gallery can be
 configured to use ``optipng`` to optimize the PNG file sizes. Typically this
-yields roughly a 50% reduction in file sizes. However, it can increase build
+yields roughly a 50% reduction in file sizes, thus reducing the loading time
+of galleries. However, it can increase build
 time. The allowed values are ``'images'`` and ``'thumbnails'``, or a
 tuple/list, such as (to optimize both)::
 
@@ -874,9 +875,9 @@ tuple/list, such as (to optimize both)::
     }
 
 The default is ``()`` (no optimization) and a warning will be emitted if
-optimization is requested but not available. You can also pass additional
-command-line options (starting with ``'-'``), for example to optimize less
-but speed up the build time you could do::
+optimization is requested but ``optipng`` is not available. You can also pass
+additional command-line options (starting with ``'-'``), for example to
+optimize less but speed up the build time you could do::
 
     sphinx_gallery_conf = {
         ...

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -30,3 +30,17 @@ every module.
    sorting
    binder
    directives
+
+.. currentmodule:: sphinx_gallery.utils
+
+.. automodule:: sphinx_gallery.utils
+   :no-members:
+   :no-inherited-members:
+
+:py:mod:`sphinx_gallery.utils`:
+
+.. autosummary::
+   :toctree: gen_modules/
+   :template: module.rst
+
+   optipng

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -22,7 +22,7 @@ from xml.sax.saxutils import quoteattr, escape
 
 from sphinx.util.console import red
 from . import sphinx_compatibility, glr_path_static, __version__ as _sg_version
-from .utils import _replace_md5
+from .utils import _replace_md5, _has_optipng
 from .backreferences import _finalize_backreferences
 from .gen_rst import (generate_dir_rst, SPHX_GLR_SIG, _get_memory_base,
                       _get_readme)
@@ -63,6 +63,7 @@ DEFAULT_GALLERY_CONF = {
     'min_reported_time': 0,
     'binder': {},
     'image_scrapers': ('matplotlib',),
+    'optimize_images': (),
     'reset_modules': ('matplotlib', 'seaborn'),
     'first_notebook_cell': '%matplotlib inline',
     'last_notebook_cell': None,
@@ -194,6 +195,33 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
         _import_matplotlib()
     except (ImportError, ValueError):
         pass
+
+    # optimize_images
+    optimize_images = gallery_conf['optimize_images']
+    if isinstance(optimize_images, str):
+        optimize_images = [optimize_images]
+    elif not isinstance(optimize_images, (tuple, list)):
+        raise TypeError('optimize_images must be a tuple, list, or str, got %s'
+                        % (type(optimize_images),))
+    optimize_images = list(optimize_images)
+    allowed_values = ('images', 'thumbnails')
+    pops = list()
+    for ki, kind in enumerate(optimize_images):
+        if kind not in allowed_values:
+            if kind.startswith('-'):
+                pops.append(ki)
+                continue
+            raise TypeError('All entries in optimize_images must be one of %s '
+                            'or a command-line switch starting with "-", '
+                            'got %r' % (allowed_values, kind))
+    optimize_images_args = [optimize_images.pop(p) for p in pops[::-1]]
+    if len(optimize_images) and not _has_optipng():
+        logger.warning(
+            'optipng binaries not found, PNG %s will not be optimized'
+            % (' and '.join(optimize_images),))
+        optimize_images = ()
+    gallery_conf['optimize_images'] = optimize_images
+    gallery_conf['optimize_images_args'] = optimize_images_args
 
     # deal with resetters
     resetters = gallery_conf['reset_modules']

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -63,7 +63,7 @@ DEFAULT_GALLERY_CONF = {
     'min_reported_time': 0,
     'binder': {},
     'image_scrapers': ('matplotlib',),
-    'optimize_images': (),
+    'compress_images': (),
     'reset_modules': ('matplotlib', 'seaborn'),
     'first_notebook_cell': '%matplotlib inline',
     'last_notebook_cell': None,
@@ -196,32 +196,32 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
     except (ImportError, ValueError):
         pass
 
-    # optimize_images
-    optimize_images = gallery_conf['optimize_images']
-    if isinstance(optimize_images, str):
-        optimize_images = [optimize_images]
-    elif not isinstance(optimize_images, (tuple, list)):
-        raise TypeError('optimize_images must be a tuple, list, or str, got %s'
-                        % (type(optimize_images),))
-    optimize_images = list(optimize_images)
+    # compress_images
+    compress_images = gallery_conf['compress_images']
+    if isinstance(compress_images, str):
+        compress_images = [compress_images]
+    elif not isinstance(compress_images, (tuple, list)):
+        raise TypeError('compress_images must be a tuple, list, or str, got %s'
+                        % (type(compress_images),))
+    compress_images = list(compress_images)
     allowed_values = ('images', 'thumbnails')
     pops = list()
-    for ki, kind in enumerate(optimize_images):
+    for ki, kind in enumerate(compress_images):
         if kind not in allowed_values:
             if kind.startswith('-'):
                 pops.append(ki)
                 continue
-            raise TypeError('All entries in optimize_images must be one of %s '
+            raise TypeError('All entries in compress_images must be one of %s '
                             'or a command-line switch starting with "-", '
                             'got %r' % (allowed_values, kind))
-    optimize_images_args = [optimize_images.pop(p) for p in pops[::-1]]
-    if len(optimize_images) and not _has_optipng():
+    compress_images_args = [compress_images.pop(p) for p in pops[::-1]]
+    if len(compress_images) and not _has_optipng():
         logger.warning(
             'optipng binaries not found, PNG %s will not be optimized'
-            % (' and '.join(optimize_images),))
-        optimize_images = ()
-    gallery_conf['optimize_images'] = optimize_images
-    gallery_conf['optimize_images_args'] = optimize_images_args
+            % (' and '.join(compress_images),))
+        compress_images = ()
+    gallery_conf['compress_images'] = compress_images
+    gallery_conf['compress_images_args'] = compress_images_args
 
     # deal with resetters
     resetters = gallery_conf['reset_modules']

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -306,8 +306,8 @@ def save_thumbnail(image_path_template, src_file, file_conf, gallery_conf):
         copyfile(img, thumb_file)
     else:
         scale_image(img, thumb_file, *gallery_conf["thumbnail_size"])
-        if 'thumbnails' in gallery_conf['optimize_images']:
-            optipng(thumb_file, gallery_conf['optimize_images_args'])
+        if 'thumbnails' in gallery_conf['compress_images']:
+            optipng(thumb_file, gallery_conf['compress_images_args'])
 
 
 def _get_readme(dir_, gallery_conf, raise_error=True):

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -35,7 +35,8 @@ import codeop
 
 from .scrapers import (save_figures, ImagePathIterator, clean_modules,
                        _find_image_ext)
-from .utils import replace_py_ipynb, scale_image, get_md5sum, _replace_md5
+from .utils import (replace_py_ipynb, scale_image, get_md5sum, _replace_md5,
+                    optipng)
 from . import glr_path_static
 from . import sphinx_compatibility
 from .backreferences import (_write_backreferences, _thumbnail_div,
@@ -305,6 +306,8 @@ def save_thumbnail(image_path_template, src_file, file_conf, gallery_conf):
         copyfile(img, thumb_file)
     else:
         scale_image(img, thumb_file, *gallery_conf["thumbnail_size"])
+        if 'thumbnails' in gallery_conf['optimize_images']:
+            optipng(thumb_file, gallery_conf['optimize_images_args'])
 
 
 def _get_readme(dir_, gallery_conf, raise_error=True):

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -16,7 +16,7 @@ import sys
 import re
 from textwrap import indent
 
-from .utils import scale_image
+from .utils import scale_image, optipng
 
 __all__ = ['save_figures', 'figure_rst', 'ImagePathIterator', 'clean_modules',
            'matplotlib_scraper', 'mayavi_scraper']
@@ -141,6 +141,8 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
                     attr not in kwargs:
                 these_kwargs[attr] = fig_attr
         fig.savefig(image_path, **these_kwargs)
+        if 'images' in gallery_conf['optimize_images']:
+            optipng(image_path, gallery_conf['optimize_images_args'])
         image_rsts.append(
             figure_rst([image_path], gallery_conf['src_dir'], fig_titles))
     plt.close('all')
@@ -206,6 +208,8 @@ def mayavi_scraper(block, block_vars, gallery_conf):
         mlab.savefig(image_path, figure=scene)
         # make sure the image is not too large
         scale_image(image_path, image_path, 850, 999)
+        if 'images' in gallery_conf['optimize_images']:
+            optipng(image_path, gallery_conf['optimize_images_args'])
         image_paths.append(image_path)
     mlab.close(all=True)
     return figure_rst(image_paths, gallery_conf['src_dir'])

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -141,8 +141,8 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
                     attr not in kwargs:
                 these_kwargs[attr] = fig_attr
         fig.savefig(image_path, **these_kwargs)
-        if 'images' in gallery_conf['optimize_images']:
-            optipng(image_path, gallery_conf['optimize_images_args'])
+        if 'images' in gallery_conf['compress_images']:
+            optipng(image_path, gallery_conf['compress_images_args'])
         image_rsts.append(
             figure_rst([image_path], gallery_conf['src_dir'], fig_titles))
     plt.close('all')
@@ -208,8 +208,8 @@ def mayavi_scraper(block, block_vars, gallery_conf):
         mlab.savefig(image_path, figure=scene)
         # make sure the image is not too large
         scale_image(image_path, image_path, 850, 999)
-        if 'images' in gallery_conf['optimize_images']:
-            optipng(image_path, gallery_conf['optimize_images_args'])
+        if 'images' in gallery_conf['compress_images']:
+            optipng(image_path, gallery_conf['compress_images_args'])
         image_paths.append(image_path)
     mlab.close(all=True)
     return figure_rst(image_paths, gallery_conf['src_dir'])

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -47,7 +47,7 @@ sphinx_gallery_conf = {
     'image_scrapers': (matplotlib_format_scraper(),),
     'expected_failing_examples': ['examples/future/plot_future_imports_broken.py'],  # noqa
     'show_memory': True,
-    'optimize_images': ('images', 'thumbnails'),
+    'compress_images': ('images', 'thumbnails'),
     'junit': op.join('sphinx-gallery', 'junit-results.xml'),
     'matplotlib_animations': True,
 }

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -47,6 +47,7 @@ sphinx_gallery_conf = {
     'image_scrapers': (matplotlib_format_scraper(),),
     'expected_failing_examples': ['examples/future/plot_future_imports_broken.py'],  # noqa
     'show_memory': True,
+    'optimize_images': ('images', 'thumbnails'),
     'junit': op.join('sphinx-gallery', 'junit-results.xml'),
     'matplotlib_animations': True,
 }


### PR DESCRIPTION
With this we ~~automatically~~ use `optipng` if it's available EDIT: and the user requests it, and emit a `logger.warning` if it's not.

Intentionally installed on some CI runs but not others to ensure we don't break things for people. @GaelVaroquaux WDYT?

Closes #655