### PR TITLE
Make md5 hash independent of platform line endings

### DIFF
--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -317,7 +317,7 @@ def _finalize_backreferences(seen_backrefs, gallery_conf):
                             gallery_conf['backreferences_dir'],
                             '%s.examples.new' % backref)
         if os.path.isfile(path):
-            _replace_md5(path)
+            _replace_md5(path, mode='t')
         else:
             level = gallery_conf['log_level'].get('backreference_missing',
                                                   'warning')

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -428,7 +428,7 @@ def generate_gallery_rst(app):
                 fhindex.write(download_fhindex)
 
             fhindex.write(SPHX_GLR_SIG)
-        _replace_md5(index_rst_new)
+        _replace_md5(index_rst_new, mode='t')
     _finalize_backreferences(seen_backrefs, gallery_conf)
 
     if gallery_conf['plot_gallery']:

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -238,10 +238,10 @@ def extract_intro_and_title(filename, docstring):
     return intro, title
 
 
-def md5sum_is_current(src_file):
+def md5sum_is_current(src_file, mode='b'):
     """Checks whether src_file has the same md5 hash as the one on disk"""
 
-    src_md5 = get_md5sum(src_file)
+    src_md5 = get_md5sum(src_file, mode)
 
     src_md5_file = src_file + '.md5'
     if os.path.exists(src_md5_file):
@@ -721,7 +721,7 @@ def execute_script(script_blocks, script_vars, gallery_conf):
         # Write md5 checksum if the example was meant to run (no-plot
         # shall not cache md5sum) and has built correctly
         with open(script_vars['target_file'] + '.md5', 'w') as file_checksum:
-            file_checksum.write(get_md5sum(script_vars['target_file']))
+            file_checksum.write(get_md5sum(script_vars['target_file'], 't'))
         gallery_conf['passing_examples'].append(script_vars['src_file'])
 
     return output_blocks, time_elapsed
@@ -754,7 +754,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
     seen_backrefs = set() if seen_backrefs is None else seen_backrefs
     src_file = os.path.normpath(os.path.join(src_dir, fname))
     target_file = os.path.join(target_dir, fname)
-    _replace_md5(src_file, target_file, 'copy')
+    _replace_md5(src_file, target_file, 'copy', mode='t')
 
     file_conf, script_blocks, node = split_code_and_text_blocks(
         src_file, return_node=True)
@@ -763,7 +763,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
 
     executable = executable_script(src_file, gallery_conf)
 
-    if md5sum_is_current(target_file):
+    if md5sum_is_current(target_file, mode='t'):
         if executable:
             gallery_conf['stale_examples'].append(target_file)
         return intro, title, (0, 0)
@@ -809,7 +809,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
     example_nb = jupyter_notebook(script_blocks, gallery_conf)
     ipy_fname = replace_py_ipynb(target_file) + '.new'
     save_notebook(example_nb, ipy_fname)
-    _replace_md5(ipy_fname)
+    _replace_md5(ipy_fname, mode='t')
 
     # Write names
     if gallery_conf['inspect_global_variables']:
@@ -945,4 +945,4 @@ def save_rst_example(example_rst, example_file, time_elapsed,
         f.write(example_rst)
     # in case it wasn't in our pattern, only replace the file if it's
     # still stale.
-    _replace_md5(write_file_new)
+    _replace_md5(write_file_new, mode='t')

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -777,3 +777,13 @@ def test_jupyter_notebook_pandoc(sphinx_app):
         assert md_pandoc in md
     else:
         assert md_sg in md
+
+
+def test_md5_hash(sphinx_app):
+    src_dir = sphinx_app.srcdir
+    fname = op.join(src_dir, 'auto_examples', 'plot_log.py.md5')
+    expected_md5 = '0edc2de97f96f3b55f8b4a21994931a8'
+    with open(fname) as md5_file:
+        actual_md5 = md5_file.read()
+
+    assert actual_md5 == expected_md5

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -292,21 +292,26 @@ def test_extract_intro_and_title():
         sg.extract_intro_and_title('<string>', '=====')  # no real title
 
 
-def test_md5sums():
+@pytest.mark.parametrize(
+    'mode,expected_md5',
+    (['b', 'a546be453c8f436e744838a4801bd3a0'],
+     ['t', 'ea8a570e9f3afc0a7c3f2a17a48b8047']))
+def test_md5sums(mode, expected_md5):
     """Test md5sum check functions work on know file content."""
+    file_content = b'Local test\r\n'
     with tempfile.NamedTemporaryFile('wb', delete=False) as f:
-        f.write(b'Local test\n')
+        f.write(file_content)
     try:
-        file_md5 = sg.get_md5sum(f.name)
+        file_md5 = sg.get_md5sum(f.name, mode)
         # verify correct md5sum
-        assert 'ea8a570e9f3afc0a7c3f2a17a48b8047' == file_md5
+        assert file_md5 == expected_md5
         # False because is a new file
         assert not sg.md5sum_is_current(f.name)
         # Write md5sum to file to check is current
         with open(f.name + '.md5', 'w') as file_checksum:
             file_checksum.write(file_md5)
         try:
-            assert sg.md5sum_is_current(f.name)
+            assert sg.md5sum_is_current(f.name, mode)
         finally:
             os.remove(f.name + '.md5')
     finally:

--- a/sphinx_gallery/utils.py
+++ b/sphinx_gallery/utils.py
@@ -124,20 +124,32 @@ def replace_py_ipynb(fname):
     return '{}{}'.format(fname_prefix, new_extension)
 
 
-def get_md5sum(src_file):
-    """Returns md5sum of file"""
-    with open(src_file, 'rt', errors='surrogateescape') as src_data:
-        src_content = src_data.read().encode(errors='surrogateescape')
+def get_md5sum(src_file, mode='b'):
+    """Returns md5sum of file
+
+    Parameters
+    ----------
+    src_file : str
+        Filename to get md5sum for.
+    mode : 't' or 'b'
+        File mode to open file with. When in text mode, universal line endings
+        are used to ensure consitency in hashes between platforms.
+    """
+    errors = 'surrogateescape' if mode == 't' else None
+    with open(src_file, 'r' + mode, errors=errors) as src_data:
+        src_content = src_data.read()
+        if mode == 't':
+            src_content = src_content.encode(errors=errors)
         return hashlib.md5(src_content).hexdigest()
 
 
-def _replace_md5(fname_new, fname_old=None, method='move'):
+def _replace_md5(fname_new, fname_old=None, method='move', mode='b'):
     assert method in ('move', 'copy')
     if fname_old is None:
         assert fname_new.endswith('.new')
         fname_old = os.path.splitext(fname_new)[0]
-    if os.path.isfile(fname_old) and (get_md5sum(fname_old) ==
-                                      get_md5sum(fname_new)):
+    if os.path.isfile(fname_old) and (get_md5sum(fname_old, mode) ==
+                                      get_md5sum(fname_new, mode)):
         if method == 'move':
             os.remove(fname_new)
     else:

--- a/sphinx_gallery/utils.py
+++ b/sphinx_gallery/utils.py
@@ -126,8 +126,8 @@ def replace_py_ipynb(fname):
 
 def get_md5sum(src_file):
     """Returns md5sum of file"""
-    with open(src_file, 'rb') as src_data:
-        src_content = src_data.read()
+    with open(src_file, 'rt', errors='surrogateescape') as src_data:
+        src_content = src_data.read().encode(errors='surrogateescape')
         return hashlib.md5(src_content).hexdigest()
 
 


### PR DESCRIPTION
Currently md5 hash for Python files depends on what platform file is on, as file endings will differ. This change reads the Python files in the hashing function with universal line endings, such md5 is independent of platform being used.

Surrogate escapes are used, to ensure that it can handle any errors without data loss.

This is useful when adding a complex or long running examples into a repository that may be used across platforms.