### PR TITLE
Add info on enabling animation support to example

### DIFF
--- a/examples/plot_8_animations.py
+++ b/examples/plot_8_animations.py
@@ -5,7 +5,8 @@ Matplotlib animation support
 Show a Matplotlib animation, which should end up nicely embedded below.
 
 In order to enable support for animations ``'matplotlib_animations'``
-must be set to ``True`` in the sphinx gallery configuration.
+must be set to ``True`` in the sphinx gallery
+:ref:`configuration <image_scrapers>`.
 """
 
 import numpy as np

--- a/examples/plot_8_animations.py
+++ b/examples/plot_8_animations.py
@@ -3,6 +3,9 @@ Matplotlib animation support
 ============================
 
 Show a Matplotlib animation, which should end up nicely embedded below.
+
+In order to enable support for animations ``'matplotlib_animations'``
+must be set to ``True`` in the sphinx gallery configuration.
 """
 
 import numpy as np


### PR DESCRIPTION
When looking at how to enable animations in sphinx gallery, this example was the first thing I came upon. I thought it would be helpful to indicate how to enable support here in the example, so users don't have to go looking in the Configuration page.