### PR TITLE
DOC Include SOURCEDIR in Makefile

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -42,7 +42,7 @@ example takes a long time to run), add the following to your ``Makefile``.
 .. code-block:: bash
 
     html-noplot:
-            $(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+            $(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html
             @echo
             @echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
I think the `SOURCEDIR` variable is missing from the suggested Makefile in the docs. Running it as-is was raising an error for me:

```
usage: sphinx-build [OPTIONS] SOURCEDIR OUTPUTDIR [FILENAMES...]
sphinx-build: error: the following arguments are required: outputdir, filenames
```