### PR TITLE
Replace Travis CI badge with Azure Badge in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 Sphinx-Gallery
 ==============
 
-.. image:: https://travis-ci.org/sphinx-gallery/sphinx-gallery.svg?branch=master
-    :target: https://travis-ci.org/sphinx-gallery/sphinx-gallery
+.. image:: https://dev.azure.com/sphinx-gallery/sphinx-gallery/_apis/build/status/sphinx-gallery.sphinx-gallery?branchName=master
+    :target: https://dev.azure.com/sphinx-gallery/sphinx-gallery/_build/latest?definitionId=1&branchName=master
 
 .. image::     https://ci.appveyor.com/api/projects/status/github/sphinx-gallery/sphinx-gallery?branch=master&svg=true
     :target: https://ci.appveyor.com/project/sphinx-gallery/sphinx-gallery/history


### PR DESCRIPTION
Reference changes in 0ea6202195845b89f02b49055d4227fcd89ec380, moving from travis CI to Azure