### PR TITLE
BUG: Fix handling of scraper error

### DIFF
--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -11,6 +11,7 @@ The only scrapers we support are Matplotlib and Mayavi, others should
 live in modules that will support them (e.g., PyVista, Plotly).
 """
 
+from logging.handlers import QueueHandler
 import os
 import sys
 import re
@@ -147,7 +148,10 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
             if to_rgba(fig_attr) != to_rgba(default_attr) and \
                     attr not in kwargs:
                 these_kwargs[attr] = fig_attr
-        fig.savefig(image_path, **these_kwargs)
+        try:
+            fig.savefig(image_path, **these_kwargs)
+        finally:
+            plt.close(fig=fig)  # always close, even if error
         if 'images' in gallery_conf['compress_images']:
             optipng(image_path, gallery_conf['compress_images_args'])
         image_rsts.append(

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -150,8 +150,9 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
                 these_kwargs[attr] = fig_attr
         try:
             fig.savefig(image_path, **these_kwargs)
-        finally:
-            plt.close(fig=fig)  # always close, even if error
+        except Exception:
+            plt.close('all')
+            raise
         if 'images' in gallery_conf['compress_images']:
             optipng(image_path, gallery_conf['compress_images_args'])
         image_rsts.append(
@@ -222,8 +223,9 @@ def mayavi_scraper(block, block_vars, gallery_conf):
     for scene, image_path in zip(e.scenes, image_path_iterator):
         try:
             mlab.savefig(image_path, figure=scene)
-        finally:
-            mlab.close(scene=scene)
+        except Exception:
+            mlab.close(all=True)
+            raise
         # make sure the image is not too large
         scale_image(image_path, image_path, 850, 999)
         if 'images' in gallery_conf['compress_images']:

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -11,7 +11,6 @@ The only scrapers we support are Matplotlib and Mayavi, others should
 live in modules that will support them (e.g., PyVista, Plotly).
 """
 
-from logging.handlers import QueueHandler
 import os
 import sys
 import re

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -220,7 +220,10 @@ def mayavi_scraper(block, block_vars, gallery_conf):
     image_paths = list()
     e = mlab.get_engine()
     for scene, image_path in zip(e.scenes, image_path_iterator):
-        mlab.savefig(image_path, figure=scene)
+        try:
+            mlab.savefig(image_path, figure=scene)
+        finally:
+            mlab.close(scene=scene)
         # make sure the image is not too large
         scale_image(image_path, image_path, 850, 999)
         if 'images' in gallery_conf['compress_images']:

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -595,6 +595,21 @@ def test_rebuild(tmpdir_factory, sphinx_app):
                        different=('plot_numpy_matplotlib.ipynb'))
 
 
+@pytest.mark.parametrize('name, want', [
+    ('future/plot_future_imports_broken',
+     '.*RuntimeError.*Forcing this example to fail on Python 3.*'),
+    ('plot_scraper_broken',
+     '.*ValueError.*zero-size array to reduction.*'),
+])
+def test_error_messages(sphinx_app, name, want):
+    """Test that informative error messages are added."""
+    src_dir = sphinx_app.srcdir
+    example_rst = op.join(src_dir, 'auto_examples', name + '.rst')
+    with codecs.open(example_rst, 'r', 'utf-8') as fid:
+        rst = fid.read().replace('\n', ' ')
+    assert re.match(want, rst) is not None
+
+
 def test_alt_text_image(sphinx_app):
     """Test alt text for matplotlib images in html and rst"""
     out_dir = sphinx_app.outdir

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -523,7 +523,7 @@ def test_rebuild(tmpdir_factory, sphinx_app):
                          buildername='html', status=StringIO())
         new_app.build(False, [])
     status = new_app._status.getvalue()
-    n = '[' + '|'.join(str(x + N_FAILING) for x in range(3)) + ']'
+    n = '[' + '|'.join(str(x + N_FAILING) for x in range(4)) + ']'
     lines = [line for line in status.split('\n') if 'source files tha' in line]
     want = '.*targets for %s source files that are out of date$.*' % n
     assert re.match(want, status, re.MULTILINE | re.DOTALL) is not None, lines

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -523,7 +523,7 @@ def test_rebuild(tmpdir_factory, sphinx_app):
                          buildername='html', status=StringIO())
         new_app.build(False, [])
     status = new_app._status.getvalue()
-    n = '[' + '|'.join(str(x + N_FAILING + 1) for x in range(3)) + ']'
+    n = '[' + '|'.join(str(x + N_FAILING) for x in range(3)) + ']'
     lines = [line for line in status.split('\n') if 'source files tha' in line]
     want = '.*targets for %s source files that are out of date$.*' % n
     assert re.match(want, status, re.MULTILINE | re.DOTALL) is not None, lines

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -523,7 +523,7 @@ def test_rebuild(tmpdir_factory, sphinx_app):
                          buildername='html', status=StringIO())
         new_app.build(False, [])
     status = new_app._status.getvalue()
-    n = '[3|4|5]'
+    n = '[' + '|'.join(str(x + N_FAILING + 1) for x in range(3)) + ']'
     lines = [line for line in status.split('\n') if 'source files tha' in line]
     want = '.*targets for %s source files that are out of date$.*' % n
     assert re.match(want, status, re.MULTILINE | re.DOTALL) is not None, lines

--- a/sphinx_gallery/tests/tinybuild/Makefile
+++ b/sphinx_gallery/tests/tinybuild/Makefile
@@ -1,3 +1,5 @@
+SPHINXOPTS=
+
 all: clean html show
 
 clean:
@@ -6,7 +8,7 @@ clean:
 	rm -rf gen_modules/
 
 html:
-	sphinx-build -b html -d _build/doctrees . _build/html
+	sphinx-build -b html -d _build/doctrees $(SPHINXOPTS) . _build/html
 
 latexpdf:
 	sphinx-build -b latex -d _build/doctrees . _build/latex

--- a/sphinx_gallery/tests/tinybuild/examples/plot_scraper_broken.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_scraper_broken.py
@@ -1,0 +1,10 @@
+"""
+Error during scraping
+=====================
+
+The error is actually introduced by the resetter in ``conf.py``. It mocks
+a "zero-size reduction" error in ``fig.savefig``.
+"""
+
+import matplotlib.pyplot as plt
+fig = plt.figure()


### PR DESCRIPTION
If a scraper hits an error, the traceback is pretty worthless, [for example](https://app.circleci.com/pipelines/github/mne-tools/mne-nirs/441/workflows/dc50c665-0471-4305-9043-d0f7f2e0d7e0/jobs/444):
```
generating gallery for auto_examples... [ 60%] plot_10_hrf.py

Extension error:
Handler <function generate_gallery_rst at 0x7fe6548b0e50> for event 'builder-inited' threw an exception (exception: zero-size array to reduction operation minimum which has no identity)
make: *** [Makefile:60: html] Error 2
```
With this PR it's handled like any other script error (from our new test):
```
...
loading intersphinx inventory from https://joblib.readthedocs.io/en/latest/objects.inv...
generating gallery...
/Users/larsoner/python/sphinx-gallery/sphinx_gallery/tests/tinybuild/examples/plot_scraper_broken.py failed to execute correctly: Traceback (most recent call last):
  File "/Users/larsoner/python/sphinx-gallery/sphinx_gallery/scrapers.py", line 327, in save_figures
    rst = scraper(block, block_vars, gallery_conf)
  File "/Users/larsoner/python/sphinx-gallery/sphinx_gallery/tests/tinybuild/conf.py", line 17, in __call__
    return matplotlib_scraper(block, block_vars, gallery_conf, **kwargs)
  File "/Users/larsoner/python/sphinx-gallery/sphinx_gallery/scrapers.py", line 150, in matplotlib_scraper
    fig.savefig(image_path, **these_kwargs)
  File "/Users/larsoner/python/sphinx-gallery/sphinx_gallery/tests/tinybuild/conf.py", line 43, in <lambda>
    Figure.savefig = lambda *args, **kwargs: np.min([])
  File "<__array_function__ internals>", line 5, in amin
  File "/Users/larsoner/opt/miniconda3/lib/python3.8/site-packages/numpy/core/fromnumeric.py", line 2792, in amin
    return _wrapreduction(a, np.minimum, 'min', axis, None, out,
  File "/Users/larsoner/opt/miniconda3/lib/python3.8/site-packages/numpy/core/fromnumeric.py", line 90, in _wrapreduction
    return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
ValueError: zero-size array to reduction operation minimum which has no identity

generating gallery for auto_examples... [100%] plot_numpy_matplotlib.py    
...
```