### PR TITLE
Enable ffmpeg for animations for newer matplotlib

### DIFF
--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -14,7 +14,7 @@ live in modules that will support them (e.g., PyVista, Plotly).
 import os
 import sys
 import re
-from distutils import LooseVersion
+from distutils.version import LooseVersion
 from textwrap import indent
 from warnings import filterwarnings
 
@@ -178,8 +178,8 @@ def _anim_rst(anim, image_path, gallery_conf):
     use_dpi = round(
         min(t_s / f_s for t_s, f_s in zip(thumb_size, fig_size)))
     # FFmpeg is buggy for GIFs before Matplotlib 3.3.1
-    if LooseVersion(matplotlib.__version__) >= LooseVersion('3.3.1') \
-            and FFMpegWriter.isAvailable():
+    if LooseVersion(matplotlib.__version__) >= LooseVersion('3.3.1') and \
+            FFMpegWriter.isAvailable():
         writer = 'ffmpeg'
     elif ImageMagickWriter.isAvailable():
         writer = 'imagemagick'

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -14,6 +14,7 @@ live in modules that will support them (e.g., PyVista, Plotly).
 import os
 import sys
 import re
+from distutils import LooseVersion
 from textwrap import indent
 from warnings import filterwarnings
 
@@ -166,7 +167,8 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
 
 
 def _anim_rst(anim, image_path, gallery_conf):
-    from matplotlib.animation import ImageMagickWriter
+    import matplotlib
+    from matplotlib.animation import FFMpegWriter, ImageMagickWriter
     # output the thumbnail as the image, as it will just be copied
     # if it's the file thumbnail
     fig = anim._fig
@@ -175,8 +177,11 @@ def _anim_rst(anim, image_path, gallery_conf):
     thumb_size = gallery_conf['thumbnail_size']
     use_dpi = round(
         min(t_s / f_s for t_s, f_s in zip(thumb_size, fig_size)))
-    # FFmpeg is buggy for GIFs
-    if ImageMagickWriter.isAvailable():
+    # FFmpeg is buggy for GIFs before Matplotlib 3.3.1
+    if LooseVersion(matplotlib.__version__) >= LooseVersion('3.3.1')
+            and FFMpegWriter.isAvailable():
+        writer = 'ffmpeg'
+    elif ImageMagickWriter.isAvailable():
         writer = 'imagemagick'
     else:
         writer = None

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -178,7 +178,7 @@ def _anim_rst(anim, image_path, gallery_conf):
     use_dpi = round(
         min(t_s / f_s for t_s, f_s in zip(thumb_size, fig_size)))
     # FFmpeg is buggy for GIFs before Matplotlib 3.3.1
-    if LooseVersion(matplotlib.__version__) >= LooseVersion('3.3.1')
+    if LooseVersion(matplotlib.__version__) >= LooseVersion('3.3.1') \
             and FFMpegWriter.isAvailable():
         writer = 'ffmpeg'
     elif ImageMagickWriter.isAvailable():


### PR DESCRIPTION
Since ffmpeg GIF writing was fixed in matplotlib/matplotlib#18093, which will be included in matplotlib 3.3.1, enable using that for capturing animations (when running a recent enough version).