### PR TITLE
ENH Add cross ref label to template module.rst

### DIFF
--- a/doc/_templates/module.rst
+++ b/doc/_templates/module.rst
@@ -16,6 +16,8 @@
 
    .. autofunction:: {{ item }}
 
+   .. _sphx_glr_backref_{{fullname}}.{{item}}:
+
    .. include:: backreferences/{{fullname}}.{{item}}.examples
 
    .. raw:: html

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -393,14 +393,22 @@ document, in this case all modules of Sphinx-Gallery.
 The template file ``module.rst`` for the ``autosummary`` directive has
 to be saved in the path ``_templates/module.rst``. We present our
 configuration in the following block. The most relevant part is the
-loop defined between lines **12-22** that parses all the functions of
-the module. There we have included the snippet introduced in the
+loop defined between lines **12-22** that parses all the functions/classes
+of the module. There we have included the snippet introduced in the
 previous section. Keep in mind that the include directive is
 **relative** to the file location, and module documentation files are
 saved in the directory we specified in the *toctree* option of the
 ``autosummary`` directive used before in the ``reference.rst`` file.
 The files we are including are from the ``backreferences_dir``
 configuration option setup for Sphinx-Gallery.
+
+We also add a cross referencing label (on line 19) before including the
+examples mini-gallery. This enables you to reference the mini-gallery for
+all functions/classes of the module using
+``:ref:`sphx_glr_backref_<fun/class>```, where '<fun/class>' is the full path
+to the function/class using dot notation (e.g.,
+``sphinx_gallery.backreferences.identify_names``). For example, see:
+:ref:`sphx_glr_backref_sphinx_gallery.backreferences.identify_names`.
 
 .. literalinclude:: _templates/module.rst
     :language: rst

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -600,3 +600,22 @@ def test_alt_text_thumbnail(sphinx_app):
     with codecs.open(generated_examples_index, 'r', 'utf-8') as fid:
         rst = fid.read()
     assert ':alt: Trivial module to provide a value for plot_numpy_matplotlib.py' in rst  # noqa: E501
+
+
+def test_backreference_labels(sphinx_app):
+    """Tests that backreference labels work."""
+    src_dir = sphinx_app.srcdir
+    out_dir = sphinx_app.outdir
+    # Test backreference label
+    backref_rst = op.join(src_dir, 'gen_modules',
+                          'sphinx_gallery.backreferences.rst')
+    with codecs.open(backref_rst, 'r', 'utf-8') as fid:
+        rst = fid.read()
+    label = '.. _sphx_glr_backref_sphinx_gallery.backreferences.identify_names:'  # noqa: E501
+    assert label in rst
+    # Test html link
+    index_html = op.join(out_dir, 'index.html')
+    with codecs.open(index_html, 'r', 'utf-8') as fid:
+        html = fid.read()
+    link = 'href="gen_modules/sphinx_gallery.backreferences.html#sphx-glr-backref-sphinx-gallery-backreferences-identify-names">'  # noqa: E501
+    assert link in html

--- a/sphinx_gallery/tests/tinybuild/_templates/module.rst
+++ b/sphinx_gallery/tests/tinybuild/_templates/module.rst
@@ -16,6 +16,8 @@
 
    .. autofunction:: {{ item }}
 
+   .. _sphx_glr_backref_{{fullname}}.{{item}}:
+
    .. include:: backreferences/{{fullname}}.{{item}}.examples
 
    .. raw:: html

--- a/sphinx_gallery/tests/tinybuild/index.rst
+++ b/sphinx_gallery/tests/tinybuild/index.rst
@@ -29,6 +29,9 @@ every module. Examples `here <auto_examples/index.html>`_.
 Examples
 --------
 
+This tests that mini-gallery reference labels work:
+:ref:`sphx_glr_backref_sphinx_gallery.backreferences.identify_names`.
+
 .. toctree::
    :maxdepth: 2
 


### PR DESCRIPTION
closes #496 

Add cross referencing label to `module.rst` to easily link to mini-galleries of module fun/classes.
Add test in tinybuild