### PR TITLE
ENH Add config that generates dummy images to prevent missing image warnings

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -54,7 +54,7 @@ Some options can also be set or overridden on a file-by-file basis:
 - ``# sphinx_gallery_line_numbers`` (:ref:`adding_line_numbers`)
 - ``# sphinx_gallery_thumbnail_number`` (:ref:`choosing_thumbnail`)
 - ``# sphinx_gallery_thumbnail_path`` (:ref:`providing_thumbnail`)
-- ``# sphinx_gallery_dummy_image`` (:ref:`dummy_images`)
+- ``# sphinx_gallery_dummy_images`` (:ref:`dummy_images`)
 
 Some options can be set on a per-code-block basis in a file:
 
@@ -1233,7 +1233,7 @@ which you then reference manually elsewhere, e.g.,:
 To prevent missing image file warnings when building without executing, you
 can add the following to the example file::
 
-    # sphinx_gallery_dummy_image=2
+    # sphinx_gallery_dummy_images=2
 
 This will cause Sphinx-Gallery to generate 2 dummy images with the same
 naming convention and stored in the same location as images that would be
@@ -1241,7 +1241,7 @@ generated when building with execution.
 
 .. note::
     This configuration **only** works when ``plot_gallery`` is False. This
-    means that you will not need to remove any ``sphinx_gallery_dummy_image``
+    means that you will not need to remove any ``sphinx_gallery_dummy_images``
     lines in your examples when you switch to building your gallery with
     execution.
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1211,11 +1211,12 @@ Generating dummy images
 =======================
 
 For quick visualization of your gallery, especially during the writing process,
-Sphinx-Gallery allows you to build your gallery without executing any of the
-code (see :ref:`without_execution`). This however, can cause warnings about
-missing image files if you have manually written links to automatically
-generated images. To prevent these warnings you can tell Sphinx-Gallery to
-create a number of dummy images for an example.
+Sphinx-Gallery allows you to build your gallery without executing the
+code (see :ref:`without_execution` and
+:ref:`filename/ignore patterns <build_pattern>`). This however,
+can cause warnings about missing image files if you have manually written
+links to automatically generated images. To prevent these warnings you can
+tell Sphinx-Gallery to create a number of dummy images for an example.
 
 For example, you may have an example ('my_example.py') that generates 2 figures,
 which you then reference manually elsewhere, e.g.,:
@@ -1240,10 +1241,12 @@ naming convention and stored in the same location as images that would be
 generated when building with execution.
 
 .. note::
-    This configuration **only** works when ``plot_gallery`` is False. This
-    means that you will not need to remove any ``sphinx_gallery_dummy_images``
-    lines in your examples when you switch to building your gallery with
-    execution.
+    This configuration **only** works when the example is set to not execute
+    (i.e., the ``plot_gallery`` is False, the example is in `ignore_pattern`
+    or the example is not in `filename_pattern - see
+    :ref:`filename/ignore patterns <build_pattern>`). This means that you will
+    not need to remove any ``sphinx_gallery_dummy_images`` lines in your
+    examples when you switch to building your gallery with execution.
 
 .. _reset_modules:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1238,7 +1238,9 @@ can add the following to the example file::
 
 This will cause Sphinx-Gallery to generate 2 dummy images with the same
 naming convention and stored in the same location as images that would be
-generated when building with execution.
+generated when building with execution. No dummy images will be generated
+if there are existing images (e.g., from a previous run of the build),
+so they will not be overwritten.
 
 .. note::
     This configuration **only** works when the example is set to not execute

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -54,6 +54,7 @@ Some options can also be set or overridden on a file-by-file basis:
 - ``# sphinx_gallery_line_numbers`` (:ref:`adding_line_numbers`)
 - ``# sphinx_gallery_thumbnail_number`` (:ref:`choosing_thumbnail`)
 - ``# sphinx_gallery_thumbnail_path`` (:ref:`providing_thumbnail`)
+- ``# sphinx_gallery_dummy_image`` (:ref:`dummy_images`)
 
 Some options can be set on a per-code-block basis in a file:
 
@@ -1203,6 +1204,46 @@ further deferred, if desired).  The following produces only one plot::
 
   plt.plot([2, 2])
   plt.show()
+
+.. _dummy_images:
+
+Generating dummy images
+=======================
+
+For quick visualization of your gallery, especially during the writing process,
+Sphinx-Gallery allows you to build your gallery without executing any of the
+code (see :ref:`without_execution`). This however, can cause warnings about
+missing image files if you have manually written links to automatically
+generated images. To prevent these warnings you can tell Sphinx-Gallery to
+create a number of dummy images for an example.
+
+For example, you may have an example ('my_example.py') that generates 2 figures,
+which you then reference manually elsewhere, e.g.,:
+
+.. code-block:: rst
+
+    Below is a great figure:
+
+    .. figure:: ../auto_examples/images/sphx_glr_my_example_001.png
+
+    Here is another one:
+
+    .. figure:: ../auto_examples/images/sphx_glr_my_example_002.png
+
+To prevent missing image file warnings when building without executing, you
+can add the following to the example file::
+
+    # sphinx_gallery_dummy_image=2
+
+This will cause Sphinx-Gallery to generate 2 dummy images with the same
+naming convention and stored in the same location as images that would be
+generated when building with execution.
+
+.. note::
+    This configuration **only** works when ``plot_gallery`` is False. This
+    means that you will not need to remove any ``sphinx_gallery_dummy_image``
+    lines in your examples when you switch to building your gallery with
+    execution.
 
 .. _reset_modules:
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -877,7 +877,8 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
             image_path_iterator = script_vars['image_path_iterator']
             stock_img = os.path.join(glr_path_static(), 'no_image.png')
             for _, path in zip(range(dummy_image), image_path_iterator):
-                copyfile(stock_img, path)
+                if not os.path.isfile(path):
+                    copyfile(stock_img, path)
 
     if gallery_conf['remove_config_comments']:
         script_blocks = [

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -866,17 +866,18 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
     logger.debug("%s ran in : %.2g seconds\n", src_file, time_elapsed)
 
     # Create dummy images
-    dummy_image = file_conf.get('dummy_image', None)
-    if dummy_image is not None:
-        if type(dummy_image) is not int:
-            raise ExtensionError(
-                'sphinx_gallery_dummy_image setting is not a number, '
-                'got %r' % (dummy_image,))
+    if not executable:
+        dummy_image = file_conf.get('dummy_image', None)
+        if dummy_image is not None:
+            if type(dummy_image) is not int:
+                raise ExtensionError(
+                    'sphinx_gallery_dummy_image setting is not a number, '
+                    'got %r' % (dummy_image,))
 
-        image_path_iterator = script_vars['image_path_iterator']
-        stock_img = os.path.join(glr_path_static(), 'no_image.png')
-        for _, path in zip(range(dummy_image), image_path_iterator):
-            copyfile(stock_img, path)
+            image_path_iterator = script_vars['image_path_iterator']
+            stock_img = os.path.join(glr_path_static(), 'no_image.png')
+            for _, path in zip(range(dummy_image), image_path_iterator):
+                copyfile(stock_img, path)
 
     if gallery_conf['remove_config_comments']:
         script_blocks = [

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -876,8 +876,6 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
         image_path_iterator = script_vars['image_path_iterator']
         stock_img = os.path.join(glr_path_static(), 'no_image.png')
         for _, path in zip(range(dummy_image), image_path_iterator):
-            print(f'_ {_}')
-            print(f'path {path}')
             copyfile(stock_img, path)
 
     if gallery_conf['remove_config_comments']:

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -867,11 +867,11 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
 
     # Create dummy images
     if not executable:
-        dummy_image = file_conf.get('dummy_image', None)
+        dummy_image = file_conf.get('dummy_images', None)
         if dummy_image is not None:
             if type(dummy_image) is not int:
                 raise ExtensionError(
-                    'sphinx_gallery_dummy_image setting is not a number, '
+                    'sphinx_gallery_dummy_images setting is not a number, '
                     'got %r' % (dummy_image,))
 
             image_path_iterator = script_vars['image_path_iterator']

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -865,6 +865,21 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
 
     logger.debug("%s ran in : %.2g seconds\n", src_file, time_elapsed)
 
+    # Create dummy images
+    dummy_image = file_conf.get('dummy_image', None)
+    if dummy_image is not None:
+        if type(dummy_image) is not int:
+            raise ExtensionError(
+                'sphinx_gallery_dummy_image setting is not a number, '
+                'got %r' % (dummy_image,))
+
+        image_path_iterator = script_vars['image_path_iterator']
+        stock_img = os.path.join(glr_path_static(), 'no_image.png')
+        for _, path in zip(range(dummy_image), image_path_iterator):
+            print(f'_ {_}')
+            print(f'path {path}')
+            copyfile(stock_img, path)
+
     if gallery_conf['remove_config_comments']:
         script_blocks = [
             (label, remove_config_comments(content), line_number)

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -823,6 +823,7 @@ def test_minigallery_directive(sphinx_app):
         # Test 2-N (both examples, no heading)
         if "Test 2-N" in lines[i]:
             text = ''.join(lines[i:i+8])
+            print(f'Text: {text}')
 
             # Confirm there isn't a heading
             assert any_heading.search(text) is None

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -779,6 +779,7 @@ def test_minigallery_directive(sphinx_app):
         # Test 1-N (first example, no heading)
         if "Test 1-N" in lines[i]:
             text = ''.join(lines[i:i+6])
+            print(f'Text: {text}')
 
             # Confirm there isn't a heading
             assert any_heading.search(text) is None
@@ -790,6 +791,7 @@ def test_minigallery_directive(sphinx_app):
         # Test 1-D-D (first example, default heading, default level)
         if "Test 1-D-D" in lines[i]:
             text = ''.join(lines[i:i+8])
+            print(f'Text: {text}')
 
             heading = re.compile(r'<h2>Examples using .+ExplicitOrder.+<\/h2>')
             assert heading.search(text) is not None

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -924,11 +924,12 @@ def test_defer_figures(sphinx_app):
     assert '../_images/sphx_glr_plot_defer_figures_002.png' not in html
 
 
-def test_dummy_image(sphinx_app):
-    """Test that sphinx_gallery_dummy_image is created."""
+def test_no_dummy_image(sphinx_app):
+    """Test that sphinx_gallery_dummy_image is NOT created (when executable
+    is True)."""
     img1 = op.join(sphinx_app.srcdir, 'auto_examples', 'images',
                    'sphx_glr_plot_repr_001.png')
     img2 = op.join(sphinx_app.srcdir, 'auto_examples', 'images',
                    'sphx_glr_plot_repr_002.png')
-    assert op.isfile(img1)
-    assert op.isfile(img2)
+    assert not op.isfile(img1)
+    assert not op.isfile(img2)

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -925,7 +925,7 @@ def test_defer_figures(sphinx_app):
 
 
 def test_no_dummy_image(sphinx_app):
-    """Test that sphinx_gallery_dummy_image is NOT created (when executable
+    """Test that sphinx_gallery_dummy_images are NOT created (when executable
     is True)."""
     img1 = op.join(sphinx_app.srcdir, 'auto_examples', 'images',
                    'sphx_glr_plot_repr_001.png')

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -922,3 +922,13 @@ def test_defer_figures(sphinx_app):
     # be only one image, not two, in the output.
     assert '../_images/sphx_glr_plot_defer_figures_001.png' in html
     assert '../_images/sphx_glr_plot_defer_figures_002.png' not in html
+
+
+def test_dummy_image(sphinx_app):
+    """Test that sphinx_gallery_dummy_image is created."""
+    img1 = op.join(sphinx_app.srcdir, 'auto_examples', 'images',
+                   'sphx_glr_plot_repr_001.png')
+    img2 = op.join(sphinx_app.srcdir, 'auto_examples', 'images',
+                   'sphx_glr_plot_repr_002.png')
+    assert op.isfile(img1)
+    assert op.isfile(img2)

--- a/sphinx_gallery/tests/test_full_noexec.py
+++ b/sphinx_gallery/tests/test_full_noexec.py
@@ -40,7 +40,7 @@ def sphinx_app(tmpdir_factory, req_mpl, req_pil):
 
 
 def test_dummy_image(sphinx_app):
-    """Test that sphinx_gallery_dummy_image is created."""
+    """Test that sphinx_gallery_dummy_images are created."""
     img1 = op.join(sphinx_app.srcdir, 'auto_examples', 'images',
                    'sphx_glr_plot_repr_001.png')
     img2 = op.join(sphinx_app.srcdir, 'auto_examples', 'images',

--- a/sphinx_gallery/tests/test_full_noexec.py
+++ b/sphinx_gallery/tests/test_full_noexec.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# License: 3-clause BSD
+from io import StringIO
+import os.path as op
+import shutil
+
+from sphinx.application import Sphinx
+from sphinx.util.docutils import docutils_namespace
+
+import pytest
+
+
+@pytest.fixture(scope='module')
+def sphinx_app(tmpdir_factory, req_mpl, req_pil):
+
+    temp_dir = (tmpdir_factory.getbasetemp() / 'root').strpath
+    src_dir = op.join(op.dirname(__file__), 'tinybuild')
+
+    def ignore(src, names):
+        return ('_build', 'gen_modules', 'auto_examples')
+
+    shutil.copytree(src_dir, temp_dir, ignore=ignore)
+    # For testing iteration, you can get similar behavior just doing `make`
+    # inside the tinybuild directory
+    src_dir = temp_dir
+    conf_dir = temp_dir
+    out_dir = op.join(temp_dir, '_build', 'html')
+    toctrees_dir = op.join(temp_dir, '_build', 'toctrees')
+    # Avoid warnings about re-registration, see:
+    # https://github.com/sphinx-doc/sphinx/issues/5038
+    confoverrides = {'sphinx_gallery_conf.plot_gallery': 0, }
+    with docutils_namespace():
+        app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
+                     buildername='html', confoverrides=confoverrides,
+                     status=StringIO(), warning=StringIO())
+        # need to build within the context manager
+        # for automodule and backrefs to work
+        app.build(False, [])
+    return app
+
+
+def test_dummy_image(sphinx_app):
+    """Test that sphinx_gallery_dummy_image is created."""
+    img1 = op.join(sphinx_app.srcdir, 'auto_examples', 'images',
+                   'sphx_glr_plot_repr_001.png')
+    img2 = op.join(sphinx_app.srcdir, 'auto_examples', 'images',
+                   'sphx_glr_plot_repr_002.png')
+    assert op.isfile(img1)
+    assert op.isfile(img2)

--- a/sphinx_gallery/tests/test_full_noexec.py
+++ b/sphinx_gallery/tests/test_full_noexec.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 # License: 3-clause BSD
+"""
+Test the SG pipeline using Sphinx and tinybuild
+"""
 from io import StringIO
 import os.path as op
 import shutil

--- a/sphinx_gallery/tests/test_full_noexec.py
+++ b/sphinx_gallery/tests/test_full_noexec.py
@@ -13,7 +13,7 @@ import pytest
 @pytest.fixture(scope='module')
 def sphinx_app(tmpdir_factory, req_mpl, req_pil):
 
-    temp_dir = (tmpdir_factory.getbasetemp() / 'root').strpath
+    temp_dir = (tmpdir_factory.getbasetemp() / 'root_nonexec').strpath
     src_dir = op.join(op.dirname(__file__), 'tinybuild')
 
     def ignore(src, names):

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -454,6 +454,15 @@ def test_remove_config_comments(gallery_conf, req_pil):
     assert '# sphinx_gallery_defer_figures' not in rst
 
 
+def test_dummy_image_error(gallery_conf, req_pil):
+    """Test correct error is raised if int not provided to
+    sphinx_gallery_dummy_image."""
+    CONTENT.extend(("# sphinx_gallery_dummy_image=False",))
+    msg = "sphinx_gallery_dummy_image setting is not a number"
+    with pytest.raises(ExtensionError, match=msg):
+        _generate_rst(gallery_conf, 'test.py', CONTENT)
+
+
 def test_final_empty_block(gallery_conf, req_pil):
     """Test empty final block is removed. Empty final block can occur after
     sole config comment is removed from final block."""

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -456,9 +456,9 @@ def test_remove_config_comments(gallery_conf, req_pil):
 
 def test_dummy_image_error(gallery_conf, req_pil):
     """Test correct error is raised if int not provided to
-    sphinx_gallery_dummy_image."""
-    content_image = CONTENT + ["# sphinx_gallery_dummy_image=False", ]
-    msg = "sphinx_gallery_dummy_image setting is not a number"
+    sphinx_gallery_dummy_images."""
+    content_image = CONTENT + ["# sphinx_gallery_dummy_images=False", ]
+    msg = "sphinx_gallery_dummy_images setting is not a number"
     with pytest.raises(ExtensionError, match=msg):
         _generate_rst(gallery_conf, 'test.py', content_image)
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -457,20 +457,19 @@ def test_remove_config_comments(gallery_conf, req_pil):
 def test_dummy_image_error(gallery_conf, req_pil):
     """Test correct error is raised if int not provided to
     sphinx_gallery_dummy_image."""
-    CONTENT.extend(("# sphinx_gallery_dummy_image=False",))
+    content_image = CONTENT + ["# sphinx_gallery_dummy_image=False",]
     msg = "sphinx_gallery_dummy_image setting is not a number"
     with pytest.raises(ExtensionError, match=msg):
-        _generate_rst(gallery_conf, 'test.py', CONTENT)
+        _generate_rst(gallery_conf, 'test.py', content_image)
 
 
 def test_final_empty_block(gallery_conf, req_pil):
     """Test empty final block is removed. Empty final block can occur after
     sole config comment is removed from final block."""
-    CONTENT.extend(
-        ('# %%', '', '# sphinx_gallery_line_numbers = True')
-    )
+    content_block = \
+        CONTENT + ['# %%', '', '# sphinx_gallery_line_numbers = True']
     gallery_conf['remove_config_comments'] = True
-    rst = _generate_rst(gallery_conf, 'test.py', CONTENT)
+    rst = _generate_rst(gallery_conf, 'test.py', content_block)
     want = "RuntimeWarning)\n\n\n.. rst-class:: sphx-glr-timing"
     assert want in rst
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -457,7 +457,7 @@ def test_remove_config_comments(gallery_conf, req_pil):
 def test_dummy_image_error(gallery_conf, req_pil):
     """Test correct error is raised if int not provided to
     sphinx_gallery_dummy_image."""
-    content_image = CONTENT + ["# sphinx_gallery_dummy_image=False",]
+    content_image = CONTENT + ["# sphinx_gallery_dummy_image=False", ]
     msg = "sphinx_gallery_dummy_image setting is not a number"
     with pytest.raises(ExtensionError, match=msg):
         _generate_rst(gallery_conf, 'test.py', content_image)

--- a/sphinx_gallery/tests/tinybuild/examples/plot_repr.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_repr.py
@@ -1,11 +1,11 @@
 """
 Repr test
 =========
-Test repr and the sphinx_gallery_dummy_image config.
+Test repr and the sphinx_gallery_dummy_images config.
 """
 
 
-# sphinx_gallery_dummy_image=2
+# sphinx_gallery_dummy_images=2
 class A:
     def _repr_html_(self):
         return '<p><b>This should print<b></p>'

--- a/sphinx_gallery/tests/tinybuild/examples/plot_repr.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_repr.py
@@ -1,10 +1,11 @@
 """
 Repr test
 =========
-Test repr.
+Test repr and the sphinx_gallery_dummy_image config.
 """
 
 
+# sphinx_gallery_dummy_image=2
 class A:
     def _repr_html_(self):
         return '<p><b>This should print<b></p>'


### PR DESCRIPTION
closes #751

It is possible for this configuration to work only when the gallery is NOT executable (e.g., when plot_gallery is False) but this complicates the code and makes testing (using tinybuild) difficult, and possibly unnecessarily restrains the config function. I have left it as always creating dummy images. The images are created after executing the code block (so after any 'real' figures are saved) - thus would not overwrite any generated 'real' figures. Open to changing.

TODO
Still need to add documentation.
Should amend to test in example that generates images, to ensure no real images are overwritten