### PR TITLE
FIX: Fix sys.stdout patching

### DIFF
--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -24,7 +24,7 @@ from sphinx_gallery.utils import _get_image, scale_image
 
 import pytest
 
-N_TOT = 8
+N_TOT = 9
 N_FAILING = 1
 N_GOOD = N_TOT - N_FAILING
 N_RST = 15 + N_TOT
@@ -329,6 +329,16 @@ def test_backreferences_examples(sphinx_app, rst_file, example_used_in):
     with codecs.open(examples_rst, 'r', 'utf-8') as fid:
         lines = fid.read()
     assert example_used_in in lines
+
+
+def test_logging_std_nested(sphinx_app):
+    """Test that nested stdout/stderr uses within a given script work."""
+    log_rst = op.join(
+        sphinx_app.srcdir, 'auto_examples', 'plot_log.rst')
+    with codecs.open(log_rst, 'r', 'utf-8') as fid:
+        lines = fid.read()
+    assert '.. code-block:: none\n\n    is in the same cell' in lines
+    assert '.. code-block:: none\n\n    is not in the same cell' in lines
 
 
 def _assert_mtimes(list_orig, list_new, different=(), ignore=()):

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -9,7 +9,6 @@ from __future__ import (division, absolute_import, print_function,
 import ast
 import codecs
 import importlib
-import io
 import tempfile
 import re
 import os
@@ -748,10 +747,9 @@ def test_ignore_repr_types(gallery_conf, req_mpl, req_pil, script_vars):
 
 class TestLoggingTee:
     def setup(self):
-        self.output_file = io.StringIO()
         self.src_filename = 'source file name'
-        self.tee = sg.LoggingTee(self.output_file, sg.logger,
-                                 self.src_filename)
+        self.tee = sg._LoggingTee(self.src_filename)
+        self.output_file = self.tee.output
 
     def test_full_line(self, log_collector):
         # A full line is output immediately.
@@ -802,7 +800,7 @@ class TestLoggingTee:
     def test_isatty(self, monkeypatch):
         assert not self.tee.isatty()
 
-        monkeypatch.setattr(self.tee.output_file, 'isatty', lambda: True)
+        monkeypatch.setattr(self.tee.output, 'isatty', lambda: True)
         assert self.tee.isatty()
 
 

--- a/sphinx_gallery/tests/tinybuild/examples/plot_log.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_log.py
@@ -1,0 +1,26 @@
+"""
+Logging test
+============
+"""
+
+# %%
+
+import logging
+import sys
+
+
+def _create_logger(name=None):
+    logger = logging.getLogger(name=name)
+    logger.setLevel(logging.INFO)
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setLevel(logging.INFO)
+    logger.addHandler(sh)
+    return logger
+
+
+# %%
+logger = _create_logger("first_logger")
+logger.info("is in the same cell")
+
+# %%
+logger.info("is not in the same cell")


### PR DESCRIPTION
This restructures our patching of `sys.stdout`/`stderr` to occur on a per-script basis, with some gymnastics to deal with our testing infrastructure calling things like `execute_code_block` outside a standard context where `with _LoggingTee` would otherwise have already set `sys.stdout`.

Closes #672.

@pmeier can you see if this fixes things for you?