### PR TITLE
Make any borders introduced when rescaling images to thumbnails transparent

### DIFF
--- a/sphinx_gallery/utils.py
+++ b/sphinx_gallery/utils.py
@@ -66,7 +66,7 @@ def scale_image(in_fname, out_fname, max_width, max_height):
     # width_sc, height_sc = img.size  # necessary if using thumbnail
 
     # insert centered
-    thumb = Image.new('RGBA', (max_width, max_height), (255, 255, 255, 255))
+    thumb = Image.new('RGBA', (max_width, max_height), (255, 255, 255, 0))
     pos_insert = ((max_width - width_sc) // 2, (max_height - height_sc) // 2)
     thumb.paste(img, pos_insert)
 


### PR DESCRIPTION
Rescaling the images down to thumbnails often results in image borders that are white. Changing the alpha value here modifies these borders to be transparent, so that any border areas from the rescaling take on the background color of the thumbnail. This is an enhancement for users who want to use custom thumbnail background colors.