### PR TITLE
ENH: Dont allow input

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
 
   global:
     PYTHON: "C:\\conda"
-    CONDA_DEPENDENCIES: numpy seaborn "matplotlib<3.2.2|>3.2.2" sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib plotly
+    CONDA_DEPENDENCIES: numpy seaborn "matplotlib>3.2.2" sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib plotly
     PIP_DEPENDENCIES: ipython"
 
   matrix:
@@ -22,7 +22,6 @@ install:
     - "git clone git://github.com/astropy/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "conda activate test"
-    - "conda install -c conda-forge ffmpeg"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,13 +6,13 @@ environment:
 
   global:
     PYTHON: "C:\\conda"
-    CONDA_DEPENDENCIES: numpy seaborn "matplotlib>3.2.2" sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib plotly
+    CONDA_DEPENDENCIES: numpy seaborn "matplotlib<3.2.1|>3.2.2" sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib plotly
     PIP_DEPENDENCIES: ipython"
 
   matrix:
     - PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
-    - PYTHON_VERSION: "3.7"
+    - PYTHON_VERSION: "3.8"
       PYTHON_ARCH: "64"
 
 platform:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ install:
     - "git clone git://github.com/astropy/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "conda activate test"
+    - "conda install -c conda-forge ffmpeg"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -553,8 +553,8 @@ def execute_code_block(compiler, block, example_globals,
         else:
             ast_Module = ast.Module
         code_ast = ast_Module([bcontent])
-        code_ast = compile(bcontent, src_file, 'exec',
-                           ast.PyCF_ONLY_AST | compiler.flags, dont_inherit)
+        flags = ast.PyCF_ONLY_AST | compiler.flags
+        code_ast = compile(bcontent, src_file, 'exec', flags, dont_inherit)
         ast.increment_lineno(code_ast, lineno - 1)
         # capture output if last line is expression
         is_last_expr = False

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -323,6 +323,8 @@ def test_md5sums(mode, expected_md5):
      'not defined'),
     (CONTENT + ['#' * 79, 'input("foo")', '#' * 79, 'second_fail'],
      'Cannot use input'),
+    (CONTENT + ['#' * 79, 'bad syntax', '#' * 79, 'second_fail'],
+     'invalid syntax'),
 ])
 def test_fail_example(gallery_conf, failing_code, want,
                       log_collector, req_pil):


### PR DESCRIPTION
Prevent users from having their builds hang because of `input()` calls. Instead of getting a hang, they now get:
```
Extension error:
Here is a summary of the problems encountered when running the examples

Unexpected failing examples:
/home/larsoner/python/sphinx-gallery/sphinx_gallery/tests/tinybuild/examples/plot_animation.py failed leaving traceback:
Traceback (most recent call last):
  File "/home/larsoner/python/sphinx-gallery/sphinx_gallery/tests/tinybuild/examples/plot_animation.py", line 15, in <module>
    input()
sphinx.errors.ExtensionError: Cannot use input() builtin function in Sphinx-gallery examples
```
Note that I added a bit of code to `_handle_exception` to trim these unhelpful lines from the traceback we print:
```
  File "/home/larsoner/python/sphinx-gallery/sphinx_gallery/gen_gallery.py", line 164, in call_memory
    mem, out = memory_usage(func, max_usage=True, retval=True,
  File "/home/larsoner/.local/lib/python3.8/site-packages/memory_profiler.py", line 343, in memory_usage
    returned = f(*args, **kw)
  File "/home/larsoner/python/sphinx-gallery/sphinx_gallery/gen_rst.py", line 464, in __call__
    exec(self.code, self.fake_main.__dict__)
sphinx.errors.ExtensionError: Cannot use input() builtin function in Sphinx-gallery examples
```
Users don't need to care about our internal call stack.