### PR TITLE
ENH: Use broader def of Animation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       # Get our data and merge with upstream
       - run: sudo apt-get update
-      - run: sudo apt-get --no-install-recommends install -y texlive texlive-latex-extra latexmk libxkbcommon-x11-0
+      - run: sudo apt-get --no-install-recommends install -y texlive texlive-latex-extra latexmk libxkbcommon-x11-0 optipng
       - checkout
       - run: echo $(git log -1 --pretty=%B) | tee gitlog.txt
       - run: echo ${CI_PULL_REQUEST//*pull\//} | tee merge.txt

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -875,7 +875,7 @@ to scrape both matplotlib and Mayavi images you can do::
 The default value is ``'image_scrapers': ('matplotlib',)`` which only scrapes
 Matplotlib images. Note that this includes any images produced by packages that
 are based on Matplotlib, for example Seaborn or Yellowbrick. If you want
-to embed :class:`matplotlib.animation.FuncAnimation`\s as animations rather
+to embed :class:`matplotlib.animation.Animation`\s as animations rather
 than a single static image of the animation figure, you should add::
 
       sphinx_gallery_conf = {

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -102,14 +102,14 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
         the images. This is often produced by :func:`figure_rst`.
     """
     matplotlib, plt = _import_matplotlib()
-    from matplotlib.animation import FuncAnimation
+    from matplotlib.animation import Animation
     image_path_iterator = block_vars['image_path_iterator']
     image_rsts = []
     # Check for animations
     anims = list()
     if gallery_conf.get('matplotlib_animations', False):
         for ani in block_vars['example_globals'].values():
-            if isinstance(ani, FuncAnimation):
+            if isinstance(ani, Animation):
                 anims.append(ani)
     # Then standard images
     for fig_num, image_path in zip(plt.get_fignums(), image_path_iterator):


### PR DESCRIPTION
Matplotlib also has `ArtistAnimation`. It would be nice to have this for matplotlib (https://github.com/matplotlib/matplotlib/pull/17477), maybe in a 0.7.1 release sometime? Let's wait to see what else breaks in the meantime before cutting one, though.