### PR TITLE
Remove matplotlib agg warning

### DIFF
--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -15,6 +15,7 @@ import os
 import sys
 import re
 from textwrap import indent
+from warnings import filterwarnings
 
 from sphinx.errors import ExtensionError
 from .utils import scale_image, optipng
@@ -33,6 +34,10 @@ def _import_matplotlib():
     import matplotlib
     matplotlib.use('agg')
     matplotlib_backend = matplotlib.get_backend().lower()
+
+    filterwarnings("ignore", category=UserWarning,
+                   message='Matplotlib is currently using agg, which is a'
+                           ' non-GUI backend, so cannot show the figure.')
 
     if matplotlib_backend != 'agg':
         raise ExtensionError(

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -748,3 +748,14 @@ def test_minigallery_directive(sphinx_app):
             # Check for examples
             assert explicitorder_example.search(text) is not None
             assert filenamesortkey_example.search(text) is not None
+
+def test_matplotlib_warning_filter(sphinx_app):
+    """Test Matplotlib agg warning is removed."""
+    out_dir = sphinx_app.outdir
+    example_html = op.join(out_dir, 'auto_examples',
+                           'plot_matplotlib_alt.html')
+    with codecs.open(example_html, 'r', 'utf-8') as fid:
+        html = fid.read()
+    warning = ('Matplotlib is currently using agg, which is a'
+               ' non-GUI backend, so cannot show the figure.')
+    assert warning not in html

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -749,6 +749,7 @@ def test_minigallery_directive(sphinx_app):
             assert explicitorder_example.search(text) is not None
             assert filenamesortkey_example.search(text) is not None
 
+
 def test_matplotlib_warning_filter(sphinx_app):
     """Test Matplotlib agg warning is removed."""
     out_dir = sphinx_app.outdir


### PR DESCRIPTION
closes #694

Did not realise it would be that simple, seems magical.

I didn't add anything to doc assuming no one would miss this warning.