### PR TITLE
Optional flag to defer figure scraping to the next code block

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -11,6 +11,49 @@ to use Sphinx-Gallery more deeply.
     :local:
     :depth: 2
 
+Using multiple code blocks to create a single figure
+====================================================
+
+By default, images are scraped following each code block in an example.  Thus,
+the following produces two plots, with one plot per code block::
+
+  # %%
+  # This first code block produces a plot with two lines
+
+  import matplotlib.pyplot as plt
+  plt.plot([1, 0])
+  plt.plot([0, 1])
+
+  # %%
+  # This second code block produces a plot with one line
+
+  plt.plot([2, 2])
+  plt.show()
+
+However, sometimes it can be useful to use multiple code blocks to create a
+single figure, particularly if the figure takes a large number commands that
+would benefit from being interleaved with text blocks.  The optional flag
+``sphinx_gallery_defer_figures`` can be inserted as a comment anywhere in a code
+block to defer the scraping of images to the next code block (where it can be
+further deferred, if desired).  The following produces only one plot::
+
+  # %%
+  # This first code block does not produce any plot
+
+  import matplotlib.pyplot as plt
+  plt.plot([1, 0])
+  plt.plot([0, 1])
+  # sphinx_gallery_defer_figures
+
+  # %%
+  # This second code block produces a plot with three lines
+
+  plt.plot([2, 2])
+  plt.show()
+
+If config comments are requested to be removed from rendered output (see
+:ref:`removing_config_comments`), these flag comments will be removed as well.
+
 Extend your Makefile for Sphinx-Gallery
 =======================================
 

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -11,49 +11,6 @@ to use Sphinx-Gallery more deeply.
     :local:
     :depth: 2
 
-Using multiple code blocks to create a single figure
-====================================================
-
-By default, images are scraped following each code block in an example.  Thus,
-the following produces two plots, with one plot per code block::
-
-  # %%
-  # This first code block produces a plot with two lines
-
-  import matplotlib.pyplot as plt
-  plt.plot([1, 0])
-  plt.plot([0, 1])
-
-  # %%
-  # This second code block produces a plot with one line
-
-  plt.plot([2, 2])
-  plt.show()
-
-However, sometimes it can be useful to use multiple code blocks to create a
-single figure, particularly if the figure takes a large number commands that
-would benefit from being interleaved with text blocks.  The optional flag
-``sphinx_gallery_defer_figures`` can be inserted as a comment anywhere in a code
-block to defer the scraping of images to the next code block (where it can be
-further deferred, if desired).  The following produces only one plot::
-
-  # %%
-  # This first code block does not produce any plot
-
-  import matplotlib.pyplot as plt
-  plt.plot([1, 0])
-  plt.plot([0, 1])
-  # sphinx_gallery_defer_figures
-
-  # %%
-  # This second code block produces a plot with three lines
-
-  plt.plot([2, 2])
-  plt.show()
-
-If config comments are requested to be removed from rendered output (see
-:ref:`removing_config_comments`), these flag comments will be removed as well.
-
 Extend your Makefile for Sphinx-Gallery
 =======================================
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -55,8 +55,12 @@ Some options can also be set or overridden on a file-by-file basis:
 - ``# sphinx_gallery_thumbnail_number`` (:ref:`choosing_thumbnail`)
 - ``# sphinx_gallery_thumbnail_path`` (:ref:`providing_thumbnail`)
 
-See also :ref:`removing_config_comments` to hide these comments from the
-rendered examples.
+Some options can be set on a per-code-block basis in a file:
+
+- ``# sphinx_gallery_defer_figures`` (:ref:`defer_figures`)
+
+See also :ref:`removing_config_comments` to hide config comments in files from
+the rendered examples.
 
 Some options can be set during the build execution step, e.g. using a Makefile:
 
@@ -647,8 +651,8 @@ setting::
 Removing config comments
 ========================
 
-Some configurations can be done on a file-by-file basis by adding a special
-comment with the pattern :samp:`# sphinx_gallery_{config} = {value}` to the
+Some configurations can be specified within a file by adding a special
+comment with the pattern :samp:`# sphinx_gallery_{config} [= {value}]` to the
 example source files. By default, the source files are parsed as is and thus
 the comment will appear in the example.
 
@@ -660,8 +664,8 @@ To remove the comment from the rendered example set the option::
     }
 
 This only removes configuration comments from code blocks, not from text
-blocks. However, note that technically, configuration comments will work when
-put in either code blocks or text blocks.
+blocks. However, note that technically, file-level configuration comments will
+work when put in either code blocks or text blocks.
 
 .. _own_notebook_cell:
 
@@ -1094,7 +1098,6 @@ optimize less but speed up the build time you could do::
 
 See ``$ optipng --help`` for a complete list of options.
 
-
 .. _image_scrapers:
 
 Image scrapers
@@ -1157,6 +1160,48 @@ images produced by an arbitrary package. For instructions, see
 useful for general use (e.g., a custom scraper for a plotting library)
 feel free to add it to the list above (see discussion
 `here <https://github.com/sphinx-gallery/sphinx-gallery/issues/441#issuecomment-493782430>`__)!
+
+.. _defer_figures:
+
+Using multiple code blocks to create a single figure
+====================================================
+
+By default, images are scraped following each code block in an example.  Thus,
+the following produces two plots, with one plot per code block::
+
+  # %%
+  # This first code block produces a plot with two lines
+
+  import matplotlib.pyplot as plt
+  plt.plot([1, 0])
+  plt.plot([0, 1])
+
+  # %%
+  # This second code block produces a plot with one line
+
+  plt.plot([2, 2])
+  plt.show()
+
+However, sometimes it can be useful to use multiple code blocks to create a
+single figure, particularly if the figure takes a large number commands that
+would benefit from being interleaved with text blocks.  The optional flag
+``sphinx_gallery_defer_figures`` can be inserted as a comment anywhere in a code
+block to defer the scraping of images to the next code block (where it can be
+further deferred, if desired).  The following produces only one plot::
+
+  # %%
+  # This first code block does not produce any plot
+
+  import matplotlib.pyplot as plt
+  plt.plot([1, 0])
+  plt.plot([0, 1])
+  # sphinx_gallery_defer_figures
+
+  # %%
+  # This second code block produces a plot with three lines
+
+  plt.plot([2, 2])
+  plt.show()
 
 .. _reset_modules:
 

--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -40,7 +40,7 @@ Example script with invalid Python syntax
 #
 #     b = 2
 INFILE_CONFIG_PATTERN = re.compile(
-    r"^[\ \t]*#\s*sphinx_gallery_([A-Za-z0-9_]+)\s*=\s*(.+)[\ \t]*\n?",
+    r"^[\ \t]*#\s*sphinx_gallery_([A-Za-z0-9_]+)(\s*=\s*(.+))?[\ \t]*\n?",
     re.MULTILINE)
 
 
@@ -137,7 +137,9 @@ def extract_file_config(content):
     file_conf = {}
     for match in re.finditer(INFILE_CONFIG_PATTERN, content):
         name = match.group(1)
-        value = match.group(2)
+        value = match.group(3)
+        if value is None:  # a flag rather than a config setting
+            continue
         try:
             value = ast.literal_eval(value)
         except (SyntaxError, ValueError):

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -23,7 +23,7 @@ from sphinx_gallery.utils import (_get_image, scale_image, _has_optipng,
 
 import pytest
 
-N_TOT = 12
+N_TOT = 13
 
 N_FAILING = 2
 N_GOOD = N_TOT - N_FAILING
@@ -908,3 +908,17 @@ def test_binder_logo_exists(sphinx_app):
     assert 'binder_badge_logo' in img_fname  # can have numbers appended
     assert op.isfile(img_fname)
     assert 'https://mybinder.org/v2/gh/sphinx-gallery/sphinx-gallery.github.io/master?urlpath=lab/tree/notebooks/auto_examples/plot_svg.ipynb' in html  # noqa: E501
+
+
+def test_defer_figures(sphinx_app):
+    """Test the deferring of figures."""
+    root = op.join(sphinx_app.outdir, 'auto_examples')
+    fname = op.join(root, 'plot_defer_figures.html')
+    with codecs.open(fname, 'r', 'utf-8') as fid:
+        html = fid.read()
+
+    # The example has two code blocks with plotting commands, but the first
+    # block has the flag ``sphinx_gallery_defer_figures``.  Thus, there should
+    # be only one image, not two, in the output.
+    assert '../_images/sphx_glr_plot_defer_figures_001.png' in html
+    assert '../_images/sphx_glr_plot_defer_figures_002.png' not in html

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -37,7 +37,8 @@ CONTENT = [
     'And this is a second paragraph',
     '"""',
     '',
-    '# sphinx_gallery_thumbnail_number = 1'
+    '# sphinx_gallery_thumbnail_number = 1',
+    '# sphinx_gallery_defer_figures',
     '# and now comes the module code',
     'import logging',
     'import sys',
@@ -445,10 +446,12 @@ def test_remove_config_comments(gallery_conf, req_pil):
     """Test the gallery_conf['remove_config_comments'] setting."""
     rst = _generate_rst(gallery_conf, 'test.py', CONTENT)
     assert '# sphinx_gallery_thumbnail_number = 1' in rst
+    assert '# sphinx_gallery_defer_figures' in rst
 
     gallery_conf['remove_config_comments'] = True
     rst = _generate_rst(gallery_conf, 'test.py', CONTENT)
     assert '# sphinx_gallery_thumbnail_number = 1' not in rst
+    assert '# sphinx_gallery_defer_figures' not in rst
 
 
 def test_final_empty_block(gallery_conf, req_pil):

--- a/sphinx_gallery/tests/test_py_source_parser.py
+++ b/sphinx_gallery/tests/test_py_source_parser.py
@@ -45,7 +45,10 @@ def test_get_docstring_and_rest(unicode_sample, tmpdir, monkeypatch):
      {'line_numbers': True}),
     ("#sphinx_gallery_thumbnail_number\n=\n5",
      {'thumbnail_number': 5}),
-    ('#sphinx_gallery_thumbnail_number=1foo', None),
+    ("#sphinx_gallery_thumbnail_number=1foo",
+     None),
+    ("# sphinx_gallery_defer_figures",
+     {}),
 ])
 def test_extract_file_config(content, file_conf, log_collector):
     if file_conf is None:
@@ -74,6 +77,8 @@ def test_extract_file_config(content, file_conf, log_collector):
      "a = 1\n\n\nb = 1"),
     ("# comment\n# sphinx_gallery_line_numbers = True\n# commment 2",
      "# comment\n# commment 2"),
+    ("# sphinx_gallery_defer_figures",
+     ""),
 ])
 def test_remove_config_comments(contents, result):
     assert sg.remove_config_comments(contents) == result

--- a/sphinx_gallery/tests/tinybuild/examples/plot_defer_figures.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_defer_figures.py
@@ -1,0 +1,21 @@
+"""
+Test plot deferring
+===================
+
+This tests the ``sphinx_gallery_defer_figures`` flag.
+"""
+
+import matplotlib.pyplot as plt
+
+# %%
+# This code block should produce no plot.
+
+plt.plot([0, 1])
+plt.plot([1, 0])
+# sphinx_gallery_defer_figures
+
+# %%
+# This code block should produce a plot with three lines.
+
+plt.plot([2, 2])
+plt.show()


### PR DESCRIPTION
Closes #363

This PR adds an optional flag for a code block to defer figure scraping to the next code block.  If the code-block executor sees the comment `# sphinx_gallery_defer_figures`, it will not run `save_figures()` to scrape figures, and any figures are left open for the next code block.  Thus, it becomes possible to interleave text blocks between multiple code blocks of plotting commands, with no figures being shown until after the desired code block.

The flag gets stripped out along with the usual config comments (e.g., `# sphinx_gallery_thumbnail_number = N`).

Here's a rendered example:
![defer](https://user-images.githubusercontent.com/991759/111487006-5b8a1500-870e-11eb-949f-74128d142577.png)
where the first code block is:
```python
plt.plot([1,2,3,4,5])
plt.plot([5,4,3,2,1])
# sphinx_gallery_defer_figures
```

This needs documentation and tests, of course, but I wanted feedback first.