### PR TITLE
Add support for image links and data URIs for notebooks

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -39,6 +39,7 @@ file:
 - ``show_memory`` (:ref:`show_memory`)
 - ``binder`` (:ref:`binder_links`)
 - ``first_notebook_cell`` and ``last_notebook_cell`` (:ref:`own_notebook_cell`)
+- ``notebook_images`` (:ref:`notebook_images`)
 - ``pypandoc`` (:ref:`use_pypandoc`)
 - ``junit`` (:ref:`junit_xml`)
 - ``log_level`` (:ref:`log_level`)
@@ -621,6 +622,62 @@ parameter::
 
 If the value of ``first_notebook_cell`` or ``last_notebook_cell`` is set to
 ``None``, then no extra first or last cell will be added to the notebook.
+
+.. _notebook_images:
+
+Adding images to notebooks
+==========================
+
+When notebooks are produced, by default (``notebook_images = False``) image
+paths from the `image` directive in rST documentation blocks (not images
+generated fom code) are included in markdown in their original form. This
+includes paths to images expected to be present on the local filesystem which
+is unlikely to be the case for those downloading the notebook.
+
+By setting ``notebook_images = True``, images will be included in the generated
+notebooks via Base64-encoded `data URIs <https://en.wikipedia.org/wiki/Data_URI_scheme>`_.
+As inclusion of images via data URIs can significantly increase size of the
+notebook, it's suggested this only be used when small images are used throughout
+galleries.
+
+An alternative is to instead provide a prefix string that'll be used for images
+e.g. the root URL of where your documentation is hosted. So for example the
+following configuration::
+
+    sphinx_gallery_conf = {
+        ...
+        'notebook_images': 'https://project.example.com/en/latest/',
+        ...
+    }
+
+with an example `image` directive in an rST being output to gallery dir
+`auto_examples` (relative and absolute paths are supported):
+
+.. code-block:: rst
+
+    .. image:: ../_static/example.jpg
+        :alt: An example image
+
+The image will be added to the generated notebook pointing to the source URL
+``https://project.example.com/en/latest/_static/example.jpg``
+
+Note that the prefix is applied directly, so a trailing ``/`` should be
+included in the prefix if it's required.
+
+.. tip::
+
+    If building multiple versions of your documentation on a hosted service and
+    using prefix, consider using `sphinx build -D <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-D>`_
+    command line option to ensure links point to the correct version. For
+    example:
+
+    .. code-block:: sh
+
+        sphinx-build \
+            -b html \
+            -D sphinx_gallery_conf.notebook_images="https://project.example.com/docs/${VERSION}/" \
+            source_dir build_dir
+
 
 .. _use_pypandoc:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -646,12 +646,14 @@ following configuration::
 
     sphinx_gallery_conf = {
         ...
+        'examples_dirs': ['../examples'],
+        'gallery_dirs': ['auto_examples'],
+        ...
         'notebook_images': 'https://project.example.com/en/latest/',
         ...
     }
 
-with an example `image` directive in an rST being output to gallery dir
-`auto_examples` (relative and absolute paths are supported):
+with an example `image` directive in an rST documentation block being:
 
 .. code-block:: rst
 
@@ -660,6 +662,9 @@ with an example `image` directive in an rST being output to gallery dir
 
 The image will be added to the generated notebook pointing to the source URL
 ``https://project.example.com/en/latest/_static/example.jpg``
+
+For the image path in rST, both relative and absolute (from source directory)
+paths are supported.
 
 Note that the prefix is applied directly, so a trailing ``/`` should be
 included in the prefix if it's required.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -630,11 +630,11 @@ Adding images to notebooks
 
 When notebooks are produced, by default (``notebook_images = False``) image
 paths from the `image` directive in rST documentation blocks (not images
-generated fom code) are included in markdown in their original form. This
+generated fom code) are included in markdown using their original paths. This
 includes paths to images expected to be present on the local filesystem which
 is unlikely to be the case for those downloading the notebook.
 
-By setting ``notebook_images = True``, images will be included in the generated
+By setting ``notebook_images = True``, images will be embedded in the generated
 notebooks via Base64-encoded `data URIs <https://en.wikipedia.org/wiki/Data_URI_scheme>`_.
 As inclusion of images via data URIs can significantly increase size of the
 notebook, it's suggested this only be used when small images are used throughout
@@ -661,10 +661,12 @@ with an example `image` directive in an rST documentation block being:
         :alt: An example image
 
 The image will be added to the generated notebook pointing to the source URL
-``https://project.example.com/en/latest/_static/example.jpg``
-
-For the image path in rST, both relative and absolute (from source directory)
-paths are supported.
+``https://project.example.com/en/latest/_static/example.jpg``. Note the image
+path in the rST examples above is a relative path, therefore the URL doesn't
+contain ``auto_examples`` as ``../`` moved up a directory to the documentation
+source directory. Both relative and absolute (from source directory) paths are
+supported; so in the example above ``/_static/example.jpg`` would have resulted
+in the same URL being produced.
 
 Note that the prefix is applied directly, so a trailing ``/`` should be
 included in the prefix if it's required.

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -69,6 +69,7 @@ DEFAULT_GALLERY_CONF = {
     'reset_modules': ('matplotlib', 'seaborn'),
     'first_notebook_cell': '%matplotlib inline',
     'last_notebook_cell': None,
+    'notebook_images': False,
     'pypandoc': False,
     'remove_config_comments': False,
     'show_memory': False,

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -806,7 +806,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
 
     save_thumbnail(image_path_template, src_file, file_conf, gallery_conf)
 
-    example_nb = jupyter_notebook(script_blocks, gallery_conf)
+    example_nb = jupyter_notebook(script_blocks, gallery_conf, target_dir)
     ipy_fname = replace_py_ipynb(target_file) + '.new'
     save_notebook(example_nb, ipy_fname)
     _replace_md5(ipy_fname, mode='t')

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -155,8 +155,9 @@ def generate_image_src(image_path, gallery_conf, target_dir):
     if not gallery_conf['notebook_images']:
         return "file://" + image_path.lstrip('/')
 
+    # If absolute path from source directory given
     if image_path.startswith('/'):
-        # Absolute path from source directory
+        # Path should now be relative to source dir, not target dir
         target_dir = gallery_conf['src_dir']
         image_path = image_path.lstrip('/')
     full_path = os.path.join(target_dir, image_path.replace('/', os.sep))

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -69,7 +69,7 @@ def directive_fun(match, directive):
 
 
 def rst2md(text, gallery_conf, target_dir, heading_levels):
-    """Converts the RST text from the examples docstrigs and comments
+    """Converts the RST text from the examples docstrings and comments
     into markdown text for the Jupyter notebooks
 
     Parameters

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -21,7 +21,8 @@ import os
 import re
 import sys
 import copy
-import warnings
+
+from sphinx.errors import ExtensionError
 
 from . import sphinx_compatibility
 from .py_source_parser import split_code_and_text_blocks
@@ -173,10 +174,9 @@ def generate_image_src(image_path, gallery_conf, target_dir):
             with open(full_path, 'rb') as image_file:
                 data = base64.b64encode(image_file.read())
         except OSError:
-            warnings.warn(
+            raise ExtensionError(
                 'Unable to open {} to generate notebook data URI'
                 ''.format(full_path))
-            return "file://" + image_path.lstrip('/')
         mime_type = mimetypes.guess_type(full_path)
         return 'data:{};base64,{}'.format(mime_type[0], data.decode('ascii'))
 

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -14,10 +14,14 @@ from collections import defaultdict
 from functools import partial
 from itertools import count
 import argparse
+import base64
 import json
+import mimetypes
+import os
 import re
 import sys
 import copy
+import warnings
 
 from . import sphinx_compatibility
 from .py_source_parser import split_code_and_text_blocks
@@ -64,14 +68,19 @@ def directive_fun(match, directive):
                     match.group(1).strip()))
 
 
-def rst2md(text, heading_levels):
-    """Converts the RST text from the examples docstrings and comments
+def rst2md(text, gallery_conf, target_dir, heading_levels):
+    """Converts the RST text from the examples docstrigs and comments
     into markdown text for the Jupyter notebooks
 
     Parameters
     ----------
     text: str
         RST input to be converted to MD
+    gallery_conf : dict
+        The sphinx-gallery configuration dictionary.
+    target_dir : str
+        Path that notebook is intended for. Used where relative paths
+        may be required.
     heading_levels: dict
         Mapping of heading style ``(over_char, under_char)`` to heading level.
         Note that ``over_char`` is `None` when only underline is present.
@@ -125,16 +134,53 @@ def rst2md(text, heading_levels):
     text = re.sub(contents, '', text)
 
     images = re.compile(
-        r'^\.\. image::(.*$)(?:\n *:alt:(.*$)\n)?(?: +:\S+:.*$\n)*',
+        r'^\.\. image::(.*$)((?:\n +:\S+:.*$)*)\n',
         flags=re.M)
+    image_opts = re.compile(r'\n +:(\S+): +(.*)$', flags=re.M)
     text = re.sub(
-        images, lambda match: '![{1}]({0})\n'.format(
-            match.group(1).strip(), (match.group(2) or '').strip()), text)
+        images,
+        lambda match: '<img src="{}"{}>\n'.format(
+            generate_image_src(
+                match.group(1).strip(), gallery_conf, target_dir),
+            re.sub(image_opts, r' \1="\2"', match.group(2) or '')),
+        text)
 
     return text
 
 
-def jupyter_notebook(script_blocks, gallery_conf):
+def generate_image_src(image_path, gallery_conf, target_dir):
+    if re.match(r'https?://', image_path):
+        return image_path
+
+    if not gallery_conf['notebook_images']:
+        return "file://" + image_path.lstrip('/')
+
+    if image_path.startswith('/'):
+        # Absolute path from source directory
+        target_dir = gallery_conf['src_dir']
+        image_path = image_path.lstrip('/')
+    full_path = os.path.join(target_dir, image_path.replace('/', os.sep))
+
+    if isinstance(gallery_conf['notebook_images'], str):
+        # Use as prefix e.g. URL
+        prefix = gallery_conf['notebook_images']
+        rel_path = os.path.relpath(full_path, gallery_conf['src_dir'])
+        return prefix + rel_path.replace(os.sep, '/')
+    else:
+        # True, but not string. Embed as data URI.
+        try:
+            with open(full_path, 'rb') as image_file:
+                data = base64.b64encode(image_file.read())
+        except OSError:
+            warnings.warn(
+                'Unable to open {} to generate notebook data URI'
+                ''.format(full_path))
+            return "file://" + image_path.lstrip('/')
+        mime_type = mimetypes.guess_type(full_path)
+        return 'data:{};base64,{}'.format(mime_type[0], data.decode('ascii'))
+
+
+def jupyter_notebook(script_blocks, gallery_conf, target_dir):
     """Generate a Jupyter notebook file cell-by-cell
 
     Parameters
@@ -143,13 +189,16 @@ def jupyter_notebook(script_blocks, gallery_conf):
         Script execution cells.
     gallery_conf : dict
         The sphinx-gallery configuration dictionary.
+    target_dir : str
+        Path that notebook is intended for. Used where relative paths
+        may be required.
     """
     first_cell = gallery_conf["first_notebook_cell"]
     last_cell = gallery_conf["last_notebook_cell"]
     work_notebook = jupyter_notebook_skeleton()
     if first_cell is not None:
         add_code_cell(work_notebook, first_cell)
-    fill_notebook(work_notebook, script_blocks, gallery_conf)
+    fill_notebook(work_notebook, script_blocks, gallery_conf, target_dir)
     if last_cell is not None:
         add_code_cell(work_notebook, last_cell)
 
@@ -191,7 +240,7 @@ def add_markdown_cell(work_notebook, markdown):
     work_notebook["cells"].append(markdown_cell)
 
 
-def fill_notebook(work_notebook, script_blocks, gallery_conf):
+def fill_notebook(work_notebook, script_blocks, gallery_conf, target_dir):
     """Writes the Jupyter notebook cells
 
     If available, uses pypandoc to convert rst to markdown.
@@ -208,7 +257,8 @@ def fill_notebook(work_notebook, script_blocks, gallery_conf):
             add_code_cell(work_notebook, bcontent)
         else:
             if gallery_conf["pypandoc"] is False:
-                markdown = rst2md(bcontent + '\n', heading_levels)
+                markdown = rst2md(
+                    bcontent + '\n', gallery_conf, target_dir, heading_levels)
             else:
                 import pypandoc
                 # pandoc automatically addds \n to the end
@@ -245,5 +295,6 @@ def python_to_jupyter_cli(args=None, namespace=None):
         file_conf, blocks = split_code_and_text_blocks(src_file)
         print('Converting {0}'.format(src_file))
         gallery_conf = copy.deepcopy(gen_gallery.DEFAULT_GALLERY_CONF)
-        example_nb = jupyter_notebook(blocks, gallery_conf)
+        target_dir = os.path.dirname(src_file)
+        example_nb = jupyter_notebook(blocks, gallery_conf, target_dir)
         save_notebook(example_nb, replace_py_ipynb(src_file))

--- a/sphinx_gallery/tests/test_notebook.py
+++ b/sphinx_gallery/tests/test_notebook.py
@@ -169,7 +169,7 @@ def test_headings():
      ('/_static/image.png', 'https://example.com/_static/image.png', True),
      ('https://example.com/image.png', 'https://example.com/image.png', False),
      ('https://example.com/image.png', 'https://example.com/image.png', True)),
-    ids=('rel_no_prefix', 'abs_no_prefix', 'abs_prefix', 'rel_prefix',
+    ids=('rel_no_prefix', 'abs_no_prefix', 'rel_prefix', 'abs_prefix',
          'url_no_prefix', 'url_prefix'))
 def test_notebook_images_prefix(gallery_conf,
                                 rst_path, md_path, prefix_enabled):

--- a/sphinx_gallery/tests/test_notebook.py
+++ b/sphinx_gallery/tests/test_notebook.py
@@ -16,6 +16,8 @@ import re
 import base64
 import textwrap
 
+from sphinx.errors import ExtensionError
+
 import sphinx_gallery.gen_rst as sg
 from sphinx_gallery.notebook import (rst2md, jupyter_notebook, save_notebook,
                                      python_to_jupyter_cli)
@@ -222,7 +224,7 @@ def test_notebook_images_data_uri(gallery_conf):
     .. image:: /this/image/is/missing.png
        :width: 500px
     """)
-    with pytest.warns(UserWarning):
+    with pytest.raises(ExtensionError):
         rst2md(rst, gallery_conf, target_dir, {})
 
 


### PR DESCRIPTION
Currently, when notebooks are generated, the links to images found in rST remain unmodified, meaning images expected to be either local or found on web server hosting documentation are broken.

This change allows inclusion of images via data URIs, or prefixing the image links in the notebooks, for example to server hosting documentation.

This also changes the markdown output to use HTML `img` tag, and such also supports the width and height options.