### PR TITLE
BUG Fix LaTeX Error: File `tgtermes.sty' not found in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             sudo apt-get --no-install-recommends install -yq \
               libosmesa6 libglx-mesa0 libopengl0 libglx0 libdbus-1-3 \
               libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 \
-              texlive texlive-latex-extra latexmk optipng
+              texlive texlive-latex-extra latexmk optipng tex-gyre
             sudo ln -s /usr/lib/x86_64-linux-gnu/libxcb-util.so.0 /usr/lib/x86_64-linux-gnu/libxcb-util.so.1
       - run:
           name: Merge with upstream


### PR DESCRIPTION
Install tex-gyre in circleCI.

Other CI failures are separate problems (will tackle in separate PR).