### PR TITLE
Use bools for 'plot_gallery' in sphinx_gallery_conf

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1065,7 +1065,7 @@ a default::
 
     sphinx_gallery_conf = {
         ...
-        'plot_gallery': 'False',
+        'plot_gallery': False,
     }
 
 The highest precedence is always given to the `-D` flag of the

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -63,10 +63,10 @@ DEFAULT_GALLERY_CONF = {
     'ignore_repr_types': r'',
     # Build options
     # -------------
-    # We use a string for 'plot_gallery' rather than simply the Python boolean
-    # `True` as it avoids a warning about unicode when controlling this value
-    # via the command line switches of sphinx-build
-    'plot_gallery': 'True',
+    # 'plot_gallery' also accepts strings that evaluate to a bool, e.g. "True",
+    # "False", "1", "0" so that they can be easily set via command line
+    # switches of sphinx-build
+    'plot_gallery': True,
     'download_all_examples': True,
     'abort_on_example_error': False,
     'only_warn_on_example_error': False,


### PR DESCRIPTION
The parser accepts both bools and strings. Strings occur when
passing the parameter in as a command line swith to sphinx-build.
However, in a python dict, we should still use the bool directly.
Having a boolean string is rather confusing.