### PR TITLE
Add a configuration to warn on error not fail

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -36,7 +36,7 @@ file:
 - ``compress_images`` (:ref:`compress_images`)
 - ``reset_modules`` (:ref:`reset_modules`)
 - ``abort_on_example_error`` (:ref:`abort_on_first`)
-- ``only_warning_on_example_error`` (:ref:`warning_on_error`)
+- ``only_warn_on_example_error`` (:ref:`warning_on_error`)
 - ``expected_failing_examples`` (:ref:`dont_fail_exit`)
 - ``min_reported_time`` (:ref:`min_reported_time`)
 - ``show_memory`` (:ref:`show_memory`)
@@ -1257,7 +1257,7 @@ the example script.
 
 .. _warning_on_error:
 
-Never Fail the build on error
+Never fail the build on error
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Sphinx-Gallery can be configured to only log warnings when examples fail. This means that sphinx will only exit with a non-zero exit code if the ``-W`` flag is passed to ``sphinx-build``. This can be enabled by setting::

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -36,6 +36,7 @@ file:
 - ``compress_images`` (:ref:`compress_images`)
 - ``reset_modules`` (:ref:`reset_modules`)
 - ``abort_on_example_error`` (:ref:`abort_on_first`)
+- ``only_warning_on_example_error`` (:ref:`warning_on_error`)
 - ``expected_failing_examples`` (:ref:`dont_fail_exit`)
 - ``min_reported_time`` (:ref:`min_reported_time`)
 - ``show_memory`` (:ref:`show_memory`)
@@ -1233,8 +1234,8 @@ the ``sphinx-build`` command.
 
 .. _dont_fail_exit:
 
-Don't fail the build on exit
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Don't fail the build if specific examples error
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 It might be the case that you want to keep the gallery even with
 failed examples. Thus you can configure Sphinx-Gallery to allow
@@ -1253,6 +1254,18 @@ the example script.
 
 .. note:: If an example is expected to fail, Sphinx-Gallery will error if
           the example runs without error.
+
+.. _warning_on_error:
+
+Never Fail the build on error
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sphinx-Gallery can be configured to only log warnings when examples fail. This means that sphinx will only exit with a non-zero exit code if the ``-W`` flag is passed to ``sphinx-build``. This can be enabled by setting::
+
+    sphinx_gallery_conf = {
+        ...
+        'only_warn_on_example_error': True
+    }
 
 
 .. _setting_thumbnail_size:

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -69,6 +69,7 @@ DEFAULT_GALLERY_CONF = {
     'plot_gallery': 'True',
     'download_all_examples': True,
     'abort_on_example_error': False,
+    'only_warn_on_example_error': False,
     'failing_examples': {},
     'passing_examples': [],
     'stale_examples': [],  # ones that did not need to be run due to md5sum
@@ -712,10 +713,13 @@ def summarize_failing_examples(app, exception):
                 color='brown')
 
     if fail_msgs:
-        raise ExtensionError(
-            "Here is a summary of the problems encountered "
-            "when running the examples\n\n" + "\n".join(fail_msgs) +
-            "\n" + "-" * 79)
+        fail_message = ("Here is a summary of the problems encountered "
+                        "when running the examples\n\n" + "\n".join(fail_msgs) +
+                        "\n" + "-" * 79)
+        if gallery_conf['only_warn_on_example_error']:
+            logger.warning(fail_message)
+        else:
+            raise ExtensionError(fail_message)
 
 
 def collect_gallery_files(examples_dirs, gallery_conf):

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -714,8 +714,8 @@ def summarize_failing_examples(app, exception):
 
     if fail_msgs:
         fail_message = ("Here is a summary of the problems encountered "
-                        "when running the examples\n\n" + "\n".join(fail_msgs) +
-                        "\n" + "-" * 79)
+                        "when running the examples\n\n" +
+                        "\n".join(fail_msgs) + "\n" + "-" * 79)
         if gallery_conf['only_warn_on_example_error']:
             logger.warning(fail_message)
         else:

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -336,7 +336,7 @@ def test_only_warn_on_example_error(sphinx_app_wrapper):
 
     build_warn = sphinx_app._warning.getvalue()
     assert 'plot_3.py failed to execute correctly' in build_warn
-    assert 'WARNING: Here is a summary of the problems encountered when running the examples' in build_warn
+    assert 'WARNING: Here is a summary of the problems' in build_warn
 
 
 @pytest.mark.conf_file(content="""

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -4,16 +4,14 @@
 r"""
 Test Sphinx-Gallery
 """
-
-from __future__ import (division, absolute_import, print_function,
-                        unicode_literals)
 import codecs
 import os
 import re
+from pathlib import Path
 
 import pytest
 
-from sphinx.errors import ConfigError, ExtensionError
+from sphinx.errors import ConfigError, ExtensionError, SphinxWarning
 from sphinx_gallery.gen_gallery import (
     check_duplicate_filenames, check_spaces_in_filenames,
     collect_gallery_files, write_computation_times, _complete_gallery_conf)
@@ -319,6 +317,45 @@ def test_expected_failing_examples_were_executed(sphinx_app_wrapper):
     See #335 for more details.
     """
     sphinx_app_wrapper.build_sphinx_app()
+
+
+@pytest.mark.conf_file(content="""
+sphinx_gallery_conf = {
+    'examples_dirs': 'src',
+    'gallery_dirs': 'ex',
+    'only_warn_on_example_error': True,
+}""")
+def test_only_warn_on_example_error(sphinx_app_wrapper):
+    """
+    Test behaviour of only_warn_on_example_error flag.
+    """
+    example_dir = Path(sphinx_app_wrapper.srcdir) / 'src'
+    with codecs.open(example_dir / 'plot_3.py', 'a', encoding='utf-8') as fid:
+        fid.write('raise ValueError')
+    sphinx_app = sphinx_app_wrapper.build_sphinx_app()
+
+    build_warn = sphinx_app._warning.getvalue()
+    assert 'plot_3.py failed to execute correctly' in build_warn
+    assert 'WARNING: Here is a summary of the problems encountered when running the examples' in build_warn
+
+
+@pytest.mark.conf_file(content="""
+sphinx_gallery_conf = {
+    'examples_dirs': 'src',
+    'gallery_dirs': 'ex',
+    'only_warn_on_example_error': True,
+}""")
+def test_only_warn_on_example_error_sphinx_warning(sphinx_app_wrapper):
+    """
+    Test behaviour of only_warn_on_example_error flag.
+    """
+    sphinx_app_wrapper.kwargs['warningiserror'] = True
+    example_dir = Path(sphinx_app_wrapper.srcdir) / 'src'
+    with codecs.open(example_dir / 'plot_3.py', 'a', encoding='utf-8') as fid:
+        fid.write('raise ValueError')
+    with pytest.raises(SphinxWarning) as excinfo:
+        sphinx_app_wrapper.build_sphinx_app()
+    assert "plot_3.py failed to execute" in str(excinfo.value)
 
 
 @pytest.mark.conf_file(content="""


### PR DESCRIPTION
With this configuration option set sphinx will only exit with a non-zero code if the -W flag is set.

I would find this useful on sunpy's CI because then sphinx-gallery will respect the fact that some of our builds have -W set and some (ones where we want to generate previews) don't.

Fixes #789 