### PR TITLE
Better alt thumbnail test for punctuation in title

### DIFF
--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -587,7 +587,7 @@ def test_alt_text_thumbnail(sphinx_app):
     generated_examples_index = op.join(out_dir, 'auto_examples', 'index.html')
     with codecs.open(generated_examples_index, 'r', 'utf-8') as fid:
         html = fid.read()
-    assert 'alt="SVG graphics"' in html
+    assert 'alt="&quot;SVG&quot;:-`graphics_`"' in html
     # check backreferences thumbnail, html
     backref_html = op.join(out_dir, 'gen_modules',
                            'sphinx_gallery.backreferences.html')

--- a/sphinx_gallery/tests/tinybuild/examples/plot_svg.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_svg.py
@@ -1,9 +1,10 @@
 """
-============
-SVG graphics
-============
+==================
+"SVG":-`graphics_`
+==================
 
 Make sure we can embed SVG graphics.
+Use title that has punctuation marks.
 """
 
 import numpy as np


### PR DESCRIPTION
Add punctuation to title of `plot_svg.py` in tinybuild to test thumbnail alt attribute.