### PR TITLE
DOC Update html-noplot

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -818,7 +818,7 @@ your ``Makefile`` with:
 .. code-block:: Makefile
 
     html-noplot:
-        $(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+        $(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
         @echo
         @echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
closes #606

Using the adaptation of the catch-all target of sphinx quick-start, suggested by @prisae also works and I'm happy to amend to that if more appropriate.
