### PR TITLE
Support headings in RST to MD

### DIFF
--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -81,10 +81,14 @@ def rst2md(text, heading_levels):
     # https://docutils.readthedocs.io/en/sphinx-docs/user/rst/quickstart.html#sections
     adornment_characters = "=`:.'\"~^_*+#<>-"
     headings = re.compile(
-        r'(?P<pre>\A|^[ \t]*\n)'  # Start of string or blank line above
-        r'(?:(?P<over>[{0}])(?P=over)*\n[ \t]*)?'  # Over, with heading space
-        r'(?P<heading>\S[^\n]*)\n'  # Heading itself
-        r'(?P<under>(?(over)(?P=over)|[{0}]))(?P=under)*$'  # if over make same
+        # Start of string or blank line
+        r'(?P<pre>\A|^[ \t]*\n)'
+        # Optional over characters, allowing leading space on heading text
+        r'(?:(?P<over>[{0}])(?P=over)*\n[ \t]*)?'
+        # The heading itself, with at least one non-white space character
+        r'(?P<heading>\S[^\n]*)\n'
+        # Under character, setting to same character if over present.
+        r'(?P<under>(?(over)(?P=over)|[{0}]))(?P=under)*$'
         r''.format(adornment_characters),
         flags=re.M)
 

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -77,7 +77,7 @@ def rst2md(text, heading_levels):
         Note that ``over_char`` is `None` when only underline is present.
     """
 
-    # Characters recommend for use with headings
+    # Characters recommended for use with headings
     # https://docutils.readthedocs.io/en/sphinx-docs/user/rst/quickstart.html#sections
     adornment_characters = "=`:.'\"~^_*+#<>-"
     headings = re.compile(

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -65,7 +65,7 @@ def directive_fun(match, directive):
 
 
 def rst2md(text, heading_levels):
-    """Converts the RST text from the examples docstrigs and comments
+    """Converts the RST text from the examples docstrings and comments
     into markdown text for the Jupyter notebooks
 
     Parameters

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -82,7 +82,7 @@ def rst2md(text, heading_levels):
     adornment_characters = "=`:.'\"~^_*+#<>-"
     headings = re.compile(
         r'(?P<pre>\A|^[ \t]*\n)'  # Start of string or blank line above
-        r'(?:(?P<over>[{0}])(?P=over)*\n[ \t]*)?'  # Over, allowing heading space
+        r'(?:(?P<over>[{0}])(?P=over)*\n[ \t]*)?'  # Over, with heading space
         r'(?P<heading>\S[^\n]*)\n'  # Heading itself
         r'(?P<under>(?(over)(?P=over)|[{0}]))(?P=under)*$'  # if over make same
         r''.format(adornment_characters),

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -81,9 +81,9 @@ def rst2md(text, heading_levels):
     # https://docutils.readthedocs.io/en/sphinx-docs/user/rst/quickstart.html#sections
     adornment_characters = "=`:.'\"~^_*+#<>-"
     headings = re.compile(
-        r'(?P<pre>\A|^\n)'  # Start of string or blank line above
-        r'(?:(?P<over>[{0}])(?P=over)*\n ?)?'  # Over, allowing heading space
-        r'(?P<heading>[^\n]+)\n'  # Heading itself
+        r'(?P<pre>\A|^[ \t]*\n)'  # Start of string or blank line above
+        r'(?:(?P<over>[{0}])(?P=over)*\n[ \t]*)?'  # Over, allowing heading space
+        r'(?P<heading>\S[^\n]*)\n'  # Heading itself
         r'(?P<under>(?(over)(?P=over)|[{0}]))(?P=under)*$'  # if over make same
         r''.format(adornment_characters),
         flags=re.M)

--- a/sphinx_gallery/tests/test_notebook.py
+++ b/sphinx_gallery/tests/test_notebook.py
@@ -122,6 +122,20 @@ def test_headings():
     ------------------
     Not valid with no blank line above
 
+    =======================
+           Centered
+    =======================
+
+    ------------------------
+
+    ------------------------
+    Blank heading above.
+
+                
+    ====================
+      White space above
+    ====================
+
     """) # noqa
 
     heading_level_counter = count(start=1)
@@ -139,6 +153,9 @@ def test_headings():
     assert "\n###### A\n" in text
     assert "\n###### BC\n" in text
     assert "# And then a heading\n" not in text
+    assert "\n# Centered\n" in text
+    assert "#\nBlank heading above." not in text
+    assert "# White space above\n" in text
 
 
 def test_jupyter_notebook(gallery_conf):


### PR DESCRIPTION
This enables support for converting headings from RST into Markdown text for Jupyter Notebooks, with heading levels maintained for entire notebook.