### PR TITLE
Fix lint in gen_gallery.py

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -439,7 +439,7 @@ def write_computation_times(gallery_conf, target_dir, costs):
                   .format(_sec_to_readable(total_time), target_dir_clean))
         lines, lens = _format_for_writing(costs, target_dir_clean)
         del costs
-        hline = ''.join(('+' + '-' * (l + 2)) for l in lens) + '+\n'
+        hline = ''.join(('+' + '-' * (length + 2)) for length in lens) + '+\n'
         fid.write(hline)
         format_str = ''.join('| {%s} ' % (ii,)
                              for ii in range(len(lines[0]))) + '|\n'

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -420,7 +420,8 @@ def _format_for_writing(costs, path, kind='rst'):
             t = '%0.2f sec' % (cost[0][0],)
         m = '{0:.1f} MB'.format(cost[0][1])
         lines.append([name, t, m])
-    lens = [max(x) for x in zip(*[[len(l) for l in ll] for ll in lines])]
+    lens = [max(x) for x in zip(*[[len(item) for item in cost]
+                                  for cost in lines])]
     return lines, lens
 
 


### PR DESCRIPTION
Fix lint:
```
sphinx_gallery/gen_gallery.py:423:47: E741 ambiguous variable name 'l'

sphinx_gallery/gen_gallery.py:441:51: E741 ambiguous variable name 'l'
```