### PR TITLE
ENH: Only add minigallery if there's something to show

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -444,7 +444,8 @@ The ``add-heading`` option adds a heading for the mini-gallery, which will be a
 default generated message if no string is provided as an argument.  The example
 mini-gallery shown above uses the default heading.  The level of the heading
 defaults to ``^``, but can be changed using the ``heading-level`` option, which
-accepts a single character (e.g., ``-``).
+accepts a single character (e.g., ``-``). The mini-gallery will only be shown
+if the item (here ``numpy.exp``) is actually used in an example.
 
 You can also list multiple items, separated by spaces, which will merge all
 examples into a single mini-gallery, e.g.:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -445,7 +445,7 @@ default generated message if no string is provided as an argument.  The example
 mini-gallery shown above uses the default heading.  The level of the heading
 defaults to ``^``, but can be changed using the ``heading-level`` option, which
 accepts a single character (e.g., ``-``). The mini-gallery will only be shown
-if the item (here ``numpy.exp``) is actually used in an example.
+if the item (here ``numpy.exp``) is actually used or referred to in an example.
 
 You can also list multiple items, separated by spaces, which will merge all
 examples into a single mini-gallery, e.g.:

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -58,12 +58,12 @@ class MiniGallery(Directive):
             heading_level = self.options.get('heading-level', '^')
             lines.append(heading_level * len(heading))
 
-        def should_show(obj):
-            # TODO: get the path in a cleaner and more robust way
-            path = os.path.abspath(os.path.join("source", backreferences_dir, '{}.examples'.format(obj)))
+        def has_backrefs(obj):
+            src_dir = config.sphinx_gallery_conf['src_dir']
+            path = os.path.join(src_dir, backreferences_dir, '{}.examples'.format(obj))
             return os.path.isfile(path) and os.path.getsize(path) > 0
 
-        if not any(should_show(obj) for obj in obj_list):
+        if not any(has_backrefs(obj) for obj in obj_list):
             return []
 
         # Insert the backreferences file(s) using the `include` directive

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -60,7 +60,8 @@ class MiniGallery(Directive):
 
         def has_backrefs(obj):
             src_dir = config.sphinx_gallery_conf['src_dir']
-            path = os.path.join(src_dir, backreferences_dir, '{}.examples'.format(obj))
+            path = os.path.join(src_dir, backreferences_dir,
+                                '{}.examples'.format(obj))
             return os.path.isfile(path) and os.path.getsize(path) > 0
 
         if not any(has_backrefs(obj) for obj in obj_list):

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -58,6 +58,14 @@ class MiniGallery(Directive):
             heading_level = self.options.get('heading-level', '^')
             lines.append(heading_level * len(heading))
 
+        def should_show(obj):
+            # TODO: get the path in a cleaner and more robust way
+            path = os.path.abspath(os.path.join("source", backreferences_dir, '{}.examples'.format(obj)))
+            return os.path.isfile(path) and os.path.getsize(path) > 0
+
+        if not any(should_show(obj) for obj in obj_list):
+            return []
+
         # Insert the backreferences file(s) using the `include` directive
         for obj in obj_list:
             path = os.path.join('/',  # Sphinx treats this as the source dir


### PR DESCRIPTION
Closes https://github.com/sphinx-gallery/sphinx-gallery/issues/812

This PR avoids showing the minigallery if there's no example using the object. It's probably too hacky for inclusion as-is but I'm not sure how to best proceed, so I'd be happy to address any feeback :)