### PR TITLE
ENH: add hidpi option to matplotlib_scraper and directive

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -370,6 +370,7 @@ sphinx_gallery_conf = {
     # each code block
     'capture_repr': ('_repr_html_', '__repr__'),
     'matplotlib_animations': True,
+    'image_srcset': ["", "2x"]
 }
 
 # Remove matplotlib agg warnings from generated doc when using plt.show

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -370,7 +370,7 @@ sphinx_gallery_conf = {
     # each code block
     'capture_repr': ('_repr_html_', '__repr__'),
     'matplotlib_animations': True,
-    'image_srcset': ["", "2x"]
+    'image_srcset': ["2x"]
 }
 
 # Remove matplotlib agg warnings from generated doc when using plt.show

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1107,17 +1107,18 @@ Multi-resolution images
 Web browsers allow a ``srcset`` parameter to the ``<img>`` tag that 
 allows the browser to support `responsive resolution images 
 <https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images>`__
-for hi-dpi/retina displays. Sphinx Gallery supports this via the ``image_srcset`` parameter::
+for hi-dpi/retina displays. Sphinx Gallery supports this via the 
+``image_srcset`` parameter::
 
     sphinx_gallery_conf = {
         ...
-        'image_srcset': ["", "2x"],
+        'image_srcset': ["2x"],
     }
 
 that saves a 1x image at the normal figure dpi (usually 100 dpi) and a 2x 
 version at twice the density (e.g. 200 dpi).  The default is no extra images 
-(``'image_srcset': [""]``), and you can specify other resolutions if desired (e.g.
-``"1.5x"``).
+(``'image_srcset': []``), and you can specify other resolutions if desired as a 
+list: ``["2x", "1.5x"]``.
 
 The matplotlib scraper creates a custom image directive, ``image-sg`` in the 
 rst file::
@@ -1127,13 +1128,13 @@ rst file::
         :srcset: /examples/images/sphx_glr_test_001.png, /examples/images/sphx_glr_test_001_2_0x.png 2.0x
         :class: sphx-glr-single-img
 
-Which is converted to html by the custom directive as::
+This is converted to html by the custom directive as::
 
     .. <img src="../_images/sphx_glr_test_001.png" alt="test", class="sphx-glr-single-img", 
         srcset="../_images/sphx_glr_test_001.png, ../_images/sphx_glr_test_001_2_0x.png 2.0x>
 
-This leads to a larger website, but responsive images will only serve the appropriate-sized 
-images to website visitors.
+This leads to a larger website, but clients that support the ``srcset`` tag will only 
+download the appropriate-sized images.
 
 Note that the ``.. image-sg`` directive currently ignores other ``.. image`` directive 
 tags like ``width``, ``height``, and ``align``.  It also only works with the *html* and 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -34,6 +34,7 @@ file:
 - ``image_scrapers`` (and the deprecated ``find_mayavi_figures``)
   (:ref:`image_scrapers`)
 - ``compress_images`` (:ref:`compress_images`)
+- ``image_srcset`` (:ref:`image_srcset`)
 - ``reset_modules`` (:ref:`reset_modules`)
 - ``abort_on_example_error`` (:ref:`abort_on_first`)
 - ``only_warn_on_example_error`` (:ref:`warning_on_error`)
@@ -1097,6 +1098,46 @@ optimize less but speed up the build time you could do::
     }
 
 See ``$ optipng --help`` for a complete list of options.
+
+.. _image_srcset:
+
+Multi-resolution images
+=======================
+
+Web browsers allow a ``srcset`` parameter to the ``<img>`` tag that 
+allows the browser to support `responsive resolution images 
+<https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images>`__
+for hi-dpi/retina displays. Sphinx Gallery supports this via the ``image_srcset`` parameter::
+
+    sphinx_gallery_conf = {
+        ...
+        'image_srcset': ["", "2x"],
+    }
+
+that saves a 1x image at the normal figure dpi (usually 100 dpi) and a 2x 
+version at twice the density (e.g. 200 dpi).  The default is no extra images 
+(``'image_srcset': [""]``), and you can specify other resolutions if desired (e.g.
+``"1.5x"``).
+
+The matplotlib scraper creates a custom image directive, ``image-sg`` in the 
+rst file::
+
+    .. image-sg:: /examples/images/sphx_glr_test_001.png
+        :alt: test
+        :srcset: /examples/images/sphx_glr_test_001.png, /examples/images/sphx_glr_test_001_2_0x.png 2.0x
+        :class: sphx-glr-single-img
+
+Which is converted to html by the custom directive as::
+
+    .. <img src="../_images/sphx_glr_test_001.png" alt="test", class="sphx-glr-single-img", 
+        srcset="../_images/sphx_glr_test_001.png, ../_images/sphx_glr_test_001_2_0x.png 2.0x>
+
+This leads to a larger website, but responsive images will only serve the appropriate-sized 
+images to website visitors.
+
+Note that the ``.. image-sg`` directive currently ignores other ``.. image`` directive 
+tags like ``width``, ``height``, and ``align``.  It also only works with the *html* and 
+*latex*  builders.  
 
 .. _image_scrapers:
 

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -2,11 +2,14 @@
 Custom Sphinx directives
 ========================
 """
-
 import os
+from pathlib import PurePosixPath
+import shutil
 
+from docutils import nodes
 from docutils import statemachine
 from docutils.parsers.rst import Directive, directives
+from docutils.parsers.rst.directives import images
 
 
 class MiniGallery(Directive):
@@ -77,3 +80,198 @@ class MiniGallery(Directive):
         self.state_machine.insert_input(include_lines, path)
 
         return []
+
+
+"""
+Image sg for responsive images
+"""
+
+
+class imgsgnode(nodes.General, nodes.Element):
+    pass
+
+
+def directive_boolean(value):
+    if not value.strip():
+        raise ValueError("No argument provided but required")
+    if value.lower().strip() in ["yes", "1", 1, "true", "ok"]:
+        return True
+    elif value.lower().strip() in ['no', '0', 0, 'false', 'none']:
+        return False
+    else:
+        raise ValueError(u"Please use one of: yes, true, no, false. "
+                         u"Do not use `{}` as boolean.".format(value))
+
+
+class ImageSg(images.Image):
+    """
+    Implements a directive to allow an optional hidpi image.  Meant to be
+    used with the `image_srcset` configuration option.
+
+    e.g.::
+
+        .. image-sg:: /plot_types/basic/images/sphx_glr_bar_001.png
+            :alt: bar
+            :srcset: /plot_types/basic/images/sphx_glr_bar_001.png,
+                     /plot_types/basic/images/sphx_glr_bar_001_2_0x.png 2.0x
+            :class: sphx-glr-single-img
+
+    The resulting html is::
+
+        <img src="sphx_glr_bar_001_hidpi.png"
+            srcset="_images/sphx_glr_bar_001.png,
+                    _images/sphx_glr_bar_001_2_0x.png 2x",
+            alt="bar"
+            class="sphx-glr-single-img" />
+
+    """
+
+    has_content = False
+    required_arguments = 1
+    optional_arguments = 3
+    final_argument_whitespace = False
+    option_spec = {
+        'srcset': directives.unchanged,
+        'class': directives.class_option,
+        'alt': directives.unchanged,
+    }
+
+    def run(self):
+        image_node = imgsgnode()
+
+        imagenm = self.arguments[0]
+        image_node['alt'] = self.options.get('alt', '')
+        image_node['class'] = self.options.get('class', None)
+
+        # we would like uri to be the highest dpi version so that
+        # latex etc will use that.  But for now, lets just make
+        # imagenm
+
+        image_node['uri'] = imagenm
+        image_node['srcset'] = self.options.get('srcset', None)
+
+        return [image_node]
+
+
+def _parse_srcset(st):
+    """ parse st"""
+    entries = st.split(',')
+    srcset = {}
+    for entry in entries:
+        spl = entry.strip().split(' ')
+        if len(spl) == 1:
+            srcset[0] = spl[0]
+        elif len(spl) == 2:
+            mult = spl[1][:-1]
+            srcset[float(mult)] = spl[0]
+    return srcset
+
+
+def visit_imgsg_html(self, node):
+
+    if node['srcset'] is None:
+        self.visit_image(node)
+        return
+
+    imagedir, srcset = _copy_images(self, node)
+
+    # /doc/examples/subd/plot_1.rst
+    docsource = self.document['source']
+    # /doc/
+    # make sure to add the trailing slash:
+    srctop = os.path.join(self.builder.srcdir, '')
+    # examples/subd/plot_1.rst
+    relsource = os.path.relpath(docsource, srctop)
+    # /doc/build/html
+    desttop = os.path.join(self.builder.outdir, '')
+    # /doc/build/html/examples/subd
+    dest = os.path.join(desttop, relsource)
+
+    # ../../_images/
+    imagerel = os.path.relpath(imagedir, os.path.dirname(dest))
+    imagerel = os.path.join(imagerel, '')
+    if '\\' in imagerel:
+        imagerel = imagerel.replace('\\', '/')
+    # make srcset str.  Need to change all the prefixes!
+    srcsetst = ''
+    for mult in srcset:
+        nm = os.path.basename(srcset[mult][1:])
+        # ../../_images/plot_1_2_0x.png
+        relpath = imagerel+nm
+        srcsetst += f'{relpath}'
+        if mult == 0:
+            srcsetst += ', '
+        else:
+            srcsetst += f' {mult:1.1f}x, '
+    # trim trailing comma and space...
+    srcsetst = srcsetst[:-2]
+
+    # make uri also be relative...
+    nm = os.path.basename(node['uri'][1:])
+    uri = imagerel + nm
+
+    alt = node['alt']
+    if node['class'] is not None:
+        classst = node['class'][0]
+        classst = f'class = "{classst}"'
+    else:
+        classst = ''
+
+    html_block = (f'<img src="{uri}" srcset="{srcsetst}" alt="{alt}"' +
+                  f' {classst}/>')
+    self.body.append(html_block)
+
+
+def visit_imgsg_latex(self, node):
+
+    if node['srcset'] is not None:
+        imagedir, srcset = _copy_images(self, node)
+        maxmult = -1
+        # choose the highest res version for latex:
+        for key in srcset.keys():
+            maxmult = max(maxmult, key)
+        node['uri'] = str(PurePosixPath(srcset[maxmult]).name)
+
+    self.visit_image(node)
+
+
+def _copy_images(self, node):
+    srcset = _parse_srcset(node['srcset'])
+
+    # where the sources are.  i.e. myproj/source
+    srctop = self.builder.srcdir
+
+    # copy image from source to imagedir.  This is
+    # *probably* supposed to be done by a builder but...
+    # ie myproj/build/html/_images
+    imagedir = os.path.join(self.builder.imagedir, '')
+    imagedir = PurePosixPath(self.builder.outdir, imagedir)
+
+    os.makedirs(imagedir, exist_ok=True)
+
+    # copy all the sources to the imagedir:
+    for mult in srcset:
+        abspath = PurePosixPath(srctop, srcset[mult][1:])
+        shutil.copyfile(abspath, imagedir / abspath.name)
+
+    return imagedir, srcset
+
+
+def depart_imgsg_html(self, node):
+    pass
+
+
+def visit_sg_other(self, node):
+    if node['uri'][0] == '/':
+        node['uri'] = node['uri'][1:]
+    self.visit_image(node)
+
+
+def depart_imgsg_latex(self, node):
+    self.depart_image(node)
+
+
+def imagesg_addnode(app):
+    app.add_node(imgsgnode,
+                 html=(visit_imgsg_html, depart_imgsg_html),
+                 latex=(visit_imgsg_latex, depart_imgsg_latex))

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -11,6 +11,8 @@ from docutils import statemachine
 from docutils.parsers.rst import Directive, directives
 from docutils.parsers.rst.directives import images
 
+from sphinx.errors import ExtensionError
+
 
 class MiniGallery(Directive):
     """
@@ -164,6 +166,8 @@ def _parse_srcset(st):
         elif len(spl) == 2:
             mult = spl[1][:-1]
             srcset[float(mult)] = spl[0]
+        else:
+            raise ExtensionError('srcset argument "{entry}" is invalid.')
     return srcset
 
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -33,7 +33,7 @@ from .docs_resolv import embed_code_links
 from .downloads import generate_zipfiles
 from .sorting import NumberOfCodeLinesSortKey
 from .binder import copy_binder_files, check_binder_conf
-from .directives import MiniGallery
+from .directives import MiniGallery, ImageSg, imagesg_addnode
 
 
 _KNOWN_CSS = ('gallery', 'gallery-binder', 'gallery-dataframe',
@@ -93,6 +93,7 @@ DEFAULT_GALLERY_CONF = {
     'inspect_global_variables': True,
     'css': _KNOWN_CSS,
     'matplotlib_animations': False,
+    'image_srcset': [""],
     'default_thumb_file': None,
     'line_numbers': False,
 }
@@ -785,6 +786,9 @@ def setup(app):
 
     # Add the custom directive
     app.add_directive('minigallery', MiniGallery)
+    app.add_directive("image-sg", ImageSg)
+
+    imagesg_addnode(app)
 
     app.connect('builder-inited', generate_gallery_rst)
     app.connect('build-finished', copy_binder_files)

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -93,7 +93,7 @@ DEFAULT_GALLERY_CONF = {
     'inspect_global_variables': True,
     'css': _KNOWN_CSS,
     'matplotlib_animations': False,
-    'image_srcset': [""],
+    'image_srcset': [],
     'default_thumb_file': None,
     'line_numbers': False,
 }

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -114,15 +114,19 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
     image_path_iterator = block_vars['image_path_iterator']
     image_rsts = []
     # Check for srcset hidpi images
-    srcset = gallery_conf.get('image_srcset', [""])
-    srcset_mult_facs = []
+    srcset = gallery_conf.get('image_srcset', [])
+    srcset_mult_facs = [1]  # one is always supplied...
     for st in srcset:
         if (len(st) > 0) and (st[-1] == 'x'):
             # "2x" = "2.0"
             srcset_mult_facs += [float(st[:-1])]
+        elif st == "":
+            pass
         else:
-            # "" = "1"
-            srcset_mult_facs += [1]
+            raise ExtensionError(
+                f'Invalid value for image_srcset parameter: "{st}". '
+                'Must be a list of strings with the multiplicative '
+                'factor followed by an "x".  e.g. ["2.0x", "1.5x"]')
 
     # Check for animations
     anims = list()
@@ -524,6 +528,13 @@ SG_IMAGE = """
    :alt: %s
    :srcset: %s
    :class: sphx-glr-single-img
+"""
+
+# keep around for back-compat:
+SINGLE_IMAGE = """
+ .. image:: /%s
+     :alt: %s
+     :class: sphx-glr-single-img
 """
 
 ###############################################################################

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -8,7 +8,9 @@ Scrapers for embedding images
 Collect images that have been produced by code blocks.
 
 The only scrapers we support are Matplotlib and Mayavi, others should
-live in modules that will support them (e.g., PyVista, Plotly).
+live in modules that will support them (e.g., PyVista, Plotly).  Scraped
+images are injected as rst ``image-sg`` directives into the ``.rst``
+file generated for each example script.
 """
 
 import os
@@ -16,6 +18,7 @@ import sys
 import re
 from distutils.version import LooseVersion
 from textwrap import indent
+from pathlib import PurePosixPath
 from warnings import filterwarnings
 
 from sphinx.errors import ExtensionError
@@ -110,6 +113,17 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
     from matplotlib.animation import Animation
     image_path_iterator = block_vars['image_path_iterator']
     image_rsts = []
+    # Check for srcset hidpi images
+    srcset = gallery_conf.get('image_srcset', [""])
+    srcset_mult_facs = []
+    for st in srcset:
+        if (len(st) > 0) and (st[-1] == 'x'):
+            # "2x" = "2.0"
+            srcset_mult_facs += [float(st[:-1])]
+        else:
+            # "" = "1"
+            srcset_mult_facs += [1]
+
     # Check for animations
     anims = list()
     if gallery_conf.get('matplotlib_animations', False):
@@ -118,9 +132,9 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
                 anims.append(ani)
     # Then standard images
     for fig_num, image_path in zip(plt.get_fignums(), image_path_iterator):
+        image_path = PurePosixPath(image_path)
         if 'format' in kwargs:
-            image_path = '%s.%s' % (os.path.splitext(image_path)[0],
-                                    kwargs['format'])
+            image_path = image_path.with_suffix('.' + kwargs['format'])
         # Set the fig_num figure as the current figure as we can't
         # save a figure that's not the current figure.
         fig = plt.figure(fig_num)
@@ -128,7 +142,8 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
         cont = False
         for anim in anims:
             if anim._fig is fig:
-                image_rsts.append(_anim_rst(anim, image_path, gallery_conf))
+                image_rsts.append(_anim_rst(anim,
+                                            str(image_path), gallery_conf))
                 cont = True
                 break
         if cont:
@@ -145,15 +160,40 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
             if to_rgba(fig_attr) != to_rgba(default_attr) and \
                     attr not in kwargs:
                 these_kwargs[attr] = fig_attr
+
+        # save the figures, and populate the srcsetpaths
         try:
             fig.savefig(image_path, **these_kwargs)
+            dpi0 = matplotlib.rcParams['savefig.dpi']
+            if dpi0 == 'figure':
+                dpi0 = fig.dpi
+            dpi0 = these_kwargs.get('dpi', dpi0)
+            srcsetpaths = {0: image_path}
+
+            # save other srcset paths, keyed by multiplication factor:
+            for mult in srcset_mult_facs:
+                if not (mult == 1):
+                    multst = f'{mult}'.replace('.', '_')
+                    name = f"{image_path.stem}_{multst}x{image_path.suffix}"
+                    hipath = image_path.parent / PurePosixPath(name)
+                    hikwargs = these_kwargs.copy()
+                    hikwargs['dpi'] = mult * dpi0
+                    fig.savefig(hipath, **hikwargs)
+                    srcsetpaths[mult] = hipath
+            srcsetpaths = [srcsetpaths]
         except Exception:
             plt.close('all')
             raise
+
         if 'images' in gallery_conf['compress_images']:
-            optipng(image_path, gallery_conf['compress_images_args'])
+            optipng(str(image_path), gallery_conf['compress_images_args'])
+            for hipath in srcsetpaths[0].items():
+                optipng(str(hipath), gallery_conf['compress_images_args'])
+
         image_rsts.append(
-            figure_rst([image_path], gallery_conf['src_dir'], fig_titles))
+            figure_rst([image_path], gallery_conf['src_dir'], fig_titles,
+                       srcsetpaths=srcsetpaths))
+
     plt.close('all')
     rst = ''
     if len(image_rsts) == 1:
@@ -347,7 +387,7 @@ def save_figures(block, block_vars, gallery_conf):
     return all_rst
 
 
-def figure_rst(figure_list, sources_dir, fig_titles=''):
+def figure_rst(figure_list, sources_dir, fig_titles='', srcsetpaths=None):
     """Generate RST for a list of image filenames.
 
     Depending on whether we have one or more figures, we use a
@@ -362,16 +402,36 @@ def figure_rst(figure_list, sources_dir, fig_titles=''):
     fig_titles : str
         Titles of figures, empty string if no titles found. Currently
         only supported for matplotlib figures, default = ''.
+    srcsetpaths : list or None
+        List of dictionaries containing absolute paths.  If
+        empty, then srcset field is populated with the figure path.
+        (see ``image_srcset`` configuration option).  Otherwise,
+        each dict is of the form
+        {0: /images/image.png, 2.0: /images/image_2_0x.png}
+        where the key is the multiplication factor and the contents
+        the path to the image created above.
 
     Returns
     -------
     images_rst : str
         rst code to embed the images in the document
+
+    The rst code will have a custom ``image-sg`` directive that allows
+    multiple resolution images to be served e.g.:
+    ``:srcset: /plot_types/imgs/img_001.png,
+      /plot_types/imgs/img_2_0x.png 2.0x``
+
     """
+
+    if srcsetpaths is None:
+        # this should never happen, but figure_rst is public, so
+        # this has to be a kwarg...
+        srcsetpaths = [{0: fl} for fl in figure_list]
 
     figure_paths = [os.path.relpath(figure_path, sources_dir)
                     .replace(os.sep, '/').lstrip('/')
                     for figure_path in figure_list]
+
     # Get alt text
     alt = ''
     if fig_titles:
@@ -388,12 +448,47 @@ def figure_rst(figure_list, sources_dir, fig_titles=''):
     images_rst = ""
     if len(figure_paths) == 1:
         figure_name = figure_paths[0]
-        images_rst = SINGLE_IMAGE % (figure_name, alt)
+        hinames = srcsetpaths[0]
+        srcset = _get_srcset_st(sources_dir, hinames)
+        images_rst = SG_IMAGE % (figure_name, alt, srcset)
+
     elif len(figure_paths) > 1:
         images_rst = HLIST_HEADER
-        for figure_name in figure_paths:
-            images_rst += HLIST_IMAGE_TEMPLATE % (figure_name, alt)
+        for nn, figure_name in enumerate(figure_paths):
+            hinames = srcsetpaths[nn]
+            srcset = _get_srcset_st(sources_dir, hinames)
+
+            images_rst += (HLIST_SG_TEMPLATE %
+                           (figure_name, alt, srcset))
+
     return images_rst
+
+
+def _get_srcset_st(sources_dir, hinames):
+    """
+    Create the srcset string for including on the rst line.
+    ie. sources_dir might be /home/sample-proj/source,
+    hinames posix paths to
+    0: /home/sample-proj/source/plot_types/images/img1.png,
+    2.0: /home/sample-proj/source/plot_types/images/img1_2_0x.png,
+    The result will be:
+    '/plot_types/basic/images/sphx_glr_pie_001.png,
+    /plot_types/basic/images/sphx_glr_pie_001_2_0x.png 2.0x'
+    """
+    srcst = ''
+    for k in hinames.keys():
+        path = os.path.relpath(hinames[k],
+                               sources_dir).replace(os.sep, '/').lstrip('/')
+        srcst += '/' + path
+        if k == 0:
+            srcst += ', '
+        else:
+            srcst += f' {k:1.1f}x, '
+    if srcst[-2:] == ', ':
+        srcst = srcst[:-2]
+    srcst += ''
+
+    return srcst
 
 
 def _single_line_sanitize(s):
@@ -415,23 +510,25 @@ HLIST_IMAGE_MATPLOTLIB = """
     *
 """
 
-HLIST_IMAGE_TEMPLATE = """
+HLIST_SG_TEMPLATE = """
     *
 
-      .. image:: /%s
+      .. image-sg:: /%s
           :alt: %s
+          :srcset: %s
           :class: sphx-glr-multi-img
 """
 
-SINGLE_IMAGE = """
-.. image:: /%s
-    :alt: %s
-    :class: sphx-glr-single-img
+SG_IMAGE = """
+.. image-sg:: /%s
+   :alt: %s
+   :srcset: %s
+   :class: sphx-glr-single-img
 """
-
 
 ###############################################################################
 # Module resetting
+
 
 def _reset_matplotlib(gallery_conf, fname):
     """Reset matplotlib."""

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -236,11 +236,20 @@ def test_image_formats(sphinx_app):
         with codecs.open(html_fname, 'r', 'utf-8') as fid:
             html = fid.read()
         for num in nums:
-            img_fname = '../_images/sphx_glr_%s_%03d.%s' % (ex, num, ext)
-            file_fname = op.join(generated_examples_dir, img_fname)
+            img_fname0 = '../_images/sphx_glr_%s_%03d.%s' % (ex, num, ext)
+            file_fname = op.join(generated_examples_dir, img_fname0)
             assert op.isfile(file_fname), file_fname
-            want_html = 'src="%s"' % (img_fname,)
+            want_html = 'src="%s"' % (img_fname0,)
             assert want_html in html
+            if ext in ('png', 'jpg'):  # check 2.0x file.  tests the directive
+                img_fname2 = ('../_images/sphx_glr_%s_%03d_2_0x.%s' %
+                              (ex, num, ext))
+                file_fname2 = op.join(generated_examples_dir, img_fname2)
+                assert op.isfile(file_fname2), file_fname2
+
+                want_html = 'srcset="%s, %s 2.0x"' % (img_fname0, img_fname2)
+                assert want_html in html
+
         if extra is not None:
             assert extra in html
 

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -241,13 +241,12 @@ def test_image_formats(sphinx_app):
             assert op.isfile(file_fname), file_fname
             want_html = 'src="%s"' % (img_fname0,)
             assert want_html in html
-            if ext in ('png', 'jpg'):  # check 2.0x file.  tests the directive
-                img_fname2 = ('../_images/sphx_glr_%s_%03d_2_0x.%s' %
-                              (ex, num, ext))
-                file_fname2 = op.join(generated_examples_dir, img_fname2)
+            img_fname2 = ('../_images/sphx_glr_%s_%03d_2_0x.%s' %
+                          (ex, num, ext))
+            file_fname2 = op.join(generated_examples_dir, img_fname2)
+            want_html = 'srcset="%s, %s 2.0x"' % (img_fname0, img_fname2)
+            if ext in ('png', 'jpg', 'svg'):  # check 2.0x (tests directive)
                 assert op.isfile(file_fname2), file_fname2
-
-                want_html = 'srcset="%s, %s 2.0x"' % (img_fname0, img_fname2)
                 assert want_html in html
 
         if extra is not None:

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -5,7 +5,7 @@ import pytest
 from sphinx.errors import ConfigError, ExtensionError
 import sphinx_gallery
 from sphinx_gallery.gen_gallery import _complete_gallery_conf
-from sphinx_gallery.scrapers import (figure_rst, mayavi_scraper, SINGLE_IMAGE,
+from sphinx_gallery.scrapers import (figure_rst, mayavi_scraper, SG_IMAGE,
                                      matplotlib_scraper, ImagePathIterator,
                                      save_figures, _KNOWN_IMG_EXTS)
 from sphinx_gallery.utils import _get_image
@@ -32,7 +32,7 @@ class matplotlib_svg_scraper():
 
 
 @pytest.mark.parametrize('ext', ('png', 'svg'))
-def test_save_matplotlib_figures(gallery_conf, ext, req_mpl, req_pil):
+def test_save_matplotlib_figures(gallery_conf, ext):
     """Test matplotlib figure save."""
     if ext == 'svg':
         gallery_conf['image_scrapers'] = (matplotlib_svg_scraper(),)
@@ -59,6 +59,50 @@ def test_save_matplotlib_figures(gallery_conf, ext, req_mpl, req_pil):
     assert len(image_path_iterator) == 5
     for ii in range(4, 6):
         fname = '/image{0}.{1}'.format(ii, ext)
+        assert fname in image_rst
+        fname = gallery_conf['gallery_dir'] + fname
+        assert os.path.isfile(fname)
+
+
+def test_save_matplotlib_figures_hidpi(gallery_conf):
+    """Test matplotlib hidpi figure save."""
+    ext = 'png'
+    gallery_conf['image_srcset'] = ["", "2x"]
+
+    import matplotlib.pyplot as plt  # nest these so that Agg can be set
+    plt.plot(1, 1)
+    fname_template = os.path.join(gallery_conf['gallery_dir'], 'image{0}.png')
+    image_path_iterator = ImagePathIterator(fname_template)
+    block = ('',) * 3
+    block_vars = dict(image_path_iterator=image_path_iterator)
+    image_rst = save_figures(block, block_vars, gallery_conf)
+
+    fname = f'/image1.{ext}'
+    assert fname in image_rst
+    assert f'/image1_2_0x.{ext} 2.0x' in image_rst
+
+    assert len(image_path_iterator) == 1
+    fname = gallery_conf['gallery_dir'] + fname
+    fnamehi = gallery_conf['gallery_dir'] + f'/image1_2_0x.{ext}'
+
+    assert os.path.isfile(fname)
+    assert os.path.isfile(fnamehi)
+
+    # Test capturing 2 images with shifted start number
+    image_path_iterator.next()
+    image_path_iterator.next()
+    plt.plot(1, 1)
+    plt.figure()
+    plt.plot(1, 1)
+    image_rst = save_figures(block, block_vars, gallery_conf)
+    assert len(image_path_iterator) == 5
+    for ii in range(4, 6):
+        fname = f'/image{ii}.{ext}'
+        assert fname in image_rst
+
+        fname = gallery_conf['gallery_dir'] + fname
+        assert os.path.isfile(fname)
+        fname = f'/image{ii}_2_0x.{ext}'
         assert fname in image_rst
         fname = gallery_conf['gallery_dir'] + fname
         assert os.path.isfile(fname)
@@ -178,38 +222,87 @@ def test_figure_rst(ext):
     """Testing rst of images"""
     figure_list = ['sphx_glr_plot_1.' + ext]
     image_rst = figure_rst(figure_list, '.')
-    single_image = """
-.. image:: /sphx_glr_plot_1.{ext}
-    :alt: pl
-    :class: sphx-glr-single-img
-""".format(ext=ext)
+    single_image = f"""
+.. image-sg:: /sphx_glr_plot_1.{ext}
+   :alt: pl
+   :srcset: /sphx_glr_plot_1.{ext}
+   :class: sphx-glr-single-img
+"""
     assert image_rst == single_image
 
     image_rst = figure_rst(figure_list + ['second.' + ext], '.')
 
-    image_list_rst = """
+    image_list_rst = f"""
 .. rst-class:: sphx-glr-horizontal
 
 
     *
 
-      .. image:: /sphx_glr_plot_1.{ext}
+      .. image-sg:: /sphx_glr_plot_1.{ext}
           :alt: pl
+          :srcset: /sphx_glr_plot_1.{ext}
           :class: sphx-glr-multi-img
 
     *
 
-      .. image:: /second.{ext}
+      .. image-sg:: /second.{ext}
           :alt: pl
+          :srcset: /second.{ext}
           :class: sphx-glr-multi-img
-""".format(ext=ext)
+"""
     assert image_rst == image_list_rst
 
     # test issue #229
     local_img = [os.path.join(os.getcwd(), 'third.' + ext)]
     image_rst = figure_rst(local_img, '.')
 
-    single_image = SINGLE_IMAGE % ("third." + ext, '')
+    single_image = SG_IMAGE % ("third." + ext, '', "/third." + ext)
+    assert image_rst == single_image
+
+
+@pytest.mark.parametrize('ext', ['png'])
+def test_figure_rst_srcset(ext):
+    """Testing rst of images"""
+    figure_list = ['sphx_glr_plot_1.' + ext]
+    hipaths = [{0: 'sphx_glr_plot_1.png', 2.0: 'sphx_glr_plot_1_2_0.png'}]
+    image_rst = figure_rst(figure_list, '.', srcsetpaths=hipaths)
+    single_image = f"""
+.. image-sg:: /sphx_glr_plot_1.{ext}
+   :alt: pl
+   :srcset: /sphx_glr_plot_1.{ext}, /sphx_glr_plot_1_2_0.{ext} 2.0x
+   :class: sphx-glr-single-img
+"""
+    assert image_rst == single_image
+
+    hipaths += [{0: 'second.png', 2.0: 'second_2_0.png'}]
+    image_rst = figure_rst(figure_list + ['second.' + ext], '.',
+                           srcsetpaths=hipaths+[])
+
+    image_list_rst = f"""
+.. rst-class:: sphx-glr-horizontal
+
+
+    *
+
+      .. image-sg:: /sphx_glr_plot_1.{ext}
+          :alt: pl
+          :srcset: /sphx_glr_plot_1.png, /sphx_glr_plot_1_2_0.png 2.0x
+          :class: sphx-glr-multi-img
+
+    *
+
+      .. image-sg:: /second.{ext}
+          :alt: pl
+          :srcset: /second.{ext}, /second_2_0.{ext} 2.0x
+          :class: sphx-glr-multi-img
+"""
+    assert image_rst == image_list_rst
+
+    # test issue #229
+    local_img = [os.path.join(os.getcwd(), 'third.' + ext)]
+    image_rst = figure_rst(local_img, '.')
+
+    single_image = SG_IMAGE % ("third." + ext, '', "/third." + ext)
     assert image_rst == single_image
 
 

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -67,7 +67,7 @@ def test_save_matplotlib_figures(gallery_conf, ext):
 def test_save_matplotlib_figures_hidpi(gallery_conf):
     """Test matplotlib hidpi figure save."""
     ext = 'png'
-    gallery_conf['image_srcset'] = ["", "2x"]
+    gallery_conf['image_srcset'] = ["2x"]
 
     import matplotlib.pyplot as plt  # nest these so that Agg can be set
     plt.plot(1, 1)

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -93,6 +93,7 @@ sphinx_gallery_conf = {
     'junit': op.join('sphinx-gallery', 'junit-results.xml'),
     'matplotlib_animations': True,
     'pypandoc': True,
+    'image_srcset': ["", "2x"]
 }
 nitpicky = True
 highlight_language = 'python3'

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -93,7 +93,7 @@ sphinx_gallery_conf = {
     'junit': op.join('sphinx-gallery', 'junit-results.xml'),
     'matplotlib_animations': True,
     'pypandoc': True,
-    'image_srcset': ["", "2x"]
+    'image_srcset': ["2x"]
 }
 nitpicky = True
 highlight_language = 'python3'


### PR DESCRIPTION
### Motivation

Right now, at least at Matplotlib.org, all images are 100 dpi, and 200 dpi images look bad on hi-dpi monitors.  We could save 200 dpi and scale, but that was deemed problematic.  The "proper" solution is to serve images with the `srcset` option and let the client browser decide what to download: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images

This PR implements this for the matplotlib scraper.  Of course this requires a new directive as well.  

### Solution

The PR adds a `image_srcset=["", "2x"]` configuration option that causes the matplotlib scraper to save two (or more) files, the usual image, and a dpi=200 (or other dpi, i.e. `image_srcset=["", "2x", "3x"]`) version that gets named `filename_2_0.png`.  It then adds a new directive to the gallery rst:

```rst
.. image-srcset:: /gallery/subdir/filename.png
   :alt: filename
   :srcset: /gallery/subdir/filename.png, /gallery/subdir/filename_2_0.png 2.0x, 
   :class: sphx-glr-single-img
```

The second part implements this new directive to create an html as:

```html
<img srcset="/gallery/subdir/filename.png, /gallery/subdir/filename_2_0.png 2.0x", src="/gallery/subdir/filename.png", 
  class="sphx-glr-single-img", alt="filename">
```

This needs tests and documentation, but I thought I'd share now to get feedback.  

- [x] tests
- [x] docs
