### PR TITLE
Implement option to pass command line args to example scripts

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -190,9 +190,12 @@ As the patterns are parsed as `regular expressions`_, users are advised to consu
 Passing command line arguments to example scripts
 =================================================
 
-By default, Sphinx-Gallery will not pass any command line arguments to example scripts.
-By setting the ``reset_argv`` option, it is possible to change this behavior and pass command line arguments to example scripts.
-``reset_argv`` needs to be a Callable that accepts the ``gallery_conf`` and ``script_vars`` dictionaries and returns a list of strings that are passed as additional command line arguments to the interpreter.
+By default, Sphinx-Gallery will not pass any command line arguments to example
+scripts.  By setting the ``reset_argv`` option, it is possible to change this
+behavior and pass command line arguments to example scripts.  ``reset_argv``
+needs to be a Callable that accepts the ``gallery_conf`` and ``script_vars``
+dictionaries as input and returns a list of strings that are passed as
+additional command line arguments to the interpreter.
 
 An example could be::
 
@@ -201,6 +204,13 @@ An example could be::
 	    return ['-a', '1']
 	elif script_vars['src_file'] == 'example2.py':
 	    return ['-a', '2']
+
+which is included in the configuration dictionary as::
+
+    sphinx_gallery_conf = {
+        ...
+        'reset_argv': reset_argv,
+    }
 
 which is then used by Sphinx-Gallery as::
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -203,7 +203,7 @@ An example could be::
         def __repr__(self):
 	    return 'ResetArgv'
 
-	def __call__(self):
+	def __call__(self, sphinx_gallery_conf, script_vars):
             if script_vars['src_file'] == 'example1.py':
 	        return ['-a', '1']
             elif script_vars['src_file'] == 'example2.py':

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -199,17 +199,21 @@ additional command line arguments to the interpreter.
 
 An example could be::
 
-    def reset_argv(gallery_confg, script_vars):
-        if script_vars['src_file'] == 'example1.py':
-	    return ['-a', '1']
-	elif script_vars['src_file'] == 'example2.py':
-	    return ['-a', '2']
+    class ResetArgv:
+        def __repr__(self):
+	    return 'ResetArgv'
+
+	def __call__(self):
+            if script_vars['src_file'] == 'example1.py':
+	        return ['-a', '1']
+            elif script_vars['src_file'] == 'example2.py':
+	        return ['-a', '2']
 
 which is included in the configuration dictionary as::
 
     sphinx_gallery_conf = {
         ...
-        'reset_argv': reset_argv,
+        'reset_argv': ResetArgv(),
     }
 
 which is then used by Sphinx-Gallery as::

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -19,6 +19,7 @@ file:
 
 - ``examples_dirs`` and ``gallery_dirs`` (:ref:`multiple_galleries_config`)
 - ``filename_pattern`` and ``ignore_pattern`` (:ref:`build_pattern`)
+- ``reset_argv`` (:ref:`reset_argv`)
 - ``subsection_order`` (:ref:`sub_gallery_order`)
 - ``within_subsection_order`` (:ref:`within_gallery_order`)
 - ``reference_url`` (:ref:`link_to_documentation`)
@@ -184,6 +185,31 @@ As the patterns are parsed as `regular expressions`_, users are advised to consu
 
         $ sphinx-build -D sphinx_gallery_conf.filename_pattern=plot_specific_example\.py ...
 
+.. _reset_argv:
+
+Passing command line arguments to example scripts
+=================================================
+
+By default, Sphinx-Gallery will not pass any command line arguments to example scripts.
+By setting the ``reset_argv`` option, it is possible to change this behavior and pass command line arguments to example scripts.
+``reset_argv`` needs to be a Callable that accepts the ``gallery_conf`` and ``script_vars`` dictionaries and returns a list of strings that are passed as additional command line arguments to the interpreter.
+
+An example could be::
+
+    def reset_argv(gallery_confg, script_vars):
+        if script_vars['src_file'] == 'example1.py':
+	    return ['-a', '1']
+	elif script_vars['src_file'] == 'example2.py':
+	    return ['-a', '2']
+
+which is then used by Sphinx-Gallery as::
+
+    import sys
+    sys.argv[0] = script_vars['src_file']
+    sys.argv[1:] = gallery_conf['reset_argv'](gallery_conf, script_vars)
+
+
+    
 .. _sub_gallery_order:
 
 Sorting gallery subsections

--- a/examples/plot_7_sys_argv.py
+++ b/examples/plot_7_sys_argv.py
@@ -4,9 +4,12 @@ Using ``sys.argv`` in examples
 
 This example demonstrates the use of ``sys.argv`` in example ``.py`` files.
 
-All example ``.py`` files will be run by Sphinx-Gallery **without** any
+By default, all example ``.py`` files will be run by Sphinx-Gallery **without** any
 arguments. Notice below that ``sys.argv`` is a list consisting of only the
 file name. Further, any arguments added will take on the default value.
+
+This behavior can be changed by using the `reset_argv` option in the sphinx configuration, see :ref:`reset_argv`.
+
 """
 
 import argparse

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -37,11 +37,20 @@ from .directives import MiniGallery
 
 _KNOWN_CSS = ('gallery', 'gallery-binder', 'gallery-dataframe')
 
+
+class DefaultResetArgv:
+    def __repr__(self):
+        return "DefaultResetArgv"
+
+    def __call__(self, gallery_conf, script_vars):
+        return []
+
+
 DEFAULT_GALLERY_CONF = {
     'filename_pattern': re.escape(os.sep) + 'plot',
     'ignore_pattern': r'__init__\.py',
     'examples_dirs': os.path.join('..', 'examples'),
-    'reset_argv': lambda gallery_conf, script_vars: [],
+    'reset_argv': DefaultResetArgv(),
     'subsection_order': None,
     'within_subsection_order': NumberOfCodeLinesSortKey,
     'gallery_dirs': 'auto_examples',

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -41,6 +41,7 @@ DEFAULT_GALLERY_CONF = {
     'filename_pattern': re.escape(os.sep) + 'plot',
     'ignore_pattern': r'__init__\.py',
     'examples_dirs': os.path.join('..', 'examples'),
+    'reset_argv': lambda gallery_conf, script_vars: [],
     'subsection_order': None,
     'within_subsection_order': NumberOfCodeLinesSortKey,
     'gallery_dirs': 'auto_examples',

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -734,7 +734,7 @@ def execute_script(script_blocks, script_vars, gallery_conf):
         # https://github.com/sphinx-gallery/sphinx-gallery/pull/252
         # for more details.
         sys.argv[0] = script_vars['src_file']
-        sys.argv[1:] = []
+        sys.argv[1:] = gallery_conf['reset_argv'](gallery_conf, script_vars)
         gc.collect()
         memory_start, _ = gallery_conf['call_memory'](lambda: None)
     else:

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -26,7 +26,7 @@ from sphinx_gallery.utils import (_get_image, scale_image, _has_optipng,
 
 import pytest
 
-N_TOT = 9
+N_TOT = 10
 N_FAILING = 1
 N_GOOD = N_TOT - N_FAILING
 N_RST = 15 + N_TOT
@@ -177,6 +177,13 @@ def test_thumbnail_path(sphinx_app, tmpdir):
     corr = np.corrcoef(new[..., :3].ravel(), orig[..., :3].ravel())[0, 1]
     assert corr > 0.99
 
+
+def test_command_line_args_img(sphinx_app):
+    generated_examples_dir = op.join(sphinx_app.outdir, 'auto_examples')
+    thumb_fname = '../_images/sphx_glr_plot_command_line_args_thumb.png'
+    file_fname = op.join(generated_examples_dir, thumb_fname)
+    assert op.isfile(file_fname), file_fname
+    
 
 def test_image_formats(sphinx_app):
     """Test Image format support."""

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -183,7 +183,7 @@ def test_command_line_args_img(sphinx_app):
     thumb_fname = '../_images/sphx_glr_plot_command_line_args_thumb.png'
     file_fname = op.join(generated_examples_dir, thumb_fname)
     assert op.isfile(file_fname), file_fname
-    
+
 
 def test_image_formats(sphinx_app):
     """Test Image format support."""

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -16,11 +16,15 @@ class matplotlib_format_scraper(object):
         return matplotlib_scraper(block, block_vars, gallery_conf, **kwargs)
 
 
-def reset_argv(sphinx_gallery_conf, script_vars):
-    if 'plot_command_line_args.py' in script_vars['src_file']:
-        return ['plot']
-    else:
-        return []
+class ResetArgv:
+    def __repr__(self):
+        return "ResetArgv"
+
+    def __call__(self, sphinx_gallery_conf, script_vars):
+        if 'plot_command_line_args.py' in script_vars['src_file']:
+            return ['plot']
+        else:
+            return []
 
 
 extensions = [
@@ -48,7 +52,7 @@ sphinx_gallery_conf = {
         'scipy': 'http://docs.scipy.org/doc/scipy/wrong_url',  # bad one
     },
     'examples_dirs': ['examples/'],
-    'reset_argv': reset_argv,
+    'reset_argv': ResetArgv(),
     'gallery_dirs': ['auto_examples'],
     'backreferences_dir': 'gen_modules/backreferences',
     'within_section_order': FileNameSortKey,

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -16,6 +16,13 @@ class matplotlib_format_scraper(object):
         return matplotlib_scraper(block, block_vars, gallery_conf, **kwargs)
 
 
+def reset_argv(sphinx_gallery_conf, script_vars):
+    if 'plot_command_line_args.py' in script_vars['src_file']:
+        return ['plot']
+    else:
+        return []
+
+
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
@@ -41,6 +48,7 @@ sphinx_gallery_conf = {
         'scipy': 'http://docs.scipy.org/doc/scipy/wrong_url',  # bad one
     },
     'examples_dirs': ['examples/'],
+    'reset_argv': reset_argv,
     'gallery_dirs': ['auto_examples'],
     'backreferences_dir': 'gen_modules/backreferences',
     'within_section_order': FileNameSortKey,

--- a/sphinx_gallery/tests/tinybuild/examples/plot_command_line_args.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_command_line_args.py
@@ -1,0 +1,19 @@
+"""
+Command line arguments support
+==============================
+
+Use command line arguments to control example script.
+"""
+
+import sys
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+if len(sys.argv) > 1 and sys.argv[1] == 'plot':
+    fig_0, ax_0 = plt.subplots(figsize=(5, 1))
+    
+
+    x = np.arange(0, 10., 1)
+    ax_0.plot(x, x**2)
+    plt.show()

--- a/sphinx_gallery/tests/tinybuild/examples/plot_command_line_args.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_command_line_args.py
@@ -12,7 +12,6 @@ import matplotlib.pyplot as plt
 
 if len(sys.argv) > 1 and sys.argv[1] == 'plot':
     fig_0, ax_0 = plt.subplots(figsize=(5, 1))
-    
 
     x = np.arange(0, 10., 1)
     ax_0.plot(x, x**2)


### PR DESCRIPTION
This PR implements an option to pass command line args to example scripts. It closely follows the suggestion by @larsoner made in #731 :

- I added a `reset_argv` option to the configuration which needs to be a callable that accepts `gallery_conf` and `script_vars` as input arguments and return a list of strings which will be the additional `sys.argv` (in addition to the src_file itself).
- As a default value, I set `reset_argv` to be a callable that just returns an empty list, which is equivalent to the current behavior.
- I also added documentation of this option.

The PR is missing a test for this function. I was not sure how to add a test for this and would need some advice since I'm not familiar with the test suite. 