### PR TITLE
Fix matplotlib resetter _reset_matplotlib

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1321,7 +1321,8 @@ to ensure that any changes made to plotting behavior in one example do not
 propagate to the other examples.
 
 By default, before each example file executes, Sphinx-Gallery will
-reset ``matplotlib`` (by using :func:`matplotlib.pyplot.rcdefaults`) and ``seaborn``
+reset ``matplotlib`` (by using :func:`matplotlib.pyplot.rcdefaults` and
+reloading submodules that populate the units registry) and ``seaborn``
 (by trying to unload the module from ``sys.modules``). This is equivalent to the
 following configuration::
 

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -13,6 +13,7 @@ images are injected as rst ``image-sg`` directives into the ``.rst``
 file generated for each example script.
 """
 
+import importlib
 import inspect
 import os
 import sys
@@ -544,8 +545,11 @@ SINGLE_IMAGE = """
 
 def _reset_matplotlib(gallery_conf, fname):
     """Reset matplotlib."""
-    _, plt = _import_matplotlib()
+    mpl, plt = _import_matplotlib()
     plt.rcdefaults()
+    importlib.reload(mpl.units)
+    importlib.reload(mpl.dates)
+    importlib.reload(mpl.category)
 
 
 def _reset_seaborn(gallery_conf, fname):

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -7,7 +7,8 @@ import sphinx_gallery
 from sphinx_gallery.gen_gallery import _complete_gallery_conf
 from sphinx_gallery.scrapers import (figure_rst, mayavi_scraper, SG_IMAGE,
                                      matplotlib_scraper, ImagePathIterator,
-                                     save_figures, _KNOWN_IMG_EXTS)
+                                     save_figures, _KNOWN_IMG_EXTS,
+                                     _reset_matplotlib)
 from sphinx_gallery.utils import _get_image
 
 
@@ -313,3 +314,15 @@ def test_iterator():
     with pytest.raises(ExtensionError, match='10 images'):
         for ii in ipi:
             pass
+
+
+def test_reset_matplotlib(gallery_conf):
+    """Test _reset_matplotlib."""
+    import matplotlib
+    matplotlib.rcParams['lines.linewidth'] = 42
+    matplotlib.units.registry.clear()
+
+    _reset_matplotlib(gallery_conf, '')
+
+    assert matplotlib.rcParams['lines.linewidth'] != 42
+    assert len(matplotlib.units.registry) > 0


### PR DESCRIPTION
Reset the units registry to its default contents by reloading all submodules that (currently, as of mpl 3.5.0) populate the registry.

Closes #889.

For further background information on reloading modules see https://stackoverflow.com/a/487718/3944322 and [this gist](https://gist.github.com/StefRe/f92b13c85cfd7cc294fa8a4b4610331f).