### PR TITLE
Sphinx directive to insert mini-galleries

### DIFF
--- a/doc/_templates/module.rst
+++ b/doc/_templates/module.rst
@@ -18,11 +18,8 @@
 
    .. _sphx_glr_backref_{{fullname}}.{{item}}:
 
-   .. include:: backreferences/{{fullname}}.{{item}}.examples
-
-   .. raw:: html
-
-	       <div class="sphx-glr-clear"></div>
+   .. minigallery:: {{fullname}}.{{item}}
+       :add-heading:
 
    {%- endfor %}
    {% endif %}
@@ -38,11 +35,8 @@
    .. autoclass:: {{ item }}
       :members:
 
-   .. include:: backreferences/{{fullname}}.{{item}}.examples
-
-   .. raw:: html
-
-	       <div class="sphx-glr-clear"></div>
+   .. minigallery:: {{fullname}}.{{item}}
+       :add-heading:
 
    {%- endfor %}
    {% endif %}

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -310,10 +310,8 @@ within function calls).
 For example, we can embed a small gallery of all examples that use or
 refer to :obj:`numpy.exp`, which looks like this:
 
-.. include:: gen_modules/backreferences/numpy.exp.examples
-.. raw:: html
-
-        <div class="sphx-glr-clear"></div>
+.. minigallery:: numpy.exp
+    :add-heading:
 
 For such behavior to be available, you have to activate it in
 your Sphinx-Gallery configuration ``conf.py`` file with::
@@ -338,18 +336,30 @@ and belonging to the modules listed in ``doc_module``.
 Within your sphinx documentation ``.rst`` files, you can use easily
 add this reduced version of the Gallery. For example, the rst below adds
 the reduced version of the Gallery for ``numpy.exp``, which includes all
-examples that use the specific function ``numpy.exp``::
+examples that use the specific function ``numpy.exp``:
 
-    .. include:: gen_modules/backreferences/numpy.exp.examples
-    .. raw:: html
+.. code-block:: rst
 
-        <div class="sphx-glr-clear"></div>
+    .. minigallery:: numpy.exp
+        :add-heading:
 
-The ``include`` directive takes a path **relative** to the ``rst``
-file it is called from. In the case of this documentation file (which
-is in the same directory as ``conf.py``) we directly use the path
-declared in ``backreferences_dir`` followed by the function whose
-examples we want to show and the file has the ``.examples`` extension.
+The ``add-heading`` option adds a heading for the mini-gallery, which will be a
+default generated message if no string is provided as an argument.  The example
+mini-gallery shown above uses the default heading.  The level of the heading
+defaults to ``^``, but can be changed using the ``heading-level`` option, which
+accepts a single character (e.g., ``-``).
+
+You can also list multiple items, separated by spaces, which will merge all
+examples into a single mini-gallery, e.g.:
+
+.. code-block:: rst
+
+    .. minigallery:: numpy.exp numpy.sin
+        :add-heading: Mini-gallery using ``numpy.exp`` or ``numpy.sin``
+        :heading-level: -
+
+For such a mini-gallery, specifying a custom heading message is recommended
+because the default message is vague: "Examples of one of multiple objects".
 
 Auto-documenting your API with links to examples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -393,16 +403,11 @@ document, in this case all modules of Sphinx-Gallery.
 The template file ``module.rst`` for the ``autosummary`` directive has
 to be saved in the path ``_templates/module.rst``. We present our
 configuration in the following block. The most relevant part is the
-loop defined between lines **12-22** that parses all the functions/classes
-of the module. There we have included the snippet introduced in the
-previous section. Keep in mind that the include directive is
-**relative** to the file location, and module documentation files are
-saved in the directory we specified in the *toctree* option of the
-``autosummary`` directive used before in the ``reference.rst`` file.
-The files we are including are from the ``backreferences_dir``
-configuration option setup for Sphinx-Gallery.
+loop defined between lines **12-21** that parses all the functions/classes
+of the module. There we have used the ``minigallery`` directive introduced in
+the previous section.
 
-We also add a cross referencing label (on line 19) before including the
+We also add a cross referencing label (on line 16) before including the
 examples mini-gallery. This enables you to reference the mini-gallery for
 all functions/classes of the module using
 ``:ref:`sphx_glr_backref_<fun/class>```, where '<fun/class>' is the full path
@@ -413,7 +418,7 @@ to the function/class using dot notation (e.g.,
 .. literalinclude:: _templates/module.rst
     :language: rst
     :lines: 3-
-    :emphasize-lines: 12-22, 32-42
+    :emphasize-lines: 12-21, 31-38
     :linenos:
 
 Toggling global variable inspection

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -29,3 +29,4 @@ every module.
    downloads
    sorting
    binder
+   directives

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -293,6 +293,8 @@ def _write_backreferences(backrefs, seen_backrefs, gallery_conf,
         with codecs.open(include_path, 'a' if seen else 'w',
                          encoding='utf-8') as ex_file:
             if not seen:
+                # Be aware that if the number of lines of this heading changes,
+                #   the minigallery directive should be modified accordingly
                 heading = 'Examples using ``%s``' % backref
                 ex_file.write('\n\n' + heading + '\n')
                 ex_file.write('^' * len(heading) + '\n')

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -1,0 +1,79 @@
+"""
+Custom Sphinx directives
+========================
+"""
+
+import os
+
+from docutils import statemachine
+from docutils.parsers.rst import Directive, directives
+
+
+class MiniGallery(Directive):
+    """
+    Custom directive to insert a mini-gallery
+
+    The required argument is one or more fully qualified names of objects,
+    separated by spaces.  The mini-gallery will be the subset of gallery
+    examples that make use of that object (from that specific namespace).
+
+    Options:
+
+    * `add-heading` adds a heading to the mini-gallery.  If an argument is
+      provided, it uses that text for the heading.  Otherwise, it uses
+      default text.
+    * `heading-level` specifies the heading level of the heading as a single
+      character.  If omitted, the default heading level is `'^'`.
+    """
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
+    option_spec = {'add-heading': directives.unchanged,
+                   'heading-level': directives.single_char_or_unicode}
+
+    def run(self):
+        # Respect the same disabling options as the `raw` directive
+        if (not self.state.document.settings.raw_enabled
+                or not self.state.document.settings.file_insertion_enabled):
+            raise self.warning('"%s" directive disabled.' % self.name)
+
+        # Retrieve the backreferences directory
+        config = self.state.document.settings.env.config
+        backreferences_dir = config.sphinx_gallery_conf['backreferences_dir']
+
+        # Parse the argument into the individual objects
+        obj_list = self.arguments[0].split()
+
+        lines = []
+
+        # Add a heading if requested
+        if 'add-heading' in self.options:
+            heading = self.options['add-heading']
+            if heading == "":
+                if len(obj_list) == 1:
+                    heading = 'Examples using ``{}``'.format(obj_list[0])
+                else:
+                    heading = 'Examples using one of multiple objects'
+            lines.append(heading)
+            heading_level = self.options.get('heading-level', '^')
+            lines.append(heading_level * len(heading))
+
+        # Insert the backreferences file(s) using the `include` directive
+        for obj in obj_list:
+            path = os.path.join('/',  # Sphinx treats this as the source dir
+                                backreferences_dir,
+                                '{}.examples'.format(obj))
+
+            # Always remove the heading (first 5 lines) from the file
+            lines.append('.. include:: {}\n    :start-line: 5'.format(path))
+
+        # Insert the end for the gallery using the `raw` directive
+        lines.append('.. raw:: html\n\n    <div class="sphx-glr-clear"></div>')
+
+        # Parse the assembly of `include` and `raw` directives
+        text = '\n'.join(lines)
+        include_lines = statemachine.string2lines(text,
+                                                  convert_whitespace=True)
+        self.state_machine.insert_input(include_lines, path)
+
+        return []

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -31,6 +31,7 @@ from .docs_resolv import embed_code_links
 from .downloads import generate_zipfiles
 from .sorting import NumberOfCodeLinesSortKey
 from .binder import copy_binder_files
+from .directives import MiniGallery
 
 
 _KNOWN_CSS = ('gallery', 'gallery-binder', 'gallery-dataframe')
@@ -671,6 +672,9 @@ def setup(app):
 
     if 'sphinx.ext.autodoc' in app.extensions:
         app.connect('autodoc-process-docstring', touch_empty_backreferences)
+
+    # Add the custom directive
+    app.add_directive('minigallery', MiniGallery)
 
     app.connect('builder-inited', generate_gallery_rst)
     app.connect('build-finished', copy_binder_files)

--- a/sphinx_gallery/tests/tinybuild/_templates/module.rst
+++ b/sphinx_gallery/tests/tinybuild/_templates/module.rst
@@ -18,11 +18,8 @@
 
    .. _sphx_glr_backref_{{fullname}}.{{item}}:
 
-   .. include:: backreferences/{{fullname}}.{{item}}.examples
-
-   .. raw:: html
-
-	       <div class="sphx-glr-clear"></div>
+   .. minigallery:: {{fullname}}.{{item}}
+       :add-heading:
 
    {%- endfor %}
    {% endif %}
@@ -38,11 +35,8 @@
    .. autoclass:: {{ item }}
       :members:
 
-   .. include:: backreferences/{{fullname}}.{{item}}.examples
-
-   .. raw:: html
-
-      <div class="sphx-glr-clear"></div>
+   .. minigallery:: {{fullname}}.{{item}}
+       :add-heading:
 
    {%- endfor %}
    {% endif %}

--- a/sphinx_gallery/tests/tinybuild/minigallery.rst
+++ b/sphinx_gallery/tests/tinybuild/minigallery.rst
@@ -1,0 +1,37 @@
+Test mini-galleries
+===================
+
+Test 1-N
+
+.. minigallery:: sphinx_gallery.sorting.ExplicitOrder
+
+Test 1-D-D
+
+.. minigallery:: sphinx_gallery.sorting.ExplicitOrder
+    :add-heading:
+
+Test 1-D-C
+
+.. minigallery:: sphinx_gallery.sorting.ExplicitOrder
+    :add-heading:
+    :heading-level: -
+
+Test 1-C-D
+
+.. minigallery:: sphinx_gallery.sorting.ExplicitOrder
+    :add-heading: This is a custom heading
+
+Test 2-N
+
+.. minigallery:: sphinx_gallery.sorting.ExplicitOrder sphinx_gallery.sorting.FileNameSortKey
+
+Test 2-D-D
+
+.. minigallery:: sphinx_gallery.sorting.ExplicitOrder sphinx_gallery.sorting.FileNameSortKey
+    :add-heading:
+
+Test 2-C-C
+
+.. minigallery:: sphinx_gallery.sorting.ExplicitOrder sphinx_gallery.sorting.FileNameSortKey
+    :add-heading: This is a different custom heading
+    :heading-level: =


### PR DESCRIPTION
Per #683, here's what I have in mind for the API for the proposed `minigallery` Sphinx directive to easily insert mini-galleries.  My conception is that the new approach would entirely replace the old approach in the user documentation, but the old approach would still work.

Once there's agreement on the API, I'll code the directive, with [this implementation](https://github.com/ayshih/sunpy/blob/c7f8cb2776acb21a9029e943c868503772740b2b/docs/conf.py#L320) as the starting point.