### PR TITLE
Enable `reset_modules` to run either before or after examples, or both

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
 
   deploy_dev:
     docker:
-      - image: circleci/python:3.6-stretch
+      - image: circleci/python:3.7-stretch
     steps:
       - checkout
       - add_ssh_keys:
@@ -95,7 +95,7 @@ jobs:
 
   deploy_stable:
     docker:
-      - image: circleci/python:3.6-stretch
+      - image: circleci/python:3.7-stretch
     steps:
       - checkout
       - add_ssh_keys:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,8 +49,10 @@ stages:
         call "%CONDA%\Scripts\activate" base
         echo "##vso[task.setvariable variable=PATH]%CONDA%\Scripts;%PATH%"
       displayName: Add conda to PATH and activate conda base
-    - script: |
-        conda install python=%PYTHON_VERSION% ipython numpy seaborn statsmodels matplotlib sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib 'plotly>=4.0'
+    - bash: |
+        set -e
+        conda install python=%PYTHON_VERSION% ipython numpy seaborn statsmodels matplotlib sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib
+        conda install "plotly>=4.0"
         conda info --envs
         conda list
       displayName: Setup conda environment

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ stages:
       displayName: Add conda to PATH and activate conda base
     - script: |
         conda install python=%PYTHON_VERSION% ipython numpy seaborn statsmodels matplotlib sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib 'plotly>=4.0'
-	conda info --envs
+        conda info --envs
       displayName: Setup conda environment
     - script: python setup.py develop
       displayName: Install sphinx-gallery

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,11 +49,8 @@ stages:
         call "%CONDA%\Scripts\activate" base
         echo "##vso[task.setvariable variable=PATH]%CONDA%\Scripts;%PATH%"
       displayName: Add conda to PATH and activate conda base
-    - bash: |
-        set -e
-        conda install python=${PYTHON_VERSION} ipython numpy seaborn statsmodels matplotlib sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib
-        conda install "plotly>=4.0"
-        conda info --envs
+    - script: |
+        conda install python=%PYTHON_VERSION% ipython numpy seaborn statsmodels matplotlib sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib "plotly>=4.0"
         conda list
       displayName: Setup conda environment
     - script: python setup.py develop

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ stages:
     strategy:
       matrix:
         Python36:
-          python.version: '3.6'
+          python.version: '3.7'
         Python38:
           python.version: '3.8'
 
@@ -84,15 +84,15 @@ stages:
       matrix:
         ubuntu_python36:
           DISTRIB: 'ubuntu'
-          PYTHON_VERSION: '3.6'
+          PYTHON_VERSION: '3.7'
           SPHINXOPTS: ''
         conda_python36_sphinx183:
           DISTRIB: 'conda'
-          PYTHON_VERSION: '3.6'
+          PYTHON_VERSION: '3.7'
           SPHINX_VERSION: '1.8.3'
         conda_python36_localeC:
           DISTRIB: 'conda'
-          PYTHON_VERSION: '3.6'
+          PYTHON_VERSION: '3.7'
           LOCALE: 'C'
           BAD_MTIME: '1'  # not clear why, maybe some specific Sphinx version?
         conda_python38_sphinxDev:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ stages:
         call "%CONDA%\Scripts\activate" base
         echo "##vso[task.setvariable variable=PATH]%CONDA%\Scripts;%PATH%"
       displayName: Add conda to PATH and activate conda base
-    - script: conda install python=%PYTHON_VERSION% ipython numpy seaborn statsmodels matplotlib sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib plotly
+    - script: conda install python=%PYTHON_VERSION% ipython numpy seaborn statsmodels matplotlib sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib 'plotly>4.0'
       displayName: Setup conda environment
     - script: python setup.py develop
       displayName: Install sphinx-gallery

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ stages:
       vmImage: 'vs2017-win2016'
     strategy:
       matrix:
-        Python36:
+        Python37:
           python.version: '3.7'
         Python38:
           python.version: '3.8'
@@ -82,15 +82,15 @@ stages:
       DISPLAY: ':99'
     strategy:
       matrix:
-        ubuntu_python36:
+        ubuntu_python37:
           DISTRIB: 'ubuntu'
           PYTHON_VERSION: '3.7'
           SPHINXOPTS: ''
-        conda_python36_sphinx183:
+        conda_python37_sphinx183:
           DISTRIB: 'conda'
           PYTHON_VERSION: '3.7'
           SPHINX_VERSION: '1.8.3'
-        conda_python36_localeC:
+        conda_python37_localeC:
           DISTRIB: 'conda'
           PYTHON_VERSION: '3.7'
           LOCALE: 'C'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ stages:
       displayName: Add conda to PATH and activate conda base
     - bash: |
         set -e
-        conda install python=%PYTHON_VERSION% ipython numpy seaborn statsmodels matplotlib sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib
+        conda install python=${PYTHON_VERSION} ipython numpy seaborn statsmodels matplotlib sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib
         conda install "plotly>=4.0"
         conda info --envs
         conda list

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,6 +52,7 @@ stages:
     - script: |
         conda install python=%PYTHON_VERSION% ipython numpy seaborn statsmodels matplotlib sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib 'plotly>=4.0'
         conda info --envs
+        conda list
       displayName: Setup conda environment
     - script: python setup.py develop
       displayName: Install sphinx-gallery

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,9 @@ stages:
         call "%CONDA%\Scripts\activate" base
         echo "##vso[task.setvariable variable=PATH]%CONDA%\Scripts;%PATH%"
       displayName: Add conda to PATH and activate conda base
-    - script: conda install python=%PYTHON_VERSION% ipython numpy seaborn statsmodels matplotlib sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib 'plotly>4.0'
+    - script: |
+        conda install python=%PYTHON_VERSION% ipython numpy seaborn statsmodels matplotlib sphinx pillow pytest pytest-cov sphinx_rtd_theme joblib 'plotly>=4.0'
+	conda info --envs
       displayName: Setup conda environment
     - script: python setup.py develop
       displayName: Install sphinx-gallery

--- a/continuous_integration/azure/install.sh
+++ b/continuous_integration/azure/install.sh
@@ -18,7 +18,7 @@ if [ "$DISTRIB" == "conda" ]; then
     CONDA_TO_INSTALL="$CONDA_TO_INSTALL python=$PYTHON_VERSION pip numpy setuptools matplotlib pillow pytest pytest-cov coverage seaborn statsmodels plotly joblib flake8 wheel"
     PIP_DEPENDENCIES="$@"
     PIP_DEPENDENCIES="$PIP_DEPENDENCIES sphinx_rtd_theme check-manifest"
-    if [ "$PYTHON_VERSION" != "3.6" -o "$LOCALE" != "C" ]; then
+    if [ "$PYTHON_VERSION" != "3.7" -o "$LOCALE" != "C" ]; then
         PIP_DEPENDENCIES="${PIP_DEPENDENCIES} memory_profiler vtk<=9.0.1 traits<6.3.0 https://github.com/enthought/mayavi/zipball/master ipython pypandoc"
     fi
     if [ "$SPHINX_VERSION" == "" ]; then

--- a/continuous_integration/azure/install.sh
+++ b/continuous_integration/azure/install.sh
@@ -15,7 +15,7 @@ if [ "$DISTRIB" == "conda" ]; then
     echo "##vso[task.prependpath]$CONDA/bin"
     export PATH=${CONDA}/bin:${PATH}
     CONDA_TO_INSTALL="$@"
-    CONDA_TO_INSTALL="$CONDA_TO_INSTALL python=$PYTHON_VERSION pip numpy setuptools matplotlib pillow pytest pytest-cov coverage seaborn statsmodels plotly joblib flake8 wheel"
+    CONDA_TO_INSTALL="$CONDA_TO_INSTALL python=$PYTHON_VERSION pip numpy setuptools matplotlib pillow pytest pytest-cov coverage seaborn statsmodels 'plotly>=4.0' joblib flake8 wheel"
     PIP_DEPENDENCIES="$@"
     PIP_DEPENDENCIES="$PIP_DEPENDENCIES sphinx_rtd_theme check-manifest"
     if [ "$PYTHON_VERSION" != "3.7" -o "$LOCALE" != "C" ]; then

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -405,7 +405,7 @@ is required to be named ``when``::
             mpl.rcParams['lines.linestyle'] = '-'
 
 The value passed into ``when`` can be ``before`` or ``after``.
-If ``reset_modules_order`` in the :ref:`configuration <reset_modules_order>`is set to ``before`` or
+If ``reset_modules_order`` in the :ref:`configuration <reset_modules_order>` is set to ``before`` or
 ``after``, ``when`` will always be the same value.  This function signature
 is only useful when used in conjuction with ``reset_modules_order`` set to ``both``.
 

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -405,7 +405,7 @@ is required to be named ``when``::
             mpl.rcParams['lines.linestyle'] = '-'
 
 The value passed into ``when`` can be ``before`` or ``after``.
-If ``reset_modules_order`` in the configuration is set to ``before`` or 
+If ``reset_modules_order`` in the :ref:`configuration <reset_modules_order>`is set to ``before`` or
 ``after``, ``when`` will always be the same value.  This function signature
 is only useful when used in conjuction with ``reset_modules_order`` set to ``both``.
 

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -401,7 +401,7 @@ is required to be named ``when``::
 
         import matplotlib as mpl
         mpl.rcParams['lines.linewidth'] = 2
-        if when == 'after' and fname=='dashed_lines'
+        if when == 'after' and fname=='dashed_lines':
             mpl.rcParams['lines.linestyle'] = '-'
 
 The value passed into ``when`` can be ``before`` or ``after``.

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -356,7 +356,7 @@ it with Sphinx-Gallery. You can:
 Resetting before each example
 =============================
 
-Sphinx-Gallery supports 'resetting' function(s) that are run before and/or after 
+Sphinx-Gallery supports 'resetting' function(s) that are run before and/or after
 each example script is executed. This is used natively in Sphinx-Gallery to 'reset'
 the behavior of the visualization packages ``matplotlib`` and ``seaborn``
 (:ref:`reset_modules`). However, this functionality could be used to reset other

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -356,12 +356,12 @@ it with Sphinx-Gallery. You can:
 Resetting before each example
 =============================
 
-Sphinx-Gallery supports 'resetting' via a prolog that is run before each
-example script is executed. This is used natively in Sphinx-Gallery to 'reset'
+Sphinx-Gallery supports 'resetting' function(s) that are run before and/or after 
+each example script is executed. This is used natively in Sphinx-Gallery to 'reset'
 the behavior of the visualization packages ``matplotlib`` and ``seaborn``
 (:ref:`reset_modules`). However, this functionality could be used to reset other
 libraries, modify the resetting behavior for a natively-reset library or run
-an arbitrary custom function at the start of each script.
+an arbitrary custom function at the start and/or end of each script.
 
 This is done by adding a custom function to the resetting tuple defined in
 ``conf.py``. The function should take two variables: a dictionary called
@@ -392,6 +392,22 @@ function (see :ref:`reset_modules`).
           standard behavior that users will experience when manually running
           examples themselves is discouraged due to the inconsistency
           that results between the rendered examples and local outputs.
+
+If the custom function needs to be aware of whether it is being run before or after
+an example, a function signature with three parameters can be used, where the third parameter
+is required to be named ``when``::
+
+    def reset_mpl(gallery_conf, fname, when):
+
+        import matplotlib as mpl
+        mpl.rcParams['lines.linewidth'] = 2
+        if when == 'after' and fname=='dashed_lines'
+            mpl.rcParams['lines.linestyle'] = '-'
+
+The value passed into ``when`` can be ``before`` or ``after``.
+If ``reset_modules_order`` in the configuration is set to ``before`` or 
+``after``, ``when`` will always be the same value.  This function signature
+is only useful when used in conjuction with ``reset_modules_order`` set to ``both``.
 
 Altering Sphinx-Gallery CSS
 ===========================

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -334,7 +334,7 @@ else:
 try:
     import plotly.io as pio
     pio.renderers.default = 'sphinx_gallery'
-except ImportError:
+except (ImportError, AttributeError):
     pass
 
 min_reported_time = 0

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -332,10 +332,11 @@ else:
 
 # Set plotly renderer to capture _repr_html_ for sphinx-gallery
 try:
-    import plotly.io as pio
-    pio.renderers.default = 'sphinx_gallery'
-except (ImportError, AttributeError):
+    import plotly.io.renderers
+except ImportError:
     pass
+else:
+    plotly.io.renderers.default = 'sphinx_gallery'
 
 min_reported_time = 0
 if 'SOURCE_DATE_EPOCH' in os.environ:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -36,6 +36,7 @@ file:
 - ``compress_images`` (:ref:`compress_images`)
 - ``image_srcset`` (:ref:`image_srcset`)
 - ``reset_modules`` (:ref:`reset_modules`)
+- ``reset_modules_order`` (:ref:`reset_modules_order`)
 - ``abort_on_example_error`` (:ref:`abort_on_first`)
 - ``only_warn_on_example_error`` (:ref:`warning_on_error`)
 - ``expected_failing_examples`` (:ref:`dont_fail_exit`)
@@ -1317,6 +1318,26 @@ this tuple in order to define resetting behavior for other visualization librari
 
 To do so, follow the instructions in :ref:`custom_reset`.
 
+.. _reset_modules_order:
+
+Order of resetting modules
+==========================
+
+By default, the Sphinx-Gallery will reset modules before each example is run.
+The choices for ``reset_modules_order`` are ``before`` (default), ``after``, and
+``both``. If the last example run in Sphinx-Gallery modifies a module, it is
+recommended to use ``after`` or ``both`` to avoid leaking out a modified module to
+other parts of the Sphinx build process.  For example, to use both use the following
+configuration::
+
+    sphinx_gallery_conf = {
+        ...
+        'reset_modules_order': 'both',
+    }
+
+Custom functions can be constructed to have custom functionality depending on
+whether they are called before or after the examples.  See :ref:`custom_reset`
+for more information.
 
 Dealing with failing Gallery example scripts
 ============================================

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1327,8 +1327,8 @@ By default, Sphinx-Gallery will reset modules before each example is run.
 The choices for ``reset_modules_order`` are ``before`` (default), ``after``, and
 ``both``. If the last example run in Sphinx-Gallery modifies a module, it is
 recommended to use ``after`` or ``both`` to avoid leaking out a modified module to
-other parts of the Sphinx build process.  For example, to use both use the following
-configuration::
+other parts of the Sphinx build process.  For example, set ``reset_modules_order``
+to ``both`` in the configuration::
 
     sphinx_gallery_conf = {
         ...

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1323,7 +1323,7 @@ To do so, follow the instructions in :ref:`custom_reset`.
 Order of resetting modules
 ==========================
 
-By default, the Sphinx-Gallery will reset modules before each example is run.
+By default, Sphinx-Gallery will reset modules before each example is run.
 The choices for ``reset_modules_order`` are ``before`` (default), ``after``, and
 ``both``. If the last example run in Sphinx-Gallery modifies a module, it is
 recommended to use ``after`` or ``both`` to avoid leaking out a modified module to

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     author="Óscar Nájera",
     author_email='najera.oscar@gmail.com',
     install_requires=install_requires,
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     license='3-clause BSD',
     classifiers=['Intended Audience :: Developers',
                  'Development Status :: 4 - Beta',

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -81,6 +81,7 @@ DEFAULT_GALLERY_CONF = {
     'image_scrapers': ('matplotlib',),
     'compress_images': (),
     'reset_modules': ('matplotlib', 'seaborn'),
+    'reset_modules_order': 'before',
     'first_notebook_cell': '%matplotlib inline',
     'last_notebook_cell': None,
     'notebook_images': False,
@@ -286,6 +287,13 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
             raise ConfigError('Module resetter %r was not callable'
                               % (resetter,))
     gallery_conf['reset_modules'] = tuple(resetters)
+
+    if not isinstance(gallery_conf['reset_modules_order'], str):
+        raise ConfigError('reset_modules_order must be a str, '
+                          'got %r' % gallery_conf['reset_modules_order'])
+    if gallery_conf['reset_modules_order'] not in ['before', 'after', 'both']:
+        raise ConfigError("reset_modules_order must be in ['before', 'after', 'both'], "
+                          'got %r' % gallery_conf['reset_modules_order'])
 
     lang = lang if lang in ('python', 'python3', 'default') else 'python'
     gallery_conf['lang'] = lang

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -292,7 +292,8 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
         raise ConfigError('reset_modules_order must be a str, '
                           'got %r' % gallery_conf['reset_modules_order'])
     if gallery_conf['reset_modules_order'] not in ['before', 'after', 'both']:
-        raise ConfigError("reset_modules_order must be in ['before', 'after', 'both'], "
+        raise ConfigError("reset_modules_order must be in"
+                          "['before', 'after', 'both'], "
                           'got %r' % gallery_conf['reset_modules_order'])
 
     lang = lang if lang in ('python', 'python3', 'default') else 'python'

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -926,7 +926,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
         'target_file': target_file}
 
     if executable and gallery_conf['reset_modules_order'] in ['before', 'both']:
-        clean_modules(gallery_conf, fname)
+        clean_modules(gallery_conf, fname, 'before')
     output_blocks, time_elapsed = execute_script(script_blocks,
                                                  script_vars,
                                                  gallery_conf)
@@ -996,7 +996,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
                           fname, intro, title)
 
     if executable and gallery_conf['reset_modules_order'] in ['after', 'both']:
-        clean_modules(gallery_conf, fname)
+        clean_modules(gallery_conf, fname, 'after')
 
     return intro, title, (time_elapsed, memory_used)
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -926,7 +926,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
         'target_file': target_file}
 
     if (
-        executable 
+        executable
         and gallery_conf['reset_modules_order'] in ['before', 'both']
     ):
         clean_modules(gallery_conf, fname, 'before')

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -925,7 +925,10 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
         'src_file': src_file,
         'target_file': target_file}
 
-    if executable and gallery_conf['reset_modules_order'] in ['before', 'both']:
+    if (
+        executable 
+        and gallery_conf['reset_modules_order'] in ['before', 'both']
+    ):
         clean_modules(gallery_conf, fname, 'before')
     output_blocks, time_elapsed = execute_script(script_blocks,
                                                  script_vars,

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -925,7 +925,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
         'src_file': src_file,
         'target_file': target_file}
 
-    if executable:
+    if executable and gallery_conf['reset_modules_order'] in ['before', 'both']:
         clean_modules(gallery_conf, fname)
     output_blocks, time_elapsed = execute_script(script_blocks,
                                                  script_vars,
@@ -994,6 +994,9 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
     # Write backreferences
     _write_backreferences(backrefs, seen_backrefs, gallery_conf, target_dir,
                           fname, intro, title)
+
+    if executable and gallery_conf['reset_modules_order'] in ['after', 'both']:
+        clean_modules(gallery_conf, fname)
 
     return intro, title, (time_elapsed, memory_used)
 

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -13,6 +13,7 @@ images are injected as rst ``image-sg`` directives into the ``.rst``
 file generated for each example script.
 """
 
+import inspect
 import os
 import sys
 import re
@@ -564,7 +565,7 @@ _reset_dict = {
 }
 
 
-def clean_modules(gallery_conf, fname):
+def clean_modules(gallery_conf, fname, when):
     """Remove, unload, or reset modules.
 
     After a script is executed it can load a variety of settings that one
@@ -577,6 +578,15 @@ def clean_modules(gallery_conf, fname):
     fname : str or None
         The example being run. Will be None when this is called entering
         a directory of examples to be built.
+    when : {'before', 'after'}
+        Whether this module is run before or after examples.
+
+        This parameter is only forwarded when the callables accept 3 parameters.
     """
     for reset_module in gallery_conf['reset_modules']:
-        reset_module(gallery_conf, fname)
+
+        sig = inspect.signature(reset_module)
+        if len(sig.parameters) == 3:
+            reset_module(gallery_conf, fname, when)
+        else:
+            reset_module(gallery_conf, fname)

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -581,7 +581,8 @@ def clean_modules(gallery_conf, fname, when):
     when : {'before', 'after'}
         Whether this module is run before or after examples.
 
-        This parameter is only forwarded when the callables accept 3 parameters.
+        This parameter is only forwarded when the callables accept 3
+        parameters.
     """
     for reset_module in gallery_conf['reset_modules']:
 
@@ -589,8 +590,8 @@ def clean_modules(gallery_conf, fname, when):
         if len(sig.parameters) == 3:
             third_param = list(sig.parameters.keys())[2]
             if not third_param == 'when':
-                raise ValueError("3rd parameter in function signature must be 'when', "
-                                 "got %s" % third_param)
+                raise ValueError("3rd parameter in function signature must"
+                                 "be 'when', got %s" % third_param)
             reset_module(gallery_conf, fname, when)
         else:
             reset_module(gallery_conf, fname)

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -590,8 +590,8 @@ def clean_modules(gallery_conf, fname, when):
         if len(sig.parameters) == 3:
             third_param = list(sig.parameters.keys())[2]
             if third_param != 'when':
-                raise ValueError("3rd parameter in function signature must "
-                                 "be 'when', got %s" % third_param)
+                raise ValueError(f"3rd parameter in {reset_module.__name__} function"
+                                          signature must be 'when', got {third_param}")
             reset_module(gallery_conf, fname, when=when)
         else:
             reset_module(gallery_conf, fname)

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -590,8 +590,9 @@ def clean_modules(gallery_conf, fname, when):
         if len(sig.parameters) == 3:
             third_param = list(sig.parameters.keys())[2]
             if third_param != 'when':
-                raise ValueError(f"3rd parameter in {reset_module.__name__} function "
-                                 f"signature must be 'when', got {third_param}")
+                raise ValueError(f"3rd parameter in {reset_module.__name__} "
+                                 "function signature must be 'when', "
+                                 f"got {third_param}")
             reset_module(gallery_conf, fname, when=when)
         else:
             reset_module(gallery_conf, fname)

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -590,7 +590,7 @@ def clean_modules(gallery_conf, fname, when):
         if len(sig.parameters) == 3:
             third_param = list(sig.parameters.keys())[2]
             if not third_param == 'when':
-                raise ValueError("3rd parameter in function signature must"
+                raise ValueError("3rd parameter in function signature must "
                                  "be 'when', got %s" % third_param)
             reset_module(gallery_conf, fname, when)
         else:

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -587,6 +587,10 @@ def clean_modules(gallery_conf, fname, when):
 
         sig = inspect.signature(reset_module)
         if len(sig.parameters) == 3:
+            third_param = list(sig.parameters.keys())[2]
+            if not third_param == 'when':
+                raise ValueError("3rd parameter in function signature must be 'when', "
+                                 "got %s" % third_param)
             reset_module(gallery_conf, fname, when)
         else:
             reset_module(gallery_conf, fname)

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -590,8 +590,8 @@ def clean_modules(gallery_conf, fname, when):
         if len(sig.parameters) == 3:
             third_param = list(sig.parameters.keys())[2]
             if third_param != 'when':
-                raise ValueError(f"3rd parameter in {reset_module.__name__} function"
-                                          signature must be 'when', got {third_param}")
+                raise ValueError(f"3rd parameter in {reset_module.__name__} function "
+                                 f"signature must be 'when', got {third_param}")
             reset_module(gallery_conf, fname, when=when)
         else:
             reset_module(gallery_conf, fname)

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -565,7 +565,7 @@ _reset_dict = {
 
 
 def clean_modules(gallery_conf, fname):
-    """Remove, unload, or reset modules after running each example.
+    """Remove, unload, or reset modules.
 
     After a script is executed it can load a variety of settings that one
     does not want to influence in other examples in the gallery.

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -578,7 +578,7 @@ def clean_modules(gallery_conf, fname, when):
     fname : str or None
         The example being run. Will be None when this is called entering
         a directory of examples to be built.
-    when : {'before', 'after'}
+    when : str
         Whether this module is run before or after examples.
 
         This parameter is only forwarded when the callables accept 3
@@ -589,9 +589,9 @@ def clean_modules(gallery_conf, fname, when):
         sig = inspect.signature(reset_module)
         if len(sig.parameters) == 3:
             third_param = list(sig.parameters.keys())[2]
-            if not third_param == 'when':
+            if third_param != 'when':
                 raise ValueError("3rd parameter in function signature must "
                                  "be 'when', got %s" % third_param)
-            reset_module(gallery_conf, fname, when)
+            reset_module(gallery_conf, fname, when=when)
         else:
             reset_module(gallery_conf, fname)

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -695,6 +695,7 @@ def test_error_messages(sphinx_app, name, want):
     example_rst = op.join(src_dir, 'auto_examples', name + '.rst')
     with codecs.open(example_rst, 'r', 'utf-8') as fid:
         rst = fid.read().replace('\n', ' ')
+    print(rst)
     assert re.match(want, rst) is not None
 
 

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -694,8 +694,9 @@ def test_error_messages(sphinx_app, name, want):
     src_dir = sphinx_app.srcdir
     example_rst = op.join(src_dir, 'auto_examples', name + '.rst')
     with codecs.open(example_rst, 'r', 'utf-8') as fid:
-        rst = fid.read().replace('\n', ' ')
+        rst = fid.read()
     print(rst)
+    rst = rst.replace('\n', ' ')
     assert re.match(want, rst) is not None
 
 

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -79,11 +79,13 @@ def test_bad_reset(sphinx_app_wrapper, err_class, err_match):
     pytest.param(ConfigError, 'reset_modules_order must be a str',
                  id='Resetter unknown',
                  marks=pytest.mark.conf_file(
-                     content="sphinx_gallery_conf={'reset_modules_order': 1,}")),
+                     content=("sphinx_gallery_conf="
+                              "{'reset_modules_order': 1,}"))),
     pytest.param(ConfigError, "reset_modules_order must be in",
                  id='reset_modules_order not valid',
                  marks=pytest.mark.conf_file(
-                     content="sphinx_gallery_conf={'reset_modules_order': 'invalid',}")),
+                     content=("sphinx_gallery_conf="
+                              "{'reset_modules_order': 'invalid',}"))),
 ])
 def test_bad_reset_modules_order(sphinx_app_wrapper, err_class, err_match):
     with pytest.raises(err_class, match=err_match):

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -76,6 +76,21 @@ def test_bad_reset(sphinx_app_wrapper, err_class, err_match):
 
 
 @pytest.mark.parametrize('err_class, err_match', [
+    pytest.param(ConfigError, 'reset_modules_order must be a str',
+                 id='Resetter unknown',
+                 marks=pytest.mark.conf_file(
+                     content="sphinx_gallery_conf={'reset_modules_order': 1,}")),
+    pytest.param(ConfigError, "reset_modules_order must be in",
+                 id='reset_modules_order not valid',
+                 marks=pytest.mark.conf_file(
+                     content="sphinx_gallery_conf={'reset_modules_order': 'invalid',}")),
+])
+def test_bad_reset_modules_order(sphinx_app_wrapper, err_class, err_match):
+    with pytest.raises(err_class, match=err_match):
+        sphinx_app_wrapper.create_sphinx_app()
+
+
+@pytest.mark.parametrize('err_class, err_match', [
     pytest.param(ConfigError, 'Unknown css', id='CSS str error',
                  marks=pytest.mark.conf_file(
                      content="sphinx_gallery_conf={'css': ('foo',)}")),

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -836,7 +836,7 @@ def test_reset_module_order_2_param(gallery_conf, order, call_count):
     mock_reset_module = mock.create_autospec(cleanup_2_param)
     gallery_conf['reset_modules'] = (mock_reset_module,)
     gallery_conf['reset_modules_order'] = order
-    _generate_rst(gallery_conf, 'plot_test.py', ALPHA_CONTENT)
+    _generate_rst(gallery_conf, 'plot_test.py', CONTENT)
     assert mock_reset_module.call_count == call_count
 
 
@@ -858,7 +858,7 @@ def test_reset_module_order_3_param(gallery_conf, order, call_count,
     mock_reset_module = mock.create_autospec(cleanup_3_param)
     gallery_conf['reset_modules'] = (mock_reset_module,)
     gallery_conf['reset_modules_order'] = order
-    _generate_rst(gallery_conf, 'plot_test.py', ALPHA_CONTENT)
+    _generate_rst(gallery_conf, 'plot_test.py', CONTENT)
     assert mock_reset_module.call_count == call_count
 
     expected_calls = [
@@ -878,7 +878,7 @@ def test_reset_module_order_3_param_invalid_when(gallery_conf):
     gallery_conf['reset_modules_order'] = 'before'
     with pytest.raises(ValueError, match=("3rd parameter in function"
                                           "signature must be 'when',")):
-        _generate_rst(gallery_conf, 'plot_test.py', ALPHA_CONTENT)
+        _generate_rst(gallery_conf, 'plot_test.py', CONTENT)
     assert mock_reset_module.call_count == 0
 
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -865,6 +865,20 @@ def test_reset_module_order_3_param(gallery_conf, order, call_count,
     mock_reset_module.assert_has_calls(expected_calls)
 
 
+def test_reset_module_order_3_param_invalid_when(gallery_conf):
+    """Test reset module with unknown 3rd parameter."""
+
+    def cleanup_3_param(gallery_conf, fname, invalid):
+        pass
+
+    mock_reset_module = mock.create_autospec(cleanup_3_param)
+    gallery_conf['reset_modules'] = (mock_reset_module,)
+    gallery_conf['reset_modules_order'] = 'before'
+    with pytest.raises(ValueError, match="3rd parameter in function signature must be 'when',"):
+        rst = _generate_rst(gallery_conf, 'plot_test.py', ALPHA_CONTENT)
+    assert mock_reset_module.call_count == 0
+
+
 class TestLoggingTee:
     def setup(self):
         self.src_filename = 'source file name'

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -13,6 +13,7 @@ import tempfile
 import re
 import os
 import shutil
+from unittest.mock import Mock
 import zipfile
 import codeop
 
@@ -821,6 +822,16 @@ def test_ignore_repr_types(gallery_conf, req_mpl, req_pil, script_vars):
         compiler, code_block, None, script_vars, gallery_conf
     )
     assert _clean_output(output) == ''
+
+
+@pytest.mark.parametrize(('order', 'call_count'), [('before', 1), ('after', 1), ('both', 2)])
+def test_reset_module_order(gallery_conf, order, call_count):
+    """Test that module order is maintained."""
+    mock_reset_module = Mock()
+    gallery_conf['reset_modules'] = (mock_reset_module,)
+    gallery_conf['reset_modules_order'] = order
+    rst = _generate_rst(gallery_conf, 'plot_test.py', ALPHA_CONTENT)
+    assert mock_reset_module.call_count == call_count
 
 
 class TestLoggingTee:

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -876,8 +876,9 @@ def test_reset_module_order_3_param_invalid_when(gallery_conf):
     mock_reset_module = mock.create_autospec(cleanup_3_param)
     gallery_conf['reset_modules'] = (mock_reset_module,)
     gallery_conf['reset_modules_order'] = 'before'
-    with pytest.raises(ValueError, match="3rd parameter in function signature must be 'when',"):
-        rst = _generate_rst(gallery_conf, 'plot_test.py', ALPHA_CONTENT)
+    with pytest.raises(ValueError, match=("3rd parameter in function"
+                                          "signature must be 'when',")):
+        _generate_rst(gallery_conf, 'plot_test.py', ALPHA_CONTENT)
     assert mock_reset_module.call_count == 0
 
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -876,7 +876,7 @@ def test_reset_module_order_3_param_invalid_when(gallery_conf):
     mock_reset_module = mock.create_autospec(cleanup_3_param)
     gallery_conf['reset_modules'] = (mock_reset_module,)
     gallery_conf['reset_modules_order'] = 'before'
-    with pytest.raises(ValueError, match=("3rd parameter in function"
+    with pytest.raises(ValueError, match=("3rd parameter in function "
                                           "signature must be 'when',")):
         _generate_rst(gallery_conf, 'plot_test.py', CONTENT)
     assert mock_reset_module.call_count == 0

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -836,15 +836,15 @@ def test_reset_module_order_2_param(gallery_conf, order, call_count):
     mock_reset_module = mock.create_autospec(cleanup_2_param)
     gallery_conf['reset_modules'] = (mock_reset_module,)
     gallery_conf['reset_modules_order'] = order
-    rst = _generate_rst(gallery_conf, 'plot_test.py', ALPHA_CONTENT)
+    _generate_rst(gallery_conf, 'plot_test.py', ALPHA_CONTENT)
     assert mock_reset_module.call_count == call_count
 
 
 @pytest.mark.parametrize(
     ('order', 'call_count', 'expected_call_order'),
     [
-        ('before', 1, ('before',)), 
-        ('after', 1, ('after',)), 
+        ('before', 1, ('before',)),
+        ('after', 1, ('after',)),
         ('both', 2, ('before', 'after'))
     ]
 )
@@ -858,10 +858,12 @@ def test_reset_module_order_3_param(gallery_conf, order, call_count,
     mock_reset_module = mock.create_autospec(cleanup_3_param)
     gallery_conf['reset_modules'] = (mock_reset_module,)
     gallery_conf['reset_modules_order'] = order
-    rst = _generate_rst(gallery_conf, 'plot_test.py', ALPHA_CONTENT)
+    _generate_rst(gallery_conf, 'plot_test.py', ALPHA_CONTENT)
     assert mock_reset_module.call_count == call_count
 
-    expected_calls = [mock.call(mock.ANY, mock.ANY, order) for order in expected_call_order]
+    expected_calls = [
+        mock.call(mock.ANY, mock.ANY, order) for order in expected_call_order
+    ]
     mock_reset_module.assert_has_calls(expected_calls)
 
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -827,7 +827,7 @@ def test_ignore_repr_types(gallery_conf, req_mpl, req_pil, script_vars):
 @pytest.mark.parametrize(
     ('order', 'call_count'), [('before', 1), ('after', 1), ('both', 2)]
 )
-def test_reset_module_order_2_param(gallery_conf, order, call_count):
+def test_reset_module_order_2_param(gallery_conf, order, call_count, req_pil):
     """Test that reset module with 2 parameters."""
 
     def cleanup_2_param(gallery_conf, fname):
@@ -849,7 +849,7 @@ def test_reset_module_order_2_param(gallery_conf, order, call_count):
     ]
 )
 def test_reset_module_order_3_param(gallery_conf, order, call_count,
-                                    expected_call_order):
+                                    expected_call_order, req_pil):
     """Test reset module with 3 parameters."""
 
     def cleanup_3_param(gallery_conf, fname, when):

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -13,7 +13,7 @@ import tempfile
 import re
 import os
 import shutil
-from unittest.mock import Mock
+from unittest import mock
 import zipfile
 import codeop
 
@@ -824,14 +824,45 @@ def test_ignore_repr_types(gallery_conf, req_mpl, req_pil, script_vars):
     assert _clean_output(output) == ''
 
 
-@pytest.mark.parametrize(('order', 'call_count'), [('before', 1), ('after', 1), ('both', 2)])
-def test_reset_module_order(gallery_conf, order, call_count):
-    """Test that module order is maintained."""
-    mock_reset_module = Mock()
+@pytest.mark.parametrize(
+    ('order', 'call_count'), [('before', 1), ('after', 1), ('both', 2)]
+)
+def test_reset_module_order_2_param(gallery_conf, order, call_count):
+    """Test that reset module with 2 parameters."""
+
+    def cleanup_2_param(gallery_conf, fname):
+        pass
+
+    mock_reset_module = mock.create_autospec(cleanup_2_param)
     gallery_conf['reset_modules'] = (mock_reset_module,)
     gallery_conf['reset_modules_order'] = order
     rst = _generate_rst(gallery_conf, 'plot_test.py', ALPHA_CONTENT)
     assert mock_reset_module.call_count == call_count
+
+
+@pytest.mark.parametrize(
+    ('order', 'call_count', 'expected_call_order'),
+    [
+        ('before', 1, ('before',)), 
+        ('after', 1, ('after',)), 
+        ('both', 2, ('before', 'after'))
+    ]
+)
+def test_reset_module_order_3_param(gallery_conf, order, call_count,
+                                    expected_call_order):
+    """Test reset module with 3 parameters."""
+
+    def cleanup_3_param(gallery_conf, fname, when):
+        pass
+
+    mock_reset_module = mock.create_autospec(cleanup_3_param)
+    gallery_conf['reset_modules'] = (mock_reset_module,)
+    gallery_conf['reset_modules_order'] = order
+    rst = _generate_rst(gallery_conf, 'plot_test.py', ALPHA_CONTENT)
+    assert mock_reset_module.call_count == call_count
+
+    expected_calls = [mock.call(mock.ANY, mock.ANY, order) for order in expected_call_order]
+    mock_reset_module.assert_has_calls(expected_calls)
 
 
 class TestLoggingTee:

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -876,8 +876,9 @@ def test_reset_module_order_3_param_invalid_when(gallery_conf):
     mock_reset_module = mock.create_autospec(cleanup_3_param)
     gallery_conf['reset_modules'] = (mock_reset_module,)
     gallery_conf['reset_modules_order'] = 'before'
-    with pytest.raises(ValueError, match=("3rd parameter in function "
-                                          "signature must be 'when',")):
+    with pytest.raises(ValueError,
+                       match=("3rd parameter in cleanup_3_param "
+                              "function signature must be 'when'")):
         _generate_rst(gallery_conf, 'plot_test.py', CONTENT)
     assert mock_reset_module.call_count == 0
 

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -1,5 +1,4 @@
 import os.path as op
-import numpy as np
 from sphinx_gallery.scrapers import matplotlib_scraper
 from sphinx_gallery.sorting import FileNameSortKey
 

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -27,7 +27,9 @@ class ResetArgv:
             return []
 
 
-def _raise():
+def _raise(*args, **kwargs):
+    import matplotlib.pyplot as plt
+    plt.close('all')
     raise ValueError('zero-size array to reduction operation minimum which '
                      'has no identity')
 
@@ -35,18 +37,18 @@ def _raise():
 class MockScrapeProblem:
 
     def __init__(self):
-        from matplotlib.figure import Figure
-        self._orig_mpl = Figure.savefig
+        from matplotlib.colors import colorConverter
+        self._orig = colorConverter.to_rgba
 
     def __repr__(self):
         return "MockScrapeProblem"
 
     def __call__(self, gallery_conf, fname):
-        from matplotlib.figure import Figure
+        from matplotlib.colors import colorConverter
         if 'scraper_broken' in fname:
-            Figure.savefig = lambda *args, **kwargs: _raise()
+            colorConverter.to_rgba = _raise
         else:
-            Figure.savefig = self._orig_mpl
+            colorConverter.to_rgba = self._orig
 
 
 extensions = [

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -28,6 +28,11 @@ class ResetArgv:
             return []
 
 
+def _raise():
+    raise ValueError('zero-size array to reduction operation minimum which '
+                     'has no identity')
+
+
 class MockScrapeProblem:
 
     def __init__(self):
@@ -40,7 +45,7 @@ class MockScrapeProblem:
     def __call__(self, gallery_conf, fname):
         from matplotlib.figure import Figure
         if 'scraper_broken' in fname:
-            Figure.savefig = lambda *args, **kwargs: np.min([])
+            Figure.savefig = lambda *args, **kwargs: _raise()
         else:
             Figure.savefig = self._orig_mpl
 


### PR DESCRIPTION
# Summary

As noted in #866, `reset_modules` functions are currently only called _before_ examples are run.  In the case that the last example modifies an import, `reset_modules` won't run subsequent to this example.  The modified module will leak out into other parts of the build process.

This PR adds another configuration option `reset_modules_order` that can be `after`, `before`, or `both`, which specifies when the callables in `reset_modules` are called.  The default is `before` which retains the current behavior.

This PR closes #866.