### PR TITLE
Config capture_repr on file-by-file basis

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -57,6 +57,7 @@ Some options can also be set or overridden on a file-by-file basis:
 - ``# sphinx_gallery_thumbnail_number`` (:ref:`choosing_thumbnail`)
 - ``# sphinx_gallery_thumbnail_path`` (:ref:`providing_thumbnail`)
 - ``# sphinx_gallery_dummy_images`` (:ref:`dummy_images`)
+- ``# sphinx_gallery_capture_repr`` (:ref:`capture_repr`)
 
 Some options can be set on a per-code-block basis in a file:
 
@@ -1578,6 +1579,13 @@ are:
   to ``format()``.
 * ``_repr_html_`` - returns a HTML version of the object. This method is only
   present in some objects, for example, pandas dataframes.
+
+Output capture can be controlled globally by the ``capture_repr`` configuration
+setting or file-by-file by adding a comment to the example file, which overrides
+any global setting::
+
+    # sphinx_gallery_capture_repr = ()
+
 
 The default setting is::
 


### PR DESCRIPTION
Make `gallery_conf['capture_repr']` overridable by `# sphinx_gallery_capture_repr` file config comment.

Use case: Sometimes, especially in examples with many short code sections, it is undesirable to have all the output boxes while you can't globally set `capture_repr` to `()` as there are some examples in the gallery where the output is needed. Making all these short code sections end with `plt.show()` or turning the last line into an assignment isn't ideal either as the former introduces a lot of extra lines of code and the latter may seem confusing, see matplotlib/matplotlib#21794 (putting a semicolon after the last expression doesn't work here as the code is first compiled into an AST and then the last expression is taken from the tree where the semicolon as code delimiter isn't present, see [code](https://github.com/sphinx-gallery/sphinx-gallery/blob/9a09fc1377de833db9f1d7f23686e37c3d7a02dc/sphinx_gallery/gen_rst.py#L573-L574)).  

So with this PR it would be possible to globally set the normal capture representation and then define exception on a file-by-file basis.