### PR TITLE
Sanitize ANSI characters from generated RST

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+Latest
+------
+
+**Fixed bugs:**
+
+-  Remove `ANSI characters <https://en.wikipedia.org/wiki/ANSI_escape_code>`_ from HTML output `#838 <https://github.com/sphinx-gallery/sphinx-gallery/pull/838>`__ (`agramfort <https://github.com/agramfort>`__)
+
+
 v0.9.0
 ------
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -674,6 +674,10 @@ def execute_code_block(compiler, block, example_globals,
         sys.path = sys_path
         logging_tee.restore_std()
 
+    # Sanitize ANSI escape characters from RST output
+    ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+    code_output = ansi_escape.sub('', code_output)
+
     return code_output
 
 
@@ -1011,10 +1015,6 @@ def rst_blocks(script_blocks, output_blocks, file_conf, gallery_conf):
         else:
             block_separator = '\n\n' if not bcontent.endswith('\n') else '\n'
             example_rst += bcontent + block_separator
-
-    # Sanitize ANSI escape characters from RST output
-    ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
-    example_rst = ansi_escape.sub('', example_rst)
 
     return example_rst
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1011,6 +1011,11 @@ def rst_blocks(script_blocks, output_blocks, file_conf, gallery_conf):
         else:
             block_separator = '\n\n' if not bcontent.endswith('\n') else '\n'
             example_rst += bcontent + block_separator
+
+    # Sanitize ANSI escape characters from RST output
+    ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+    example_rst = ansi_escape.sub('', example_rst)
+
     return example_rst
 
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -651,7 +651,7 @@ def test_output_indentation(gallery_conf, script_vars):
 def test_output_no_ansi(gallery_conf, script_vars):
     """Test ANSI characters are removed.
 
-    See: https://en.wikipedia.org/wiki/ANSI_escape_code)
+    See: https://en.wikipedia.org/wiki/ANSI_escape_code
     """
     gallery_conf.update(image_scrapers=())
     compiler = codeop.Compile()

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -648,6 +648,26 @@ def test_output_indentation(gallery_conf, script_vars):
     assert output_test_string == test_string.replace(r"\n", "\n")
 
 
+def test_output_no_ansi(gallery_conf, script_vars):
+    """Test ANSI characters are removed.
+
+    See: https://en.wikipedia.org/wiki/ANSI_escape_code)
+    """
+    gallery_conf.update(image_scrapers=())
+    compiler = codeop.Compile()
+
+    code = 'print("\033[94m0.25")'
+    code_block = ("code", code, 1)
+    output = sg.execute_code_block(
+        compiler, code_block, None, script_vars, gallery_conf
+    )
+    output_test_string = "\n".join(
+        [line[4:] for line in output.strip().split("\n")[-3:]]
+    )
+
+    assert output_test_string.split('\n')[-1] == "0.25"
+
+
 def test_empty_output_box(gallery_conf, script_vars):
     """Tests that `print(__doc__)` doesn't produce an empty output box."""
     gallery_conf.update(image_scrapers=())


### PR DESCRIPTION
See the problem in the output block in https://braindecode.org/auto_examples/plot_sleep_staging.html#training

See all the `[36m` which are otherwise used to get colors in the terminal.

With this fix it looks much better !

cc @robintibor 

<img width="756" alt="Screenshot 2021-06-25 at 18 03 35" src="https://user-images.githubusercontent.com/161052/123453360-bc639c00-d5df-11eb-950d-498c4bbbfc05.png">
