### PR TITLE
FIX: Remove newlines from title

### DIFF
--- a/examples/plot_1_exp.py
+++ b/examples/plot_1_exp.py
@@ -35,7 +35,7 @@ def main():
     plt.plot(x, -np.exp(-x))
     plt.xlabel('$x$')
     plt.ylabel('$-\exp(-x)$')
-    plt.title('Negative exponential function')
+    plt.title('Negative exponential\nfunction')
     # To avoid matplotlib text output
     plt.show()
 

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -310,6 +310,7 @@ def figure_rst(figure_list, sources_dir, fig_titles=''):
         # replace - & _ with \s
         file_name_final = re.sub(r'[-,_]', ' ', file_name_noext)
         alt = file_name_final
+    alt = _single_line_sanitize(alt)
 
     images_rst = ""
     if len(figure_paths) == 1:
@@ -320,6 +321,13 @@ def figure_rst(figure_list, sources_dir, fig_titles=''):
         for figure_name in figure_paths:
             images_rst += HLIST_IMAGE_TEMPLATE % (figure_name, alt)
     return images_rst
+
+
+def _single_line_sanitize(s):
+    """Remove problematic newlines."""
+    # For example, when setting a :alt: for an image, it shouldn't have \n
+    # This is a function in case we end up finding other things to replace
+    return s.replace('\n', ' ')
 
 
 # The following strings are used when we have several pictures: we use

--- a/sphinx_gallery/tests/tinybuild/examples/plot_matplotlib_alt.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_matplotlib_alt.py
@@ -14,7 +14,7 @@ axs[0].plot([1, 2, 3])
 axs[0].set_title('subplot 1')
 axs[0].set_xlabel('x label')
 axs[0].set_ylabel('y lab')
-fig.suptitle('This is a sup title')
+fig.suptitle('This is a\nsup title')
 
 axs[1].plot([2, 3, 4])
 axs[1].set_title('subplot 2')


### PR DESCRIPTION
In MNE I have been getting cryptic errors:

https://app.circleci.com/pipelines/github/mne-tools/mne-python/1345/workflows/3cb34706-7fa5-473a-8b57-376bd238c024/jobs/19753/steps

Examining the RST shows:

```
.. rst-class:: sphx-glr-horizontal


    *

      .. image:: /auto_examples/decoding/images/sphx_glr_plot_receptive_field_mtrf_003.png
          :alt: Mean Model
      Coefficients
          :class: sphx-glr-multi-img
```