### PR TITLE
ENH: Add run_stale_examples config var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
         apt:
           packages:
             - optipng
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" SPHINX_VERSION="dev"
+    - env: DISTRIB="conda" PYTHON_VERSION="3.8" SPHINX_VERSION="dev"
     - python: 3.7
       env: DISTRIB="minimal"
     - python: "nightly"
@@ -38,6 +38,8 @@ matrix:
             - liblapack-dev
             - gfortran
             - optipng
+  allow_failures:
+  - python: "nightly"
 
 before_install:
   # Make sure that things work even if the locale is set to C (which

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -19,6 +19,7 @@ file:
 
 - ``examples_dirs`` and ``gallery_dirs`` (:ref:`multiple_galleries_config`)
 - ``filename_pattern`` and ``ignore_pattern`` (:ref:`build_pattern`)
+- ``run_stale_examples`` (:ref:`run_stale_examples`)
 - ``reset_argv`` (:ref:`reset_argv`)
 - ``subsection_order`` (:ref:`sub_gallery_order`)
 - ``within_subsection_order`` (:ref:`within_gallery_order`)
@@ -155,10 +156,7 @@ one is targeting a specific file, it would match the dot in the filename even wi
 
 .. note::
     Sphinx-gallery only re-runs examples that have changed (according to their
-    md5 hash). You can delete the associated MD5 files (e.g.,
-    ``./auto_examples/plot_awesome_example.py.md5``) to force a rebuild if
-    you have not changed the example itself between subsequent ``sphinx``
-    calls.
+    md5 hash). See :ref:`run_stale_examples` below for information.
 
 Similarly, to build only examples in a specific directory, you can do::
 
@@ -185,6 +183,46 @@ As the patterns are parsed as `regular expressions`_, users are advised to consu
     .. code-block:: console
 
         $ sphinx-build -D sphinx_gallery_conf.filename_pattern=plot_specific_example\.py ...
+
+.. _run_stale_examples::
+
+Rerunning stale examples
+========================
+By default, sphinx-gallery only rebuilds examples that have changed.
+For example, starting from a clean ``doc/`` directory, running your HTML build
+once will result in Sphinx-gallery executing all examples that match your given
+filename / ignore patterns. Then, running
+the exact same command a second time *should not run any examples*, because the
+MD5 hash of each example will be checked against the MD5 hash (saved to disk
+as ``<filename>.md5`` in the generated directory) that the example file had
+during the first build, they will match and thus the example will be determined
+to be "stale", and it will not be rebuilt by Sphinx-gallery.
+This design feature allows for more rapid documentation iteration by only
+rebuilding examples when they change.
+
+However, this presents a problem during some modes of debugging and
+iteration. Let's say that you have one particular
+example that you want to rebuild repeatedly while modifying some function in
+your underlying library, while leaving the example file contents themselves
+fixed. To do this, you'd either need to make some change (e.g., add/delete a
+newline) to your example or delete the ``.md5`` file to force Sphinx-gallery
+to rebuild the example. Instead, you can use the configuration value::
+
+    sphinx_gallery_conf = = {
+        ...
+        'run_stale_examples': True,
+    }
+
+This can be combined with other options to repeatedly rerun a single example
+from the command line for example by doing some variant of:
+
+.. code-block:: console
+
+    $ make html SPHINXOPTS='-D sphinx_gallery_conf.run_stale_examples=True' -Dsphinx_gallery_conf.filename_pattern='my_example_name'``
+
+This will cause any examples matching the filename/ignore patterns to be
+rebuilt, regardless of their MD5 hashes.
+
 
 .. _reset_argv:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -191,7 +191,7 @@ Rerunning stale examples
 By default, sphinx-gallery only rebuilds examples that have changed.
 For example, when starting from a clean ``doc/`` directory, running your HTML
 build once will result in Sphinx-gallery executing all examples that match your
-given :ref:`filename/ignore patterns <build pattern>`. Then, running
+given :ref:`filename/ignore patterns <build_pattern>`. Then, running
 the exact same command a second time *should not run any examples*, because the
 MD5 hash of each example will be checked against the MD5 hash (saved to disk
 as ``<filename>.md5`` in the generated directory) that the example file had

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -189,23 +189,23 @@ As the patterns are parsed as `regular expressions`_, users are advised to consu
 Rerunning stale examples
 ========================
 By default, sphinx-gallery only rebuilds examples that have changed.
-For example, starting from a clean ``doc/`` directory, running your HTML build
-once will result in Sphinx-gallery executing all examples that match your given
-filename / ignore patterns. Then, running
+For example, when starting from a clean ``doc/`` directory, running your HTML
+build once will result in Sphinx-gallery executing all examples that match your
+given :ref:`filename/ignore patterns <build pattern>`. Then, running
 the exact same command a second time *should not run any examples*, because the
 MD5 hash of each example will be checked against the MD5 hash (saved to disk
 as ``<filename>.md5`` in the generated directory) that the example file had
-during the first build, they will match and thus the example will be determined
-to be "stale", and it will not be rebuilt by Sphinx-gallery.
+during the first build. These will match and thus the example will be
+determined to be "stale", and it will not be rebuilt by Sphinx-gallery.
 This design feature allows for more rapid documentation iteration by only
 rebuilding examples when they change.
 
 However, this presents a problem during some modes of debugging and
 iteration. Let's say that you have one particular
 example that you want to rebuild repeatedly while modifying some function in
-your underlying library, while leaving the example file contents themselves
-fixed. To do this, you'd either need to make some change (e.g., add/delete a
-newline) to your example or delete the ``.md5`` file to force Sphinx-gallery
+your underlying library but do not want to change the example file contents
+themselves. To do this, you'd either need to make some change (e.g., add/delete
+a newline) to your example or delete the ``.md5`` file to force Sphinx-gallery
 to rebuild the example. Instead, you can use the configuration value::
 
     sphinx_gallery_conf = = {
@@ -213,15 +213,18 @@ to rebuild the example. Instead, you can use the configuration value::
         'run_stale_examples': True,
     }
 
-This can be combined with other options to repeatedly rerun a single example
-from the command line for example by doing some variant of:
+With this configuration, all examples matching the filename/ignore pattern will
+be rebuilt, even if their MD5 hash shows that the example did not change.
+You can combine this with :ref:`filename/ignore patterns <build_pattern>`
+to repeatedly rerun a single example.
+This could be done from the command line, for example:
 
 .. code-block:: console
 
     $ make html SPHINXOPTS='-D sphinx_gallery_conf.run_stale_examples=True' -Dsphinx_gallery_conf.filename_pattern='my_example_name'``
 
-This will cause any examples matching the filename/ignore patterns to be
-rebuilt, regardless of their MD5 hashes.
+This command will cause any examples matching the filename pattern
+``'my_example_name'`` to be rebuilt, regardless of their MD5 hashes.
 
 
 .. _reset_argv:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -184,7 +184,7 @@ As the patterns are parsed as `regular expressions`_, users are advised to consu
 
         $ sphinx-build -D sphinx_gallery_conf.filename_pattern=plot_specific_example\.py ...
 
-.. _run_stale_examples::
+.. _run_stale_examples:
 
 Rerunning stale examples
 ========================

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -809,9 +809,14 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
     executable = executable_script(src_file, gallery_conf)
 
     if md5sum_is_current(target_file, mode='t'):
+        do_return = True
         if executable:
-            gallery_conf['stale_examples'].append(target_file)
-        return intro, title, (0, 0)
+            if gallery_conf['run_stale_examples']:
+                do_return = False
+            else:
+                gallery_conf['stale_examples'].append(target_file)
+        if do_return:
+            return intro, title, (0, 0)
 
     image_dir = os.path.join(target_dir, 'images')
     if not os.path.exists(image_dir):

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -551,14 +551,12 @@ def _rerun(how, src_dir, conf_dir, out_dir, toctrees_dir,
                 if 'FYI this' in line:
                     line = 'A ' + line
                 fid.write(line)
-        n_ch = '9'
         out_of, excluding = N_FAILING + 1, N_GOOD - 1
         n_stale = N_GOOD - 1
     else:
         assert how == 'run_stale'
         confoverrides['sphinx_gallery_conf.run_stale_examples'] = 'True'
         confoverrides['sphinx_gallery_conf.filename_pattern'] = 'plot_numpy_ma'
-        n_ch = '[8|9]'
         out_of, excluding = 1, 0
         n_stale = 0
     with docutils_namespace():
@@ -576,6 +574,7 @@ def _rerun(how, src_dir, conf_dir, out_dir, toctrees_dir,
     # ... but then later detects that only two have changed
     lines = [line for line in status.split('\n') if 'changed,' in line]
     lines = '\n'.join([how] + lines)
+    n_ch = '[8|9]'
     want = '.*updating environment:.*0 added, %s changed, 0 removed.*' % n_ch
     assert re.match(want, status, flags) is not None, lines
     want = ('.*executed 1 out of %s.*after excluding %s files.*based on MD5.*'

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -579,7 +579,10 @@ def _rerun(how, src_dir, conf_dir, out_dir, toctrees_dir,
     # unknown reason)
     lines = [line for line in status.split('\n') if 'changed,' in line]
     lines = '\n'.join([how] + lines)
-    n_ch = '[8|9]'
+    if how == 'run_stale':
+        n_ch = '8'
+    else:
+        n_ch = '9'
     want = '.*updating environment:.*0 added, %s changed, 0 removed.*' % n_ch
     assert re.match(want, status, flags) is not None, lines
     want = ('.*executed 1 out of %s.*after excluding %s files.*based on MD5.*'

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -558,7 +558,7 @@ def _rerun(how, src_dir, conf_dir, out_dir, toctrees_dir,
         assert how == 'run_stale'
         confoverrides['sphinx_gallery_conf.run_stale_examples'] = 'True'
         confoverrides['sphinx_gallery_conf.filename_pattern'] = 'plot_numpy_ma'
-        n_ch = '8'
+        n_ch = '[8|9]'
         out_of, excluding = 1, 0
         n_stale = 0
     with docutils_namespace():
@@ -568,12 +568,14 @@ def _rerun(how, src_dir, conf_dir, out_dir, toctrees_dir,
         new_app.build(False, [])
     status = new_app._status.getvalue()
     lines = [line for line in status.split('\n') if 'source files tha' in line]
+    lines = '\n'.join([how] + lines)
     flags = re.MULTILINE | re.DOTALL
     if how == 'run_stale':  # confoverrides shows them as out of date...
         want = '.*targets for %s source files that are out of date$.*' % N_RST
         assert re.match(want, status, flags) is not None, lines
     # ... but then later detects that only two have changed
     lines = [line for line in status.split('\n') if 'changed,' in line]
+    lines = '\n'.join([how] + lines)
     want = '.*updating environment:.*0 added, %s changed, 0 removed.*' % n_ch
     assert re.match(want, status, flags) is not None, lines
     want = ('.*executed 1 out of %s.*after excluding %s files.*based on MD5.*'

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -572,9 +572,8 @@ def _rerun(how, src_dir, conf_dir, out_dir, toctrees_dir,
     flags = re.MULTILINE | re.DOTALL
     # for some reason, setting "confoverrides" above causes Sphinx to show
     # all targets out of date, even though they haven't been modified...
-    if how == 'run_stale':
-        want = '.*targets for %s source files that are out of date$.*' % N_RST
-        assert re.match(want, status, flags) is not None, lines
+    want = '.*targets for %s source files that are out of date$.*' % N_RST
+    assert re.match(want, status, flags) is not None, lines
     # ... but then later detects that only some have actually changed
     # (sometimes this is 8, other times 9, depending on Windows/Linux for some
     # unknown reason)

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -574,15 +574,12 @@ def _rerun(how, src_dir, conf_dir, out_dir, toctrees_dir,
     # all targets out of date, even though they haven't been modified...
     want = '.*targets for %s source files that are out of date$.*' % N_RST
     assert re.match(want, status, flags) is not None, lines
-    # ... but then later detects that only some have actually changed
-    # (sometimes this is 8, other times 9, depending on Windows/Linux for some
-    # unknown reason)
+    # ... but then later detects that only some have actually changed:
+    # Linux: 8 changed when how='run_stale', 9 when how='modify'.
+    # Windows: always 9 for some reason
     lines = [line for line in status.split('\n') if 'changed,' in line]
     lines = '\n'.join([how] + lines)
-    if how == 'run_stale':
-        n_ch = '8'
-    else:
-        n_ch = '9'
+    n_ch = '[8|9]'
     want = '.*updating environment:.*0 added, %s changed, 0 removed.*' % n_ch
     assert re.match(want, status, flags) is not None, lines
     want = ('.*executed 1 out of %s.*after excluding %s files.*based on MD5.*'

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -567,7 +567,6 @@ def _rerun(how, src_dir, conf_dir, out_dir, toctrees_dir,
                          confoverrides=confoverrides)
         new_app.build(False, [])
     status = new_app._status.getvalue()
-    n = '[' + '|'.join(str(x + N_FAILING) for x in range(4)) + ']'
     lines = [line for line in status.split('\n') if 'source files tha' in line]
     flags = re.MULTILINE | re.DOTALL
     if how == 'run_stale':  # confoverrides shows them as out of date...


### PR DESCRIPTION
Makes it much easier to have a Makefile target to force re-running of a specific example/examples. See extended explanation in `configuration.rst`.