### PR TITLE
Bug Pin markupsafe version in Python nightly

### DIFF
--- a/continuous_integration/azure/install.sh
+++ b/continuous_integration/azure/install.sh
@@ -54,7 +54,7 @@ elif [ "$DISTRIB" == "nightly" ]; then
     # pip install --no-use-pep517 -q https://api.github.com/repos/matplotlib/matplotlib/zipball/master
     #
     # So for now we'll just live without NumPy.
-    pip install -q --upgrade --pre sphinx joblib pytest-cov pygments colorama jinja2>=2.3
+    pip install -q --upgrade --pre sphinx joblib pytest-cov pygments colorama jinja2>=2.10.3
     pip install -q .
     pip list
 elif [ "$DISTRIB" == "minimal" ]; then

--- a/continuous_integration/azure/install.sh
+++ b/continuous_integration/azure/install.sh
@@ -54,7 +54,7 @@ elif [ "$DISTRIB" == "nightly" ]; then
     # pip install --no-use-pep517 -q https://api.github.com/repos/matplotlib/matplotlib/zipball/master
     #
     # So for now we'll just live without NumPy.
-    pip install -q --upgrade --pre sphinx joblib pytest-cov pygments colorama jinja2>=2.10.3
+    pip install -q --upgrade --pre sphinx joblib pytest-cov pygments colorama jinja2>=2.3 markupsafe>=1.1
     pip install -q .
     pip list
 elif [ "$DISTRIB" == "minimal" ]; then

--- a/continuous_integration/azure/install.sh
+++ b/continuous_integration/azure/install.sh
@@ -56,6 +56,7 @@ elif [ "$DISTRIB" == "nightly" ]; then
     # So for now we'll just live without NumPy.
     pip install -q --upgrade --pre sphinx joblib pytest-cov pygments colorama jinja2>=2.3
     pip install -q .
+    pip list
 elif [ "$DISTRIB" == "minimal" ]; then
     python -m pip install --upgrade . pytest pytest-cov coverage
 elif [ "$DISTRIB" == "ubuntu" ]; then


### PR DESCRIPTION
Fix
> ../../../.local/lib/python3.10/site-packages/jinja2/__init__.py:6: in <module>
    from markupsafe import escape
/usr/lib/python3/dist-packages/markupsafe/__init__.py:13: in <module>
    from collections import Mapping
E   ImportError: cannot import name 'Mapping' from 'collections' (/usr/lib/python3.10/collections/__init__.py)

I think this is fixed here: https://github.com/pallets/markupsafe/commit/86d4146f0debc004b4a8b6aa69df818ef4ad9080

Pin markupsafe to version >=1.1

(Previously we had to pin jinja2 due to same eror, I wonder if adding all these pins is robust/a good fix?)