### PR TITLE
DOC Add link to cross referencing example

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -10,7 +10,9 @@ Creating a basic Gallery
 This section describes how to set up a basic gallery for your examples
 using the Sphinx extension Sphinx-Gallery, which will do the following:
 
-* Automatically generate Sphinx rST out of your ``.py`` example files. The
+* Automatically generate `Sphinx rST
+  <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_
+  out of your ``.py`` example files. The
   rendering of the resulting rST will provide the users with ``.ipynb``
   (Jupyter notebook) and ``.py`` files of each example, which users can
   download.

--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -38,8 +38,10 @@ For a quick reference have a look at the example
 Embed rST in your example Python files
 ======================================
 
-Additionally, you may embed rST syntax within your Python scripts. This will
-be rendered in-line with the Python code and its outputs, similar to how
+Additionally, you may embed rST syntax within your Python scripts. rST
+allows you to easily add formatted text, math equations and reference links,
+including :ref:`cross referencing other examples <cross_ref_example>`. This
+will be rendered in-line with the Python code and its outputs, similar to how
 Jupyter Notebooks are structured (in fact, Sphinx-Gallery also **creates** a
 Jupyter Notebook for each example that is built).
 

--- a/examples/plot_0_sin.py
+++ b/examples/plot_0_sin.py
@@ -66,6 +66,8 @@ print('This example shows a sin plot!')
 # .. math::
 #    \sin
 #
+# .. _cross_ref_example:
+#
 # Cross referencing
 # ^^^^^^^^^^^^^^^^^
 #
@@ -73,7 +75,7 @@ print('This example shows a sin plot!')
 # including from other examples. Sphinx-Gallery automatically creates reference
 # labels for each example. The label consists of the ``.py`` file name,
 # prefixed with ``sphx_glr_`` and the name of the
-# folder(s) the example is in. In this case, the example we want to
+# folder(s) the example is in. Below, the example we want to
 # cross-reference is in ``auto_examples`` (the ``gallery_dirs``; see
 # :ref:`configure_and_use_sphinx_gallery`), then the subdirectory ``no_output``
 # (since the example is within a sub-gallery). The file name of the example is
@@ -82,7 +84,7 @@ print('This example shows a sin plot!')
 # ``:ref:`sphx_glr_auto_examples_no_output_plot_syntaxerror.py```.
 #
 # .. seealso::
-#     :ref:`sphx_glr_auto_examples_no_output_plot_syntaxerror.py` for a
+#     See :ref:`sphx_glr_auto_examples_no_output_plot_syntaxerror.py` for
 #     an example with an error.
 #
 # .. |docstring| replace:: """


### PR DESCRIPTION
Add link to `syntax.rst` to the explanation on how to reference other examples.

Some other doc nitpicks