### PR TITLE
Use pseudo-elements for 'Out:' prefixing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+Next version
+------------
+
+In this version, the "Out:" prefix applied to code outputs is now created from
+CSS pseudo-elements instead of additional real text. For more details, see
+`#896 <https://github.com/sphinx-gallery/sphinx-gallery/pull/896>`.
+
 v0.10.1
 -------
 

--- a/sphinx_gallery/_static/sg_gallery.css
+++ b/sphinx_gallery/_static/sg_gallery.css
@@ -74,15 +74,25 @@ thumbnail with its default link Background color */
 
 .sphx-glr-script-out {
   color: #888;
-  margin: 0;
+  display: flex;
+  gap: 0.5em;
 }
-p.sphx-glr-script-out {
-    padding-top: 0.7em;
+.sphx-glr-script-out::before {
+  content: "Out:";
+  /* These numbers come from the pre style in the pydata sphinx theme. This
+   * turns out to match perfectly on the rtd theme, but be a bit too low for
+   * the pydata sphinx theme. As I could not find a dimension to use that was
+   * scaled the same way, I just picked one option that worked pretty close for
+   * both. */
+  line-height: 1.4;
+  padding-top: 10px;
 }
 .sphx-glr-script-out .highlight {
   background-color: transparent;
-  margin-left: 2.5em;
-  margin-top: -2.9em;
+  /* These options make the div expand... */
+  flex-grow: 1;
+  /* ... but also keep it from overflowing its flex container. */
+  overflow: auto;
 }
 .sphx-glr-script-out .highlight pre {
   background-color: #fafae2;
@@ -90,7 +100,10 @@ p.sphx-glr-script-out {
   max-height: 30em;
   overflow: auto;
   padding-left: 1ex;
-  margin: 0px;
+  /* This margin is necessary in the pydata sphinx theme because pre has a box
+   * shadow which would be clipped by the overflow:auto in the parent div
+   * above. */
+  margin: 2px;
   word-break: break-word;
 }
 .sphx-glr-script-out + p {

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -140,8 +140,6 @@ SINGLE_IMAGE = """
 
 CODE_OUTPUT = """.. rst-class:: sphx-glr-script-out
 
- Out:
-
  .. code-block:: none
 
 {0}\n"""

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -518,7 +518,7 @@ def test_pattern_matching(gallery_conf, log_collector, req_pil):
     gallery_conf.update(image_scrapers=(), reset_modules=())
     gallery_conf.update(filename_pattern=re.escape(os.sep) + 'plot_0')
 
-    code_output = ('\n Out:\n\n .. code-block:: none\n'
+    code_output = ('\n .. code-block:: none\n'
                    '\n'
                    '    Óscar output\n'
                    '    log:Óscar\n'
@@ -746,9 +746,7 @@ html_out = """.. raw:: html
     <br />
     <br />"""
 
-text_above_html = """Out:
-
- .. code-block:: none
+text_above_html = """.. code-block:: none
 
     print statement
 
@@ -768,7 +766,7 @@ def _clean_output(output):
         return output_test_string.strip()
     elif is_text:
         output_test_string = "\n".join(
-            [line[4:] for line in output.strip().split("\n")[6:]])
+            [line[4:] for line in output.strip().split("\n")[4:]])
         return output_test_string.strip()
     elif is_html:
         output_test_string = "\n".join(output.strip().split("\n"))


### PR DESCRIPTION
There's still an arbitrary padding, but now it goes on the added content instead of the existing `pre`. Without the negative margin, this prevents the `pre` from accidentally overlapping previous content. Some additional tweaks are necessary to work with the pydata sphinx theme, but it appears to work for the rtd theme as well.

For example, the error output [on this page](https://65575-1385122-gh.circle-artifacts.com/0/doc/build/html/gallery/style_sheets/style_sheets_reference.html) uses the same class, but is oddly placed due to the negative margins.

On the plot strings example (i.e., using rtd theme), this looks like this (at 500%):
![image](https://user-images.githubusercontent.com/302469/146628432-c7ddfec8-349f-4a90-b5e2-f66bf9dea4f7.png)
and here's how it looks in a Matplotlib example (i.e., using mpl-sphinx-theme, which derives from pydata-sphinx-theme):
![image](https://user-images.githubusercontent.com/302469/146629389-d77b5f36-2ad3-4c32-90be-ac2436487a9e.png)
It's a tiny bit too low, but that's not noticeable at normal scale.