### PR TITLE
DOC update link in projects_list

### DIFF
--- a/doc/projects_list.rst
+++ b/doc/projects_list.rst
@@ -4,7 +4,7 @@ Who uses Sphinx-Gallery
 
 Here is a list of projects using `sphinx-gallery`.
 
-* `Sphinx-Gallery <https://sphinx-gallery.github.io/auto_examples/index.html>`_
+* `Sphinx-Gallery <https://sphinx-gallery.github.io/stable/auto_examples/index.html>`_
 * `Scikit-learn <http://scikit-learn.org/dev/auto_examples/index.html>`_
 * `Nilearn <https://nilearn.github.io/auto_examples/index.html>`_
 * `MNE-python <https://www.martinos.org/mne/stable/auto_examples/index.html>`_

--- a/doc/projects_list.rst
+++ b/doc/projects_list.rst
@@ -4,7 +4,7 @@ Who uses Sphinx-Gallery
 
 Here is a list of projects using `sphinx-gallery`.
 
-* `Sphinx-Gallery <https://sphinx-gallery.github.io/stable/auto_examples/index.html>`_
+* :ref:`Sphinx-Gallery <sphx_glr_auto_examples>`
 * `Scikit-learn <http://scikit-learn.org/dev/auto_examples/index.html>`_
 * `Nilearn <https://nilearn.github.io/auto_examples/index.html>`_
 * `MNE-python <https://www.martinos.org/mne/stable/auto_examples/index.html>`_


### PR DESCRIPTION
closes #753

Ideally when you are in the dev version of the docs, this link should be https://sphinx-gallery.github.io/dev/auto_examples/index.html, but I am not sure how to make this link change depending on the doc version...any ideas @larsoner ? It's also not that important and I am sure we can leave as stable.