### PR TITLE
BUG: Use relative paths for zip downloads

### DIFF
--- a/sphinx_gallery/downloads.py
+++ b/sphinx_gallery/downloads.py
@@ -117,14 +117,14 @@ def generate_zipfiles(gallery_dir):
             target_dir = os.path.join(gallery_dir, directory)
             listdir.extend(list_downloadable_sources(target_dir))
 
-    py_zipfile = python_zip(listdir, gallery_dir)
-    jy_zipfile = python_zip(listdir, gallery_dir, ".ipynb")
+    py_zipfile = os.path.basename(python_zip(listdir, gallery_dir))
+    jy_zipfile = os.path.basename(python_zip(listdir, gallery_dir, ".ipynb"))
 
     def rst_path(filepath):
         return filepath.replace(os.sep, '/')
 
-    dw_rst = CODE_ZIP_DOWNLOAD.format(os.path.basename(py_zipfile),
+    dw_rst = CODE_ZIP_DOWNLOAD.format(py_zipfile,
                                       rst_path(py_zipfile),
-                                      os.path.basename(jy_zipfile),
+                                      jy_zipfile,
                                       rst_path(jy_zipfile))
     return dw_rst

--- a/sphinx_gallery/downloads.py
+++ b/sphinx_gallery/downloads.py
@@ -95,7 +95,7 @@ def list_downloadable_sources(target_dir):
             if fname.endswith('.py')]
 
 
-def generate_zipfiles(gallery_dir):
+def generate_zipfiles(gallery_dir, src_dir):
     """
     Collects all Python source files and Jupyter notebooks in
     gallery_dir and makes zipfiles of them
@@ -104,6 +104,8 @@ def generate_zipfiles(gallery_dir):
     ----------
     gallery_dir : str
         path of the gallery to collect downloadable sources
+    src_dir : str
+        The file source directory. Needed to make the RST paths relative.
 
     Return
     ------
@@ -117,14 +119,15 @@ def generate_zipfiles(gallery_dir):
             target_dir = os.path.join(gallery_dir, directory)
             listdir.extend(list_downloadable_sources(target_dir))
 
-    py_zipfile = os.path.basename(python_zip(listdir, gallery_dir))
-    jy_zipfile = os.path.basename(python_zip(listdir, gallery_dir, ".ipynb"))
+    py_zipfile = python_zip(listdir, gallery_dir)
+    jy_zipfile = python_zip(listdir, gallery_dir, ".ipynb")
 
     def rst_path(filepath):
+        filepath = os.path.relpath(filepath, os.path.normpath(src_dir))
         return filepath.replace(os.sep, '/')
 
-    dw_rst = CODE_ZIP_DOWNLOAD.format(py_zipfile,
+    dw_rst = CODE_ZIP_DOWNLOAD.format(os.path.basename(py_zipfile),
                                       rst_path(py_zipfile),
-                                      jy_zipfile,
+                                      os.path.basename(jy_zipfile),
                                       rst_path(jy_zipfile))
     return dw_rst

--- a/sphinx_gallery/downloads.py
+++ b/sphinx_gallery/downloads.py
@@ -105,7 +105,7 @@ def generate_zipfiles(gallery_dir, src_dir):
     gallery_dir : str
         path of the gallery to collect downloadable sources
     src_dir : str
-        The file source directory. Needed to make the RST paths relative.
+        The build source directory. Needed to make the RST paths relative.
 
     Return
     ------

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -384,7 +384,8 @@ def generate_gallery_rst(app):
                 write_computation_times(gallery_conf, target_dir, this_costs)
 
             if gallery_conf['download_all_examples']:
-                download_fhindex = generate_zipfiles(gallery_dir)
+                download_fhindex = generate_zipfiles(
+                    gallery_dir, app.builder.srcdir)
                 fhindex.write(download_fhindex)
 
             fhindex.write(SPHX_GLR_SIG)


### PR DESCRIPTION
Closes #704, Cc @larsoner

### TL;DR

The zip files comprising all examples were included with absolute file links. If one wants to use galleries built on another machine this results in an error if the paths do not match.