### PR TITLE
ENH: Style HTML output like jupyter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - restore_cache:
           keys:
             - cache-pip
-      - run: pip install --user numpy matplotlib pyqt5 seaborn sphinx_rtd_theme pillow joblib sphinx pytest vtk traits traitsui pyface https://github.com/enthought/mayavi/zipball/master memory_profiler ipython plotly
+      - run: pip install --user numpy matplotlib pyqt5 seaborn statsmodels sphinx_rtd_theme pillow joblib sphinx pytest vtk traits traitsui pyface https://github.com/enthought/mayavi/zipball/master memory_profiler ipython plotly
       - save_cache:
           key: cache-pip
           paths:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
 
   global:
     PYTHON: "C:\\conda"
-    CONDA_DEPENDENCIES: numpy seaborn "matplotlib<3.2.1|>3.2.2" sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib plotly
+    CONDA_DEPENDENCIES: numpy seaborn statsmodels "matplotlib<3.2.1|>3.2.2" sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib plotly
     PIP_DEPENDENCIES: ipython"
 
   matrix:

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -9,7 +9,7 @@
 set -e
 
 if [ "$DISTRIB" == "conda" ]; then
-    export CONDA_DEPENDENCIES="pip numpy setuptools matplotlib pillow pytest pytest-cov coverage seaborn plotly joblib flake8 check-manifest ${CONDA_PKGS}"
+    export CONDA_DEPENDENCIES="pip numpy setuptools matplotlib pillow pytest pytest-cov coverage seaborn statsmodels plotly joblib flake8 check-manifest ${CONDA_PKGS}"
     export PIP_DEPENDENCIES="sphinx_rtd_theme"
     if [ "$PYTHON_VERSION" != "3.5" ] && [ "$PYTHON_VERSION" != "3.6" -o "$LOCALE" != "C" ]; then
         export PIP_DEPENDENCIES="${PIP_DEPENDENCIES} memory_profiler vtk https://github.com/enthought/mayavi/zipball/master ipython pypandoc"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,7 @@ numpy
 matplotlib
 pillow
 seaborn
+statsmodels
 joblib
 flake8
 check-manifest

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1331,7 +1331,7 @@ expression. If this method does not exist for the expression, the second
 'representation' method in the tuple, ``__repr__``, would be captured. If the
 ``__repr__`` also does not exist (unlikely for non-user defined objects),
 nothing would be captured. Data directed to standard output is **always**
-captured. For several examples, see :ref:`capture-repr-examples`.
+captured. For several examples, see :ref:`capture_repr_examples`.
 
 To capture only data directed to standard output, configure ``'capture_repr'``
 to be an empty tuple: ``'capture_repr': ()``. This will imitate the behaviour

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -223,7 +223,7 @@ which is then used by Sphinx-Gallery as::
     sys.argv[1:] = gallery_conf['reset_argv'](gallery_conf, script_vars)
 
 
-    
+
 .. _sub_gallery_order:
 
 Sorting gallery subsections
@@ -1331,7 +1331,7 @@ expression. If this method does not exist for the expression, the second
 'representation' method in the tuple, ``__repr__``, would be captured. If the
 ``__repr__`` also does not exist (unlikely for non-user defined objects),
 nothing would be captured. Data directed to standard output is **always**
-captured.
+captured. For several examples, see :ref:`capture-repr-examples`.
 
 To capture only data directed to standard output, configure ``'capture_repr'``
 to be an empty tuple: ``'capture_repr': ()``. This will imitate the behaviour

--- a/examples/plot_3_capture_repr.py
+++ b/examples/plot_3_capture_repr.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-.. _capture-repr-examples:
+.. _capture_repr_examples:
 
 Capturing output representations
 ================================

--- a/examples/plot_3_capture_repr.py
+++ b/examples/plot_3_capture_repr.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-r"""
+"""
+.. _capture-repr-examples:
+
 Capturing output representations
 ================================
 
@@ -53,6 +55,14 @@ df
 # example 4
 print('Hello world')
 a + b
+
+#%%
+# Statsmodels tables should also be styled appropriately:
+
+# example 5
+import numpy as np
+import statsmodels.iolib.table
+statsmodels.iolib.table.SimpleTable(np.zeros((3, 3)))
 
 #%%
 # ``print()`` outputs to standard output, which is always captured. The

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,7 @@ setup(
     version=sphinx_gallery.__version__,
     packages=find_packages(),
     package_data={'sphinx_gallery': [
-        '_static/gallery.css',
-        '_static/gallery-binder.css',
-        '_static/gallery-dataframe.css',
+        '_static/gallery*.css',
         '_static/no_image.png',
         '_static/broken_example.png',
         '_static/binder_badge_logo.svg'

--- a/sphinx_gallery/_static/gallery-rendered-html.css
+++ b/sphinx_gallery/_static/gallery-rendered-html.css
@@ -1,0 +1,209 @@
+/* Adapted from notebook/static/style/style.min.css */
+
+.rendered_html {
+  color: #000;
+  /* any extras will just be numbers: */
+}
+.rendered_html em {
+  font-style: italic;
+}
+.rendered_html strong {
+  font-weight: bold;
+}
+.rendered_html u {
+  text-decoration: underline;
+}
+.rendered_html :link {
+  text-decoration: underline;
+}
+.rendered_html :visited {
+  text-decoration: underline;
+}
+.rendered_html h1 {
+  font-size: 185.7%;
+  margin: 1.08em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+}
+.rendered_html h2 {
+  font-size: 157.1%;
+  margin: 1.27em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+}
+.rendered_html h3 {
+  font-size: 128.6%;
+  margin: 1.55em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+}
+.rendered_html h4 {
+  font-size: 100%;
+  margin: 2em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+}
+.rendered_html h5 {
+  font-size: 100%;
+  margin: 2em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+  font-style: italic;
+}
+.rendered_html h6 {
+  font-size: 100%;
+  margin: 2em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+  font-style: italic;
+}
+.rendered_html h1:first-child {
+  margin-top: 0.538em;
+}
+.rendered_html h2:first-child {
+  margin-top: 0.636em;
+}
+.rendered_html h3:first-child {
+  margin-top: 0.777em;
+}
+.rendered_html h4:first-child {
+  margin-top: 1em;
+}
+.rendered_html h5:first-child {
+  margin-top: 1em;
+}
+.rendered_html h6:first-child {
+  margin-top: 1em;
+}
+.rendered_html ul:not(.list-inline),
+.rendered_html ol:not(.list-inline) {
+  padding-left: 2em;
+}
+.rendered_html ul {
+  list-style: disc;
+}
+.rendered_html ul ul {
+  list-style: square;
+  margin-top: 0;
+}
+.rendered_html ul ul ul {
+  list-style: circle;
+}
+.rendered_html ol {
+  list-style: decimal;
+}
+.rendered_html ol ol {
+  list-style: upper-alpha;
+  margin-top: 0;
+}
+.rendered_html ol ol ol {
+  list-style: lower-alpha;
+}
+.rendered_html ol ol ol ol {
+  list-style: lower-roman;
+}
+.rendered_html ol ol ol ol ol {
+  list-style: decimal;
+}
+.rendered_html * + ul {
+  margin-top: 1em;
+}
+.rendered_html * + ol {
+  margin-top: 1em;
+}
+.rendered_html hr {
+  color: black;
+  background-color: black;
+}
+.rendered_html pre {
+  margin: 1em 2em;
+  padding: 0px;
+  background-color: #fff;
+}
+.rendered_html code {
+  background-color: #eff0f1;
+}
+.rendered_html p code {
+  padding: 1px 5px;
+}
+.rendered_html pre code {
+  background-color: #fff;
+}
+.rendered_html pre,
+.rendered_html code {
+  border: 0;
+  color: #000;
+  font-size: 100%;
+}
+.rendered_html blockquote {
+  margin: 1em 2em;
+}
+.rendered_html table {
+  margin-left: auto;
+  margin-right: auto;
+  border: none;
+  border-collapse: collapse;
+  border-spacing: 0;
+  color: black;
+  font-size: 12px;
+  table-layout: fixed;
+}
+.rendered_html thead {
+  border-bottom: 1px solid black;
+  vertical-align: bottom;
+}
+.rendered_html tr,
+.rendered_html th,
+.rendered_html td {
+  text-align: right;
+  vertical-align: middle;
+  padding: 0.5em 0.5em;
+  line-height: normal;
+  white-space: normal;
+  max-width: none;
+  border: none;
+}
+.rendered_html th {
+  font-weight: bold;
+}
+.rendered_html tbody tr:nth-child(odd) {
+  background: #f5f5f5;
+}
+.rendered_html tbody tr:hover {
+  background: rgba(66, 165, 245, 0.2);
+}
+.rendered_html * + table {
+  margin-top: 1em;
+}
+.rendered_html p {
+  text-align: left;
+}
+.rendered_html * + p {
+  margin-top: 1em;
+}
+.rendered_html img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+.rendered_html * + img {
+  margin-top: 1em;
+}
+.rendered_html img,
+.rendered_html svg {
+  max-width: 100%;
+  height: auto;
+}
+.rendered_html img.unconfined,
+.rendered_html svg.unconfined {
+  max-width: none;
+}
+.rendered_html .alert {
+  margin-bottom: initial;
+}
+.rendered_html * + .alert {
+  margin-top: 1em;
+}
+[dir="rtl"] .rendered_html p {
+  text-align: right;
+}

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -35,7 +35,8 @@ from .binder import copy_binder_files, check_binder_conf
 from .directives import MiniGallery
 
 
-_KNOWN_CSS = ('gallery', 'gallery-binder', 'gallery-dataframe')
+_KNOWN_CSS = ('gallery', 'gallery-binder', 'gallery-dataframe',
+              'gallery-rendered-html')
 
 
 class DefaultResetArgv:

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -164,11 +164,15 @@ SPHX_GLR_SIG = """\n
 # Header used to include raw html
 html_header = """.. raw:: html
 
-{0}\n    <br />\n    <br />"""
+    <div class="output_subarea output_html rendered_html output_result">
+{0}
+    </div>
+    <br />
+    <br />"""
 
 
 def codestr2rst(codestr, lang='python', lineno=None):
-    """Return reStructuredText code block from code string"""
+    """Return reStructuredText code block from code string."""
     if lineno is not None:
         # Sphinx only starts numbering from the first non-empty line.
         blank_lines = codestr.count('\n', 0, -len(codestr.lstrip()))

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -26,7 +26,8 @@ from sphinx_gallery.utils import (_get_image, scale_image, _has_optipng,
 
 import pytest
 
-N_TOT = 11
+N_TOT = 12
+
 N_FAILING = 2
 N_GOOD = N_TOT - N_FAILING
 N_RST = 15 + N_TOT
@@ -218,6 +219,16 @@ def test_image_formats(sphinx_app):
             assert want_html in html
         if extra is not None:
             assert extra in html
+
+
+def test_repr_html_classes(sphinx_app):
+    """Test appropriate _repr_html_ classes."""
+    example_file = op.join(
+        sphinx_app.outdir, 'auto_examples', 'plot_repr.html')
+    with codecs.open(example_file, 'r', 'utf-8') as fid:
+        lines = fid.read()
+    assert 'div class="output_subarea output_html rendered_html output_result"' in lines  # noqa: E501
+    assert 'gallery-rendered-html.css' in lines
 
 
 def test_embed_links_and_styles(sphinx_app):

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -689,7 +689,9 @@ fig
 
 html_out = """.. raw:: html
 
+    <div class="output_subarea output_html rendered_html output_result">
     <div> This is the _repr_html_ div </div>
+    </div>
     <br />
     <br />"""
 

--- a/sphinx_gallery/tests/tinybuild/examples/plot_repr.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_repr.py
@@ -1,0 +1,13 @@
+"""
+Repr test
+=========
+Test repr.
+"""
+
+
+class A:
+    def _repr_html_(self):
+        return '<p><b>This should print<b></p>'
+
+
+A()


### PR DESCRIPTION
I dug into the Jupyter notebook default formatting a bit, and this allows us to hopefully style our HTML outputs similarly to theirs. See for example:

https://github.com/mne-tools/mne-nirs/pull/167#issuecomment-698277516

On my machine on this PR I now get:

![Screenshot from 2020-10-06 09-31-38](https://user-images.githubusercontent.com/2365790/95208166-bfe79680-07b6-11eb-9f53-8310342aa255.png)
