### PR TITLE
ENH, DEP: Check for invalid keys, remove ancient key

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -92,6 +92,8 @@ DEFAULT_GALLERY_CONF = {
     'inspect_global_variables': True,
     'css': _KNOWN_CSS,
     'matplotlib_animations': False,
+    'default_thumb_file': None,
+    'line_numbers': False,
 }
 
 logger = sphinx_compatibility.getLogger('sphinx-gallery')

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -14,6 +14,7 @@ from __future__ import division, print_function, absolute_import
 import codecs
 import copy
 from datetime import timedelta, datetime
+from difflib import get_close_matches
 from importlib import import_module
 import re
 import os
@@ -105,7 +106,7 @@ def _bool_eval(x):
     return bool(x)
 
 
-def parse_config(app):
+def parse_config(app, check_keys=True):
     """Process the Sphinx Gallery configuration."""
     plot_gallery = _bool_eval(app.builder.config.plot_gallery)
     src_dir = app.builder.srcdir
@@ -114,7 +115,8 @@ def parse_config(app):
     lang = app.builder.config.highlight_language
     gallery_conf = _complete_gallery_conf(
         app.config.sphinx_gallery_conf, src_dir, plot_gallery,
-        abort_on_example_error, lang, app.builder.name, app)
+        abort_on_example_error, lang, app.builder.name, app,
+        check_keys)
 
     # this assures I can call the config in other places
     app.config.sphinx_gallery_conf = gallery_conf
@@ -124,8 +126,21 @@ def parse_config(app):
 
 def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
                            abort_on_example_error, lang='python',
-                           builder_name='html', app=None):
+                           builder_name='html', app=None, check_keys=True):
     gallery_conf = copy.deepcopy(DEFAULT_GALLERY_CONF)
+    options = sorted(gallery_conf)
+    extra_keys = sorted(set(sphinx_gallery_conf) - set(options))
+    if extra_keys and check_keys:
+        msg = 'Unknown key(s) in sphinx_gallery_conf:\n'
+        for key in extra_keys:
+            options = get_close_matches(key, options, cutoff=0.66)
+            msg += repr(key)
+            if len(options) == 1:
+                msg += ', did you mean %r?' % (options[0],)
+            elif len(options) > 1:
+                msg += ', did you mean one of %r?' % (options,)
+            msg += '\n'
+        raise ConfigError(msg.strip())
     gallery_conf.update(sphinx_gallery_conf)
     if sphinx_gallery_conf.get('find_mayavi_figures', False):
         logger.warning(
@@ -142,20 +157,6 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
         gallery_conf[key] = _bool_eval(gallery_conf[key])
     gallery_conf['src_dir'] = src_dir
     gallery_conf['app'] = app
-
-    if gallery_conf.get("mod_example_dir", False):
-        backreferences_warning = """\n========
-        Sphinx-Gallery found the configuration key 'mod_example_dir'. This
-        is deprecated, and you should now use the key 'backreferences_dir'
-        instead. Support for 'mod_example_dir' will be removed in a subsequent
-        version of Sphinx-Gallery. For more details, see the backreferences
-        documentation:
-
-        https://sphinx-gallery.github.io/configuration.html#references-to-examples"""  # noqa: E501
-        gallery_conf['backreferences_dir'] = gallery_conf['mod_example_dir']
-        logger.warning(
-            backreferences_warning,
-            type=DeprecationWarning)
 
     # Check capture_repr
     capture_repr = gallery_conf['capture_repr']

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -301,8 +301,9 @@ def save_thumbnail(image_path_template, src_file, file_conf, gallery_conf):
         img = thumbnail_image_path
     elif not os.path.exists(thumb_file):
         # create something to replace the thumbnail
-        img = os.path.join(glr_path_static(), 'no_image.png')
-        img = gallery_conf.get("default_thumb_file", img)
+        img = gallery_conf.get("default_thumb_file")
+        if img is None:
+            img = os.path.join(glr_path_static(), 'no_image.png')
     else:
         return
     if ext in ('svg', 'gif'):

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -131,19 +131,20 @@ def test_custom_scraper(gallery_conf, monkeypatch):
                   lambda: _custom_func, raising=False)
         for cust in (_custom_func, 'sphinx_gallery'):
             gallery_conf.update(image_scrapers=[cust])
-            _complete_gallery_conf(*complete_args)  # smoke test that it works
+            # smoke test that it works
+            _complete_gallery_conf(*complete_args, check_keys=False)
     # degenerate
     # without the monkey patch to add sphinx_gallery._get_sg_image_scraper,
     # we should get an error
     gallery_conf.update(image_scrapers=['sphinx_gallery'])
     with pytest.raises(ConfigError,
                        match="has no attribute '_get_sg_image_scraper'"):
-        _complete_gallery_conf(*complete_args)
+        _complete_gallery_conf(*complete_args, check_keys=False)
 
     # other degenerate conditions
     gallery_conf.update(image_scrapers=['foo'])
     with pytest.raises(ConfigError, match='Unknown image scraper'):
-        _complete_gallery_conf(*complete_args)
+        _complete_gallery_conf(*complete_args, check_keys=False)
     gallery_conf.update(image_scrapers=[_custom_func])
     fname_template = os.path.join(gallery_conf['gallery_dir'],
                                   'image{0}.png')
@@ -161,12 +162,12 @@ def test_custom_scraper(gallery_conf, monkeypatch):
         m.setattr(sphinx_gallery, '_get_sg_image_scraper', 'foo',
                   raising=False)
         with pytest.raises(ConfigError, match='^Unknown image.*\n.*callable'):
-            _complete_gallery_conf(*complete_args)
+            _complete_gallery_conf(*complete_args, check_keys=False)
     with monkeypatch.context() as m:
         m.setattr(sphinx_gallery, '_get_sg_image_scraper', lambda: 'foo',
                   raising=False)
         with pytest.raises(ConfigError, match='^Scraper.*was not callable'):
-            _complete_gallery_conf(*complete_args)
+            _complete_gallery_conf(*complete_args, check_keys=False)
 
 
 @pytest.mark.parametrize('ext', _KNOWN_IMG_EXTS)

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -82,7 +82,7 @@ sphinx_gallery_conf = {
     'reset_modules': (MockScrapeProblem(), 'matplotlib'),
     'gallery_dirs': ['auto_examples'],
     'backreferences_dir': 'gen_modules/backreferences',
-    'within_section_order': FileNameSortKey,
+    'within_subsection_order': FileNameSortKey,
     'image_scrapers': (matplotlib_format_scraper(),),
     'expected_failing_examples': [
         'examples/future/plot_future_imports_broken.py',


### PR DESCRIPTION
Closes #774.

Also removes `mod_example_dir` -- we deprecated it 3 years ago, should be safe to remove.