### PR TITLE
DOC Specify matplotlib in animation example

### DIFF
--- a/examples/plot_8_animations.py
+++ b/examples/plot_8_animations.py
@@ -1,8 +1,8 @@
 """
-Animation support
-=================
+Matplotlib animation support
+============================
 
-Show an animation, which should end up nicely embedded below.
+Show a Matplotlib animation, which should end up nicely embedded below.
 """
 
 import numpy as np


### PR DESCRIPTION
I thought it would be useful to specify 'Maplotlib' in the animation example, especially if we will add a plotly example (#715).