### PR TITLE
BUG: Always do linking

### DIFF
--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -423,12 +423,7 @@ def embed_code_links(app, exception):
     if exception is not None:
         return
 
-    # No need to waste time embedding hyperlinks when not running the examples
-    # XXX: also at the time of writing this fixes make html-noplot
-    # for some reason I don't fully understand
     gallery_conf = app.config.sphinx_gallery_conf
-    if not gallery_conf['plot_gallery']:
-        return
 
     # XXX: Whitelist of builders for which it makes sense to embed
     # hyperlinks inside the example html. Note that the link embedding


### PR DESCRIPTION
I was doing a `make html_dev-noplot` run and I was confused why links weren't showing up in the code. There isn't really a good reason not to put them in nowadays since we use `intersphinx` to find names and such. It's quick relative to the entire build time, and useful even in noplot runs.

Hopefully the "inexplicable fix" workaround is no longer needed. If it causes problems, we should fix the underlying bug.