### PR TITLE
BUG Fix test_minigallery_directive failing on Windows

### DIFF
--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -814,7 +814,7 @@ def test_minigallery_directive(sphinx_app, test, nlines, filenamesortkey):
             text = ''.join(lines[i:i+nlines])
             # Check headings
             if heading_str[test]:
-                heading = re.compile(heading_str[test]):
+                heading = re.compile(heading_str[test])
                 assert heading.search(text) is not None
             else:
                 # Confirm there isn't a heading

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -778,11 +778,11 @@ def test_backreference_labels(sphinx_app):
         # first example, custom heading, default level
         ('Test 1-C-D', 8, False),
         # both examples, no heading
-        ('Test 2-N', 11, True),
+        ('Test 2-N', 10, True),
         # both examples, default heading, default level
-        ('Test 2-D-D', 14, True),
+        ('Test 2-D-D', 13, True),
         # both examples, custom heading, custom level
-        ('Test 2-C-C', 15, True),
+        ('Test 2-C-C', 14, True),
     ]
 )
 def test_minigallery_directive(sphinx_app, test, nlines, filenamesortkey):

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -778,11 +778,11 @@ def test_backreference_labels(sphinx_app):
         # first example, custom heading, default level
         ('Test 1-C-D', 8, False),
         # both examples, no heading
-        ('Test 2-N', 10, True),
+        ('Test 2-N', 11, True),
         # both examples, default heading, default level
         ('Test 2-D-D', 14, True),
         # both examples, custom heading, custom level
-        ('Test 2-C-C', 14, True),
+        ('Test 2-C-C', 15, True),
     ]
 )
 def test_minigallery_directive(sphinx_app, test, nlines, filenamesortkey):

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -780,7 +780,7 @@ def test_backreference_labels(sphinx_app):
         # both examples, no heading
         ('Test 2-N', 8, True),
         # both examples, default heading, default level
-        ('Test 2-D-D', 13, True),
+        ('Test 2-D-D', 15, True),
         # both examples, custom heading, custom level
         ('Test 2-C-C', 12, True),
     ]

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -783,7 +783,8 @@ def test_backreference_labels(sphinx_app):
         ('Test 2-D-D', 12, True),
         # both examples, custom heading, custom level
         ('Test 2-C-C', 12, True),
-])
+    ]
+)
 def test_minigallery_directive(sphinx_app, test, nlines, filenamesortkey):
     """Tests the functionality of the minigallery directive."""
     out_dir = sphinx_app.outdir

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -783,7 +783,7 @@ def test_backreference_labels(sphinx_app):
      # both examples, custom heading, custom level
      ['Test 2-C-C', 12, True])
 )
-def test_minigallery_directive(sphinx_app, test, nlines):
+def test_minigallery_directive(sphinx_app, test, nlines, filenamesortkey):
     """Tests the functionality of the minigallery directive."""
     out_dir = sphinx_app.outdir
     minigallery_html = op.join(out_dir, 'minigallery.html')

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -814,6 +814,7 @@ def test_minigallery_directive(sphinx_app, test, nlines, filenamesortkey):
     for i in range(len(lines)):
         if test in lines[i]:
             text = ''.join(lines[i:i+nlines])
+            print(f'{test}: {text}')
             # Check headings
             if heading_str[test]:
                 heading = re.compile(heading_str[test])

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -766,23 +766,24 @@ def test_backreference_labels(sphinx_app):
     link = 'href="gen_modules/sphinx_gallery.backreferences.html#sphx-glr-backref-sphinx-gallery-backreferences-identify-names">'  # noqa: E501
     assert link in html
 
+
 @pytest.mark.parametrize(
-    'test, nlines, filenamesortkey',
-    (# first example, no heading
-     ['Test 1-N', 6, False],
-     # first example, default heading, default level
-     ['Test 1-D-D', 8, False],
-     # first example, default heading, custom level
-     ['Test 1-D-C', 8, False],
-     # first example, custom heading, default level
-     ['Test 1-C-D', 8, False],
-     # both examples, no heading
-     ['Test 2-N', 8, True],
-     # both examples, default heading, default level
-     ['Test 2-D-D', 12, True],
-     # both examples, custom heading, custom level
-     ['Test 2-C-C', 12, True])
-)
+    'test, nlines, filenamesortkey', [
+        # first example, no heading
+        ('Test 1-N', 6, False),
+        # first example, default heading, default level
+        ('Test 1-D-D', 8, False),
+        # first example, default heading, custom level
+        ('Test 1-D-C', 8, False),
+        # first example, custom heading, default level
+        ('Test 1-C-D', 8, False),
+        # both examples, no heading
+        ('Test 2-N', 8, True),
+        # both examples, default heading, default level
+        ('Test 2-D-D', 12, True),
+        # both examples, custom heading, custom level
+        ('Test 2-C-C', 12, True),
+])
 def test_minigallery_directive(sphinx_app, test, nlines, filenamesortkey):
     """Tests the functionality of the minigallery directive."""
     out_dir = sphinx_app.outdir

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -776,13 +776,13 @@ def test_backreference_labels(sphinx_app):
         # first example, default heading, custom level
         ('Test 1-D-C', 8, False),
         # first example, custom heading, default level
-        ('Test 1-C-D', 8, False),
+        ('Test 1-C-D', 9, False),
         # both examples, no heading
-        ('Test 2-N', 10, True),
+        ('Test 2-N', 11, True),
         # both examples, default heading, default level
-        ('Test 2-D-D', 13, True),
+        ('Test 2-D-D', 14, True),
         # both examples, custom heading, custom level
-        ('Test 2-C-C', 14, True),
+        ('Test 2-C-C', 15, True),
     ]
 )
 def test_minigallery_directive(sphinx_app, test, nlines, filenamesortkey):

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -780,7 +780,7 @@ def test_backreference_labels(sphinx_app):
         # both examples, no heading
         ('Test 2-N', 8, True),
         # both examples, default heading, default level
-        ('Test 2-D-D', 12, True),
+        ('Test 2-D-D', 13, True),
         # both examples, custom heading, custom level
         ('Test 2-C-C', 12, True),
     ]

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -766,8 +766,24 @@ def test_backreference_labels(sphinx_app):
     link = 'href="gen_modules/sphinx_gallery.backreferences.html#sphx-glr-backref-sphinx-gallery-backreferences-identify-names">'  # noqa: E501
     assert link in html
 
-
-def test_minigallery_directive(sphinx_app):
+@pytest.mark.parametrize(
+    'test, nlines, filenamesortkey',
+    (# first example, no heading
+     ['Test 1-N', 6, False],
+     # first example, default heading, default level
+     ['Test 1-D-D', 8, False],
+     # first example, default heading, custom level
+     ['Test 1-D-C', 8, False],
+     # first example, custom heading, default level
+     ['Test 1-C-D', 8, False],
+     # both examples, no heading
+     ['Test 2-N', 8, True],
+     # both examples, default heading, default level
+     ['Test 2-D-D', 12, True],
+     # both examples, custom heading, custom level
+     ['Test 2-C-C', 12, True])
+)
+def test_minigallery_directive(sphinx_app, test, nlines):
     """Tests the functionality of the minigallery directive."""
     out_dir = sphinx_app.outdir
     minigallery_html = op.join(out_dir, 'minigallery.html')
@@ -782,86 +798,34 @@ def test_minigallery_directive(sphinx_app):
     filenamesortkey_example = re.compile(r'(?s)<img .+'
                                          r'(plot_numpy_matplotlib).+'
                                          r'auto_examples\/\1\.html')
+    # Heading strings
+    heading_str = {
+        "Test 1-N": None,
+        "Test 1-D-D": r'<h2>Examples using .+ExplicitOrder.+<\/h2>',
+        "Test 1-D-C": r'<h3>Examples using .+ExplicitOrder.+<\/h3>',
+        "Test 1-C-D": r'<h2>This is a custom heading.*<\/h2>',
+        "Test 2-N": None,
+        "Test 2-D-D": r'<h2>Examples using one of multiple objects.*<\/h2>',
+        "Test 2-C-C": r'<h1>This is a different custom heading.*<\/h1>'
+    }
 
     for i in range(len(lines)):
-        # Test 1-N (first example, no heading)
-        if "Test 1-N" in lines[i]:
-            text = ''.join(lines[i:i+6])
-
-            # Confirm there isn't a heading
-            assert any_heading.search(text) is None
-
-            # Check for examples
-            assert explicitorder_example.search(text) is not None
-            assert filenamesortkey_example.search(text) is None
-
-        # Test 1-D-D (first example, default heading, default level)
-        if "Test 1-D-D" in lines[i]:
-            text = ''.join(lines[i:i+8])
-
-            heading = re.compile(r'<h2>Examples using .+ExplicitOrder.+<\/h2>')
-            assert heading.search(text) is not None
+        if test in lines[i]:
+            text = ''.join(lines[i:i+nlines])
+            # Check headings
+            if heading_str[test]:
+                heading = re.compile(heading_str[test]):
+                assert heading.search(text) is not None
+            else:
+                # Confirm there isn't a heading
+                assert any_heading.search(text) is None
 
             # Check for examples
             assert explicitorder_example.search(text) is not None
-            assert filenamesortkey_example.search(text) is None
-
-        # Test 1-D-C (first example, default heading, custom level)
-        if "Test 1-D-C" in lines[i]:
-            text = ''.join(lines[i:i+8])
-
-            heading = re.compile(r'<h3>Examples using .+ExplicitOrder.+<\/h3>')
-            assert heading.search(text) is not None
-
-            # Check for examples
-            assert explicitorder_example.search(text) is not None
-            assert filenamesortkey_example.search(text) is None
-
-        # Test 1-C-D (first example, custom heading, default level)
-        if "Test 1-C-D" in lines[i]:
-            text = ''.join(lines[i:i+8])
-
-            heading = re.compile(r'<h2>This is a custom heading.*<\/h2>')
-            assert heading.search(text) is not None
-
-            # Check for examples
-            assert explicitorder_example.search(text) is not None
-            assert filenamesortkey_example.search(text) is None
-
-        # Test 2-N (both examples, no heading)
-        if "Test 2-N" in lines[i]:
-            text = ''.join(lines[i:i+8])
-
-            # Confirm there isn't a heading
-            assert any_heading.search(text) is None
-
-            # Check for examples
-            assert explicitorder_example.search(text) is not None
-            assert filenamesortkey_example.search(text) is not None
-
-        # Test 2-D-D (both examples, default heading, default level)
-        if "Test 2-D-D" in lines[i]:
-            text = ''.join(lines[i:i+12])
-
-            heading = re.compile(r'<h2>Examples using one of multiple objects'
-                                 r'.*<\/h2>')
-            assert heading.search(text) is not None
-
-            # Check for examples
-            assert explicitorder_example.search(text) is not None
-            assert filenamesortkey_example.search(text) is not None
-
-        # Test 2-C-C (both examples, custom heading, custom level)
-        if "Test 2-C-C" in lines[i]:
-            text = ''.join(lines[i:i+12])
-
-            heading = re.compile(r'<h1>This is a different custom heading.*'
-                                 r'<\/h1>')
-            assert heading.search(text) is not None
-
-            # Check for examples
-            assert explicitorder_example.search(text) is not None
-            assert filenamesortkey_example.search(text) is not None
+            if filenamesortkey:
+                assert filenamesortkey_example.search(text) is not None
+            else:
+                assert filenamesortkey_example.search(text) is None
 
 
 def test_matplotlib_warning_filter(sphinx_app):

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -778,11 +778,11 @@ def test_backreference_labels(sphinx_app):
         # first example, custom heading, default level
         ('Test 1-C-D', 8, False),
         # both examples, no heading
-        ('Test 2-N', 8, True),
+        ('Test 2-N', 10, True),
         # both examples, default heading, default level
-        ('Test 2-D-D', 15, True),
+        ('Test 2-D-D', 14, True),
         # both examples, custom heading, custom level
-        ('Test 2-C-C', 12, True),
+        ('Test 2-C-C', 14, True),
     ]
 )
 def test_minigallery_directive(sphinx_app, test, nlines, filenamesortkey):


### PR DESCRIPTION
Parameterise test_minigallery_directive to make debugging easier.

Fix `test_minigallery_directive` failing in Windows. HTML output in Windows has more (new) lines, so had to make `nlines` bigger to capture some sections completely. It should not interfer with the linux html output as have only increased `nlines` by 1-3, and this should max only capture the test name part of the next section, e.g.:

```html
</div>
</div><div class="sphx-glr-clear"></div><p>Test 2-D-D</p>
</div>
```
and not capture the heading lines.
