### PR TITLE
ENH More informative 'alt' attribute for images

### DIFF
--- a/examples/plot_1_exp.py
+++ b/examples/plot_1_exp.py
@@ -29,11 +29,13 @@ def main():
     plt.plot(x, y)
     plt.xlabel('$x$')
     plt.ylabel('$\exp(x)$')
+    plt.title('Exponential function')
 
     plt.figure()
     plt.plot(x, -np.exp(-x))
     plt.xlabel('$x$')
     plt.ylabel('$-\exp(-x)$')
+    plt.title('Negative exponential function')
     # To avoid matplotlib text output
     plt.show()
 

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -119,8 +119,8 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
     if len(image_rsts) == 1:
         rst = image_rsts[0]
     else:
-        image_rsts = [re.sub(r'sphx-glr-single-img',
-                             'sphx-glr-multi-img',
+        image_rsts = [re.sub(r':class: sphx-glr-single-img',
+                             ':class: sphx-glr-multi-img',
                              image) for image in image_rsts]
         image_rsts = [HLIST_IMAGE_MATPLOTLIB + indent(image, u' ' * 6)
                       for image in image_rsts]

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -81,6 +81,8 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
         # Set the fig_num figure as the current figure as we can't
         # save a figure that's not the current figure.
         fig = plt.figure(fig_num)
+        print(fig.axes)
+        print(fig.gca().get_title())
         to_rgba = matplotlib.colors.colorConverter.to_rgba
         # shallow copy should be fine here, just want to avoid changing
         # "kwargs" for subsequent figures processed by the loop

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -52,8 +52,9 @@ def _import_matplotlib():
 def _matplotlib_fig_titles(fig):
     titles = []
     # get supertitle if exists
-    if fig._suptitle:
-        titles.append(fig._suptitle.get_text())
+    suptitle = getattr(fig, "_suptitle", None)
+    if suptitle is not None:
+        titles.append(suptitle.get_text())
     # get titles from all axes, for all locs
     title_locs = ['left', 'center', 'right']
     for ax in fig.axes:
@@ -91,7 +92,6 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
     """
     matplotlib, plt = _import_matplotlib()
     image_path_iterator = block_vars['image_path_iterator']
-    fig_titles = ''
     image_rsts = []
     for fig_num, image_path in zip(plt.get_fignums(), image_path_iterator):
         if 'format' in kwargs:

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -116,9 +116,10 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
         image_rsts.append(
             figure_rst([image_path], gallery_conf['src_dir'], fig_titles))
     plt.close('all')
+    rst = ''
     if len(image_rsts) == 1:
         rst = image_rsts[0]
-    else:
+    elif len(image_rsts) > 1:
         image_rsts = [re.sub(r':class: sphx-glr-single-img',
                              ':class: sphx-glr-multi-img',
                              image) for image in image_rsts]
@@ -318,7 +319,6 @@ def figure_rst(figure_list, sources_dir, fig_titles=''):
         images_rst = HLIST_HEADER
         for figure_name in figure_paths:
             images_rst += HLIST_IMAGE_TEMPLATE % (figure_name, alt)
-
     return images_rst
 
 

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -99,7 +99,6 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
         # Set the fig_num figure as the current figure as we can't
         # save a figure that's not the current figure.
         fig = plt.figure(fig_num)
-        print(fig_titles)
         # get fig titles
         fig_titles = _matplotlib_fig_titles(fig)
         to_rgba = matplotlib.colors.colorConverter.to_rgba

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -551,6 +551,7 @@ def test_rebuild(tmpdir_factory, sphinx_app):
         _assert_mtimes(copied_ipy_0, copied_ipy_1,
                        different=('plot_numpy_matplotlib.ipynb'))
 
+
 def test_alt_text(sphinx_app):
     """Test alt text"""
     src_dir = sphinx_app.srcdir

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -550,3 +550,21 @@ def test_rebuild(tmpdir_factory, sphinx_app):
         # mtimes for .ipynb files
         _assert_mtimes(copied_ipy_0, copied_ipy_1,
                        different=('plot_numpy_matplotlib.ipynb'))
+
+def test_alt_text(sphinx_app):
+    """Test alt text"""
+    fname = op.join(src_dir, 'auto_examples', 'plot_matplotlib_alt.rst')
+    assert op.isfile(fname)
+    with codecs.open(fname, 'r', 'utf-8') as fid:
+        rst = fid.read()
+    # suptitle and axes titles
+    assert ':alt: This is a sup title, subplot 1, subplot 2' in rst
+    # multiple titles
+    assert ':alt: Left Title, Center Title, Right Title' in rst
+
+    fname = op.join(src_dir, 'auto_examples', 'plot_numpy_matplotlib.rst')
+    assert op.isfile(fname)
+    with codecs.open(fname, 'r', 'utf-8') as fid:
+        rst = fid.read()
+    # file name when no fig title
+    assert 'plot numpy matplotlib' in rst

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -553,6 +553,7 @@ def test_rebuild(tmpdir_factory, sphinx_app):
 
 def test_alt_text(sphinx_app):
     """Test alt text"""
+    src_dir = sphinx_app.srcdir
     fname = op.join(src_dir, 'auto_examples', 'plot_matplotlib_alt.rst')
     assert op.isfile(fname)
     with codecs.open(fname, 'r', 'utf-8') as fid:

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -24,7 +24,7 @@ from sphinx_gallery.utils import _get_image, scale_image
 
 import pytest
 
-N_TOT = 6
+N_TOT = 7
 N_FAILING = 1
 N_GOOD = N_TOT - N_FAILING
 N_RST = 14 + N_TOT

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -732,8 +732,7 @@ def test_capture_repr(gallery_conf, capture_repr, code, expected_out,
     output = sg.execute_code_block(
         compiler, code_block, None, script_vars, gallery_conf
     )
-    print(_clean_output(output))
-    # assert _clean_output(output) == expected_out
+    assert _clean_output(output) == expected_out
 
 
 def test_ignore_repr_types(gallery_conf, req_mpl, req_pil, script_vars):

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -732,7 +732,8 @@ def test_capture_repr(gallery_conf, capture_repr, code, expected_out,
     output = sg.execute_code_block(
         compiler, code_block, None, script_vars, gallery_conf
     )
-    assert _clean_output(output) == expected_out
+    print(_clean_output(output))
+    # assert _clean_output(output) == expected_out
 
 
 def test_ignore_repr_types(gallery_conf, req_mpl, req_pil, script_vars):

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -204,7 +204,7 @@ def test_figure_rst(ext):
     local_img = [os.path.join(os.getcwd(), 'third.' + ext)]
     image_rst = figure_rst(local_img, '.')
 
-    single_image = SINGLE_IMAGE % ("third." + ext)
+    single_image = SINGLE_IMAGE % ("third." + ext, '')
     assert image_rst == single_image
 
 

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -175,6 +175,7 @@ def test_figure_rst(ext):
     image_rst = figure_rst(figure_list, '.')
     single_image = """
 .. image:: /sphx_glr_plot_1.{ext}
+    :alt: pl
     :class: sphx-glr-single-img
 """.format(ext=ext)
     assert image_rst == single_image
@@ -188,12 +189,14 @@ def test_figure_rst(ext):
     *
 
       .. image:: /sphx_glr_plot_1.{ext}
-            :class: sphx-glr-multi-img
+          :alt: pl
+          :class: sphx-glr-multi-img
 
     *
 
       .. image:: /second.{ext}
-            :class: sphx-glr-multi-img
+          :alt: pl
+          :class: sphx-glr-multi-img
 """.format(ext=ext)
     assert image_rst == image_list_rst
 

--- a/sphinx_gallery/tests/tinybuild/examples/plot_matplotlib_alt.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_matplotlib_alt.py
@@ -10,13 +10,13 @@ figures.
 import matplotlib.pyplot as plt
 
 fig, axs = plt.subplots(2, 1, constrained_layout=True)
-axs[0].plot([1,2,3])
+axs[0].plot([1, 2, 3])
 axs[0].set_title('subplot 1')
 axs[0].set_xlabel('x label')
 axs[0].set_ylabel('y lab')
 fig.suptitle('This is a sup title')
 
-axs[1].plot([2,3,4])
+axs[1].plot([2, 3, 4])
 axs[1].set_title('subplot 2')
 axs[1].set_xlabel('x label')
 axs[1].set_ylabel('y label')
@@ -26,8 +26,6 @@ plt.show()
 
 # %%
 # Several titles.
-
-import matplotlib.pyplot as plt
 
 plt.plot(range(10))
 

--- a/sphinx_gallery/tests/tinybuild/examples/plot_matplotlib_alt.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_matplotlib_alt.py
@@ -1,0 +1,38 @@
+"""
+======================
+Matplotlib alt text
+======================
+
+This example tests that the alt text is generated correctly for matplotlib
+figures.
+"""
+
+import matplotlib.pyplot as plt
+
+fig, axs = plt.subplots(2, 1, constrained_layout=True)
+axs[0].plot([1,2,3])
+axs[0].set_title('subplot 1')
+axs[0].set_xlabel('x label')
+axs[0].set_ylabel('y lab')
+fig.suptitle('This is a sup title')
+
+axs[1].plot([2,3,4])
+axs[1].set_title('subplot 2')
+axs[1].set_xlabel('x label')
+axs[1].set_ylabel('y label')
+
+plt.show()
+
+
+# %%
+# Several titles.
+
+import matplotlib.pyplot as plt
+
+plt.plot(range(10))
+
+plt.title('Center Title')
+plt.title('Left Title', loc='left')
+plt.title('Right Title', loc='right')
+
+plt.show()


### PR DESCRIPTION
closes #538 

For matplotlib figures, checks for 'suptitle', then tries `get_title()` for all axes of a figure.
If no text found, uses the file name. File name also used by default, for all non-matplotlib figures.

Currently only works for single figures. Will rework `matplotlib_scraper` so `figure_rst` is run on every loop so it works for 'HLIST_IMAGE_TEMPLATE'. Suggestions welcome

cc @ogrisel 