### PR TITLE
Let sphinx_gallery_thumbnail_number support negative indexes

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -663,24 +663,24 @@ Add your own first and last notebook cell
 Sphinx-Gallery allows you to add your own first and/or last cell to *every*
 generated notebook. Adding a first cell can be useful for including code that
 is required to run properly in the notebook, but not in a ``.py`` file. By
-default, the following first cell is added to each notebook::
+default, the following first cell is added to each notebook:
 
 .. code-block:: ipython
 
-   %matplotlib inline
+    %matplotlib inline
 
 Adding a last cell can be useful for performing a desired action such as
 reporting on the user's environment. By default no last cell is added.
 
 You can choose whatever text you like by modifying the ``first_notebook_cell``
 and ``last_notebook_cell`` configuration parameters. For example, the gallery
-of this documentation adds the following first cell::
+of this documentation adds the following first cell:
 
 .. code-block:: ipython
 
-  # This cell is added by sphinx-gallery
-  # It can be customized to whatever you like
-  %matplotlib inline
+    # This cell is added by sphinx-gallery
+    # It can be customized to whatever you like
+    %matplotlib inline
 
 Which is achieved by the following configuration::
 
@@ -1256,7 +1256,7 @@ Setting gallery thumbnail size
 
 By default Sphinx-Gallery will generate thumbnails at size ``(400, 280)``.
 The thumbnail image will then be scaled to the size specified by
-``'thumbnail_size``, adding pillarboxes or letterboxes as necessary to
+``thumbnail_size``, adding pillarboxes or letterboxes as necessary to
 maintain the original aspect ratio. The default ``thumbnail_size`` is
 ``(400, 280)`` (no scaling) and can be changed via the ``thumbnail_size``
 configuration, e.g.::
@@ -1269,7 +1269,7 @@ configuration, e.g.::
 The gallery uses various CSS classes to display these thumbnails, which
 default to maximum 160x112px. To change this, e.g. to display the images
 at 250x250px, you can modify the default CSS with something like the following
-in your ``gallery.css``` file:
+in your ``gallery.css`` file:
 
 .. code-block:: css
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -839,6 +839,11 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
             for label, content, line_number in script_blocks
         ]
 
+    # Remove final empty block, which can occur after config comments
+    # are removed
+    if script_blocks[-1][1].isspace():
+        script_blocks = script_blocks[:-1]
+
     if executable:
         clean_modules(gallery_conf, fname)
     output_blocks, time_elapsed = execute_script(script_blocks,

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -181,6 +181,29 @@ def test_thumbnail_path(sphinx_app, tmpdir):
     assert corr > 0.99
 
 
+def test_negative_thumbnail_config(sphinx_app, tmpdir):
+    """Test 'sphinx_gallery_thumbnail_number' config works correctly for
+    negative numbers."""
+    import numpy as np
+    # Make sure our thumbnail is the 2nd (last) image
+    fname_orig = op.join(
+        sphinx_app.outdir, '_images',
+        'sphx_glr_plot_matplotlib_alt_002.png')
+    fname_thumb = op.join(
+        sphinx_app.outdir, '_images',
+        'sphx_glr_plot_matplotlib_alt_thumb.png')
+    fname_new = str(tmpdir.join('new.png'))
+    scale_image(fname_orig, fname_new,
+                *sphinx_app.config.sphinx_gallery_conf["thumbnail_size"])
+    Image = _get_image()
+    orig = np.asarray(Image.open(fname_thumb))
+    new = np.asarray(Image.open(fname_new))
+    assert new.shape[:2] == orig.shape[:2]
+    assert new.shape[2] in (3, 4)  # optipng can strip the alpha channel
+    corr = np.corrcoef(new[..., :3].ravel(), orig[..., :3].ravel())[0, 1]
+    assert corr > 0.99
+
+
 def test_command_line_args_img(sphinx_app):
     generated_examples_dir = op.join(sphinx_app.outdir, 'auto_examples')
     thumb_fname = '../_images/sphx_glr_plot_command_line_args_thumb.png'

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -451,6 +451,18 @@ def test_remove_config_comments(gallery_conf, req_pil):
     assert '# sphinx_gallery_thumbnail_number = 1' not in rst
 
 
+def test_final_empty_block(gallery_conf, req_pil):
+    """Test empty final block is removed. Empty final block can occur after
+    sole config comment is removed from final block."""
+    CONTENT.extend(
+        ('# %%', '', '# sphinx_gallery_line_numbers = True')
+    )
+    gallery_conf['remove_config_comments'] = True
+    rst = _generate_rst(gallery_conf, 'test.py', CONTENT)
+    want = "RuntimeWarning)\n\n\n.. rst-class:: sphx-glr-timing"
+    assert want in rst
+
+
 def test_download_link_note_only_html(gallery_conf, req_pil):
     """Test html only directive for download_link."""
     rst = _generate_rst(gallery_conf, 'test.py', CONTENT)

--- a/sphinx_gallery/tests/tinybuild/examples/plot_matplotlib_alt.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_matplotlib_alt.py
@@ -27,6 +27,8 @@ plt.show()
 # %%
 # Several titles.
 
+# sphinx_gallery_thumbnail_number = -1
+
 plt.plot(range(10))
 
 plt.title('Center Title')


### PR DESCRIPTION
- Let sphinx_gallery_thumbnail_number support negative index
- Add an example with a negative index

Fixes #785.