### PR TITLE
Enable html to be rendered on readthedocs

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -163,11 +163,9 @@ SPHX_GLR_SIG = """\n
 """
 
 # Header used to include raw html
-html_header = """.. only:: builder_html or readthedocs
+html_header = """.. raw:: html
 
-    .. raw:: html
-
-{0}\n        <br />\n        <br />"""
+{0}\n    <br />\n    <br />"""
 
 
 def codestr2rst(codestr, lang='python', lineno=None):
@@ -602,7 +600,7 @@ def execute_code_block(compiler, block, example_globals,
         images_rst = save_figures(block, script_vars, gallery_conf)
         # give html output its own header
         if repr_meth == '_repr_html_':
-            captured_html = html_header.format(indent(last_repr, u' ' * 8))
+            captured_html = html_header.format(indent(last_repr, u' ' * 4))
         else:
             captured_html = ''
         code_output = u"\n{0}\n\n{1}\n{2}\n\n".format(

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -163,7 +163,7 @@ SPHX_GLR_SIG = """\n
 """
 
 # Header used to include raw html
-html_header = """.. only:: builder_html
+html_header = """.. only:: builder_html or readthedocs
 
     .. raw:: html
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -656,13 +656,11 @@ plt.close('all')
 fig
 """
 
-html_out = """.. only:: builder_html
+html_out = """.. raw:: html
 
-    .. raw:: html
-
-        <div> This is the _repr_html_ div </div>
-        <br />
-        <br />"""
+    <div> This is the _repr_html_ div </div>
+    <br />
+    <br />"""
 
 text_above_html = """Out:
 
@@ -677,7 +675,7 @@ text_above_html = """Out:
 def _clean_output(output):
     is_text = '.. rst-class:: sphx-glr-script-out' in output
 
-    is_html = '.. only:: builder_html' in output
+    is_html = '.. raw:: html' in output
 
     if output.isspace():
         return ''


### PR DESCRIPTION
Per comment: https://github.com/readthedocs/readthedocs.org/issues/4765#issuecomment-431927720

I was able to test this by monkey patching the change, and confirm that HTML now renders both on local build and on Read the Docs.