### PR TITLE
Fix "Out" layout for pydata-sphinx-theme

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1190,7 +1190,7 @@ than a single static image of the animation figure, you should add::
 
 HTML embedding options can be changed by setting ``rcParams['animation.html']``
 and related options in your
-:ref:`matplotlib rcParams <matplotlib:matplotlib-rcparams>`.
+`matplotlib rcParams <https://matplotlib.org/stable/tutorials/introductory/customizing.html>`_.
 It's also recommended to ensure that "imagemagick" is available as a
 ``writer``, which you can check with
 :class:`matplotlib.animation.ImageMagickWriter.isAvailable()

--- a/sphinx_gallery/_static/sg_gallery.css
+++ b/sphinx_gallery/_static/sg_gallery.css
@@ -82,7 +82,7 @@ p.sphx-glr-script-out {
 .sphx-glr-script-out .highlight {
   background-color: transparent;
   margin-left: 2.5em;
-  margin-top: -2.1em;
+  margin-top: -2.9em;
 }
 .sphx-glr-script-out .highlight pre {
   background-color: #fafae2;


### PR DESCRIPTION
Follow up to #484, which got misaligned again, likely through pydata-sphinx-theme.

Note: This is a purely empirical suggestion based on the matplotlib docs, e.g.:
https://matplotlib.org/devdocs/tutorials/colors/colormap-manipulation.html

I don't know how to find out whether this is generally ok.

Before:
![grafik](https://user-images.githubusercontent.com/2836374/143152055-1de79c74-91b1-437d-b613-224b414ac8b8.png)

![grafik](https://user-images.githubusercontent.com/2836374/143151870-90b9e023-7123-4aa6-b076-c22753964d88.png)


After:
![grafik](https://user-images.githubusercontent.com/2836374/143152008-ec87013e-c564-4eeb-bd75-65080d6f87a0.png)


![grafik](https://user-images.githubusercontent.com/2836374/143151827-69a0e1d9-22e1-4acb-b1e2-ed5689b728c0.png)


