### PR TITLE
Fix logger message pypandoc

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -293,9 +293,12 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
         logger.warning("'pypandoc' not available. Using Sphinx-Gallery to "
                        "convert rst text blocks to markdown for .ipynb files.")
         gallery_conf['pypandoc'] = False
-    else:
+    elif isinstance(gallery_conf['pypandoc'], dict):
         logger.info("Using pandoc version: %s to convert rst text blocks to "
                     "markdown for .ipynb files" % (version,))
+    else:
+        logger.info("Using Sphinx-Gallery to convert rst text blocks to "
+                    "markdown for .ipynb files.")
     if isinstance(pypandoc, dict):
         accepted_keys = ('extra_args', 'filters')
         for key in pypandoc:


### PR DESCRIPTION
I realised even when `'pypandoc': False` logger outputs:
```
 Using pandoc version: None to convert rst text blocks to markdown for .ipynb files
```

Added a message for when `'pypandoc': False` but happy to change to `else: pass` have no message 