### PR TITLE
ArtifactList instead if ImagePathIterator

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -296,7 +296,7 @@ def save_thumbnail(image_path_template, src_file, script_vars, file_conf,
         # negative index means counting from the last one
         if thumbnail_number < 0:
             thumbnail_number += len(script_vars["artifact_paths"]) + 1
-        image_path = image_path_template.format(thumbnail_number)
+        image_path = image_path_template.format("%03d" % thumbnail_number)
     del thumbnail_number, thumbnail_path, image_path_template
     thumbnail_image_path, ext = _find_image_ext(image_path)
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -195,7 +195,8 @@ def test_rst_empty_code_block(gallery_conf, tmpdir):
 
     gallery_conf['abort_on_example_error'] = True
     script_vars = dict(execute_script=True, src_file=filename,
-                       image_path_iterator=[], target_file=filename)
+                       image_path_iterator=[], artifact_paths=[],
+                       target_file=filename)
 
     output_blocks, time_elapsed = sg.execute_script(
         blocks, script_vars, gallery_conf)
@@ -239,6 +240,7 @@ b = 'foo'
     assert file_conf == {}
     script_vars = {'execute_script': True, 'src_file': filename,
                    'image_path_iterator': [],
+                   'artifact_paths': [],
                    'target_file': filename}
     output_blocks, time_elapsed = sg.execute_script(
         blocks, script_vars, gallery_conf)

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -22,7 +22,7 @@ from sphinx.errors import ExtensionError
 import sphinx_gallery.gen_rst as sg
 from sphinx_gallery import downloads
 from sphinx_gallery.gen_gallery import generate_dir_rst
-from sphinx_gallery.scrapers import ImagePathIterator, figure_rst
+from sphinx_gallery.scrapers import ArtifactList, figure_rst
 
 CONTENT = [
     '"""',
@@ -617,9 +617,11 @@ def script_vars(tmpdir):
     fake_main = importlib.util.module_from_spec(
         importlib.util.spec_from_loader('__main__', None))
     fake_main.__dict__.update({'__doc__': ''})
+    artifact_paths = ArtifactList(str(tmpdir.join("temp.png")))
     script_vars = {
         "execute_script": True,
-        "image_path_iterator": ImagePathIterator(str(tmpdir.join("temp.png"))),
+        "image_path_iterator": artifact_paths.ordinal_path_iterator(),
+        "artifact_paths": artifact_paths,
         "src_file": __file__,
         "memory_delta": [],
         "fake_main": fake_main,

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -25,7 +25,7 @@ def gallery_conf(tmpdir):
 @pytest.fixture(scope='function')
 def block_vars(gallery_conf):
     fname_template = os.path.join(gallery_conf['gallery_dir'], 'image{0}')
-    artifact_paths = ArtifactList(fname_template)
+    artifact_paths = ArtifactList(fname_template, min_digits=1)
     return dict(artifact_paths=artifact_paths,
                 image_path_iterator=artifact_paths.ordinal_path_iterator())
 
@@ -61,8 +61,8 @@ def test_save_matplotlib_figures(block, block_vars, gallery_conf, ext):
     assert os.path.isfile(fname)
 
     # Test capturing 2 images with shifted start number
-    image_path_iterator.next()
-    image_path_iterator.next()
+    next(image_path_iterator)
+    next(image_path_iterator)
     plt.plot(1, 1)
     plt.figure()
     plt.plot(1, 1)
@@ -98,8 +98,8 @@ def test_save_matplotlib_figures_hidpi(block, block_vars, gallery_conf):
     assert os.path.isfile(fnamehi)
 
     # Test capturing 2 images with shifted start number
-    image_path_iterator.next()
-    image_path_iterator.next()
+    next(image_path_iterator)
+    next(image_path_iterator)
     plt.plot(1, 1)
     plt.figure()
     plt.plot(1, 1)
@@ -159,7 +159,7 @@ def test_save_mayavi_figures(block, block_vars, gallery_conf, req_mpl, req_pil):
     plt.pcolor([[0]], cmap='Reds')
     image_rst = save_figures(block, block_vars, gallery_conf)
     assert len(plt.get_fignums()) == 0
-    assert len(image_path_iterator) == 3
+    assert len(artifact_paths) == 3
     assert '/image1.png' not in image_rst
     assert '/image2.png' not in image_rst
     assert '/image3.png' in image_rst
@@ -174,7 +174,7 @@ def test_save_mayavi_figures(block, block_vars, gallery_conf, req_mpl, req_pil):
 
 
 def _custom_func(x, y, z):
-    return y['image_path_iterator'].next()
+    return next(y['image_path_iterator'])
 
 
 def test_custom_scraper(block, block_vars, gallery_conf, monkeypatch):


### PR DESCRIPTION
Fixes #833 

@lucyleeow I've not got tests here here yet, and I've got one test failure, `sphinx_gallery/tests/test_full_noexec.py::test_dummy_image`. There seem to be no image paths generated when the "Create Dummy Images" in `gen_rst.py` is executed. Where is the logic where a dummy image path was previously generated? I am finding it hard to locate this logic in the code.