### PR TITLE
Minor documentation about overwriting css files

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -406,6 +406,20 @@ the path(s) listed will be copied over after the builtin Sphinx-Gallery files,
 so if you have a file named "gallery.css", it will overwrite the builtin
 "gallery.css".
 
+To complete the process though, you need to register the stylesheet
+as mentioned in the `sphinx documentation 
+<https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_css_file>`_ .
+
+A quick recipe you can do if you find that the files are not getting copied over 
+is adding the following to your ``conf.py`` file:
+
+.. code-block:: python
+
+    def setup(app):
+        app.connect('builder-inited', lambda app: app.config.html_static_path.append('_static'))
+        app.add_css_file('gallery.css')
+
+
 The appearance of :ref:`code links <stylizing_code_links>` and
 :ref:`thumbnail size <setting_thumbnail_size>` can be altered via addition
 of your own CSS. Can also do things like hide the download buttons in the


### PR DESCRIPTION
@lucyleeow Here is the PR related to #399  . I mentioned that the css file had to be registered through the add_css_file() method.

I also included the recipe from @maartenbreddels , problem with including this is that:

- Is more directly related to sphinx
- I'm not even sure why it works (just some minor intuition of "it makes sense")
- I'm still unsure why just doing ``app.html_static_path.append(path_to_my_files);app.add_css_file('gallery.css');`` does not work. I have the same problem as @choldgraf . 
 
My understanding is that it should work and seems to be the expected behavior since after all it seems what sphinx-gallery does  by itself:

https://github.com/sphinx-gallery/sphinx-gallery/blob/master/sphinx_gallery/gen_gallery.py#L350-L355

I'm yet too much of a sphinx newbie to understand this.

The problem with not including the recipe in the documentation is that is a headache for something seemingly simple. Another option is to link the issue rather than including the recipe directly on the documentation.



