### PR TITLE
[WIP] Handle nested structures

### DIFF
--- a/examples/no_output/README.txt
+++ b/examples/no_output/README.txt
@@ -1,5 +1,3 @@
-.. _no_out_examples:
-
 No image output examples
 ------------------------
 

--- a/examples/no_output/README.txt
+++ b/examples/no_output/README.txt
@@ -1,3 +1,5 @@
+.. _no_out_examples:
+
 No image output examples
 ------------------------
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -420,7 +420,18 @@ def generate_gallery_rst(app):
     """Generate the Main examples gallery reStructuredText
 
     Start the Sphinx-Gallery configuration and recursively scan the examples
-    directories in order to populate the examples gallery
+    directories in order to populate the examples gallery.
+
+    We create a 2-level nested structure by iterating through every
+    sibling folder of the current index file.
+    In each of these folders, we look for a section index file,
+    for which we generate a toctree pointing to sibling scripts.
+    Then, we append the content of this section index file
+    to the current index file,
+    after we remove toctree (to keep a clean nested structure)
+    and sphinx tags (to prevent tag duplication)
+    Eventually, we create a toctree in the current index file
+    which points to section index files.
     """
     blocked_builder = ['dirhtml']
     if app.builder.name in blocked_builder:
@@ -450,8 +461,8 @@ def generate_gallery_rst(app):
         examples_dir_abs_path = os.path.join(app.builder.srcdir, examples_dir)
         gallery_dir_abs_path = os.path.join(app.builder.srcdir, gallery_dir)
 
-        # Here we don't use an os.walk, but we recurse only twice: flat is
-        # better than nested.
+        # Create section rst files and fetch content which will
+        # be added to current index file
         this_fhindex, this_costs, this_toctree, _ = generate_dir_rst(
             examples_dir_abs_path,
             gallery_dir_abs_path,

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -459,6 +459,16 @@ def generate_gallery_rst(app):
             seen_backrefs
         )
 
+        # Filter out tags from fhindex
+        # to prevent tag duplication across the documentation
+        tag_regex = r"^\.\.(\s+)\_(.+)\:(\s*)$"
+        this_fhindex = "\n".join(list(
+            filter(
+                lambda l: re.match(tag_regex, l) is None,
+                iter(this_fhindex.splitlines())
+            )
+        ))
+
         costs += this_costs
         write_computation_times(gallery_conf, gallery_dir_abs_path, this_costs)
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -472,7 +472,9 @@ def generate_gallery_rst(app):
                         '/', gallery_dir, subsection, 'index.rst'
                     )
                 )
-                subsection_index_content, subsection_costs, _, subsection_index_path = \
+
+                subsection_index_content, subsection_costs, \
+                    _, subsection_index_path = \
                     generate_dir_rst(src_dir, target_dir, gallery_conf,
                                      seen_backrefs)
                 fhindex.write(subsection_index_content)

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -484,16 +484,6 @@ def generate_gallery_rst(app):
             seen_backrefs
         )
 
-        # Filter out tags from fhindex
-        # to prevent tag duplication across the documentation
-        tag_regex = r"^\.\.(\s+)\_(.+)\:(\s*)$"
-        this_fhindex = "\n".join(list(
-            filter(
-                lambda l: re.match(tag_regex, l) is None,
-                iter(this_fhindex.splitlines())
-            )
-        ))
-
         costs += this_costs
         write_computation_times(gallery_conf, gallery_dir_abs_path, this_costs)
 
@@ -516,10 +506,23 @@ def generate_gallery_rst(app):
                     )
                 )
 
-                subsection_index_content, subsection_costs, \
-                    _, subsection_index_path = \
-                    generate_dir_rst(src_dir, target_dir, gallery_conf,
-                                     seen_backrefs)
+                (
+                    subsection_index_content,
+                    subsection_costs,
+                    _,
+                    subsection_index_path,
+                ) = generate_dir_rst(
+                    src_dir, target_dir, gallery_conf, seen_backrefs
+                )
+
+                # Filter out tags from subsection content
+                # to prevent tag duplication across the documentation
+                tag_regex = r"^\.\.(\s+)\_(.+)\:(\s*)$"
+                subsection_index_content = "\n".join([
+                    line for line in subsection_index_content.splitlines()
+                    if re.match(tag_regex, line) is None
+                ] + [''])
+
                 fhindex.write(subsection_index_content)
 
                 costs += subsection_costs

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -486,7 +486,7 @@ def generate_gallery_rst(app):
 
                 _replace_md5(subsection_index_path, mode='t')
 
-            # generate and write toctree with subsections
+            # generate toctree with subsections
             subsections_toctree = """
 .. toctree::
    :hidden:
@@ -495,7 +495,9 @@ def generate_gallery_rst(app):
    %s\n
 """ % "\n   ".join(subsection_index_files)
 
-            fhindex.write(subsections_toctree)
+            # add toctree to file only if there are subsections
+            if len(subsection_index_files) > 0:
+                fhindex.write(subsections_toctree)
 
             if gallery_conf['download_all_examples']:
                 download_fhindex = generate_zipfiles(

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -444,7 +444,7 @@ def generate_gallery_rst(app):
 
         # Here we don't use an os.walk, but we recurse only twice: flat is
         # better than nested.
-        this_fhindex, this_costs = generate_dir_rst(
+        this_fhindex, this_costs, this_toctree, _ = generate_dir_rst(
             examples_dir_abs_path,
             gallery_dir_abs_path,
             gallery_conf,
@@ -458,7 +458,7 @@ def generate_gallery_rst(app):
         index_rst_new = os.path.join(gallery_dir_abs_path, 'index.rst.new')
         with codecs.open(index_rst_new, 'w', encoding='utf-8') as fhindex:
             # :orphan: to suppress "not included in TOCTREE" sphinx warnings
-            fhindex.write(":orphan:\n\n" + this_fhindex)
+            fhindex.write(":orphan:\n\n" + this_fhindex + this_toctree)
 
             # list all paths to subsection index files in this array
             subsection_index_files = []
@@ -468,9 +468,11 @@ def generate_gallery_rst(app):
                 src_dir = os.path.join(examples_dir_abs_path, subsection)
                 target_dir = os.path.join(gallery_dir_abs_path, subsection)
                 subsection_index_files.append(
-                    os.path.join('/', gallery_dir, subsection, 'index.rst')
+                    os.path.join(
+                        '/', gallery_dir, subsection, 'index.rst'
+                    )
                 )
-                subsection_index_content, subsection_costs = \
+                subsection_index_content, subsection_costs, _, subsection_index_path = \
                     generate_dir_rst(src_dir, target_dir, gallery_conf,
                                      seen_backrefs)
                 fhindex.write(subsection_index_content)
@@ -480,13 +482,16 @@ def generate_gallery_rst(app):
                     gallery_conf, target_dir, subsection_costs
                 )
 
+                _replace_md5(subsection_index_path, mode='t')
+
             # generate and write toctree with subsections
             subsections_toctree = """
 .. toctree::
    :hidden:
    :includehidden:
 
-   %s\n""" % "\n   ".join(subsection_index_files)
+   %s\n
+""" % "\n   ".join(subsection_index_files)
 
             fhindex.write(subsections_toctree)
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -388,7 +388,7 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
 
     # Add div containing all thumbnails;
     # this is helpful for controlling grid or flexbox behaviours
-    fhindex += THUMBNAIL_PARENT_DIV
+    subsection_index_content += THUMBNAIL_PARENT_DIV
 
     entries_text = []
     costs = []
@@ -417,7 +417,7 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
         subsection_index_content += entry_text
 
     # Close thumbnail parent div
-    fhindex += THUMBNAIL_PARENT_DIV_CLOSE
+    subsection_index_content += THUMBNAIL_PARENT_DIV_CLOSE
 
     # Create toctree for index file
     # with all gallery items which belong to current subsection

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -435,7 +435,10 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
             head_ref.replace(os.path.sep, '_')
         ))
         findex.write(subsection_index_content)
-        findex.write(subsection_index_toctree)
+
+        # add toctree to file only if it's not empty
+        if len(subsection_toctree_filenames) > 0:
+            findex.write(subsection_index_toctree)
 
     return subsection_index_content, costs, subsection_index_toctree, \
         subsection_index_path

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -347,10 +347,7 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
     """Generate the gallery reStructuredText for an example directory."""
     head_ref = os.path.relpath(target_dir, gallery_conf['src_dir'])
 
-    subsection_index_content = """\n\n.. _sphx_glr_{0}:\n\n""".format(
-        head_ref.replace(os.path.sep, '_')
-    )
-
+    subsection_index_content = ""
     subsection_readme_fname = _get_readme(src_dir, gallery_conf)
 
     with codecs.open(subsection_readme_fname, 'r', encoding='utf-8') as fid:
@@ -409,15 +406,19 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
 .. toctree::
    :hidden:
 
-   /%s\n""" % "\n   /".join(subsection_toctree_filenames)
+   /%s\n
+""" % "\n   /".join(subsection_toctree_filenames)
 
     # Write subsection index file
     subsection_index_path = os.path.join(target_dir, 'index.rst.new')
     with codecs.open(subsection_index_path, 'w', encoding='utf-8') as findex:
+        findex.write("""\n\n.. _sphx_glr_{0}:\n\n""".format(
+            head_ref.replace(os.path.sep, '_')
+        ))
         findex.write(subsection_index_content)
         findex.write(subsection_index_toctree)
 
-    return subsection_index_content, costs
+    return subsection_index_content, costs, subsection_index_toctree, subsection_index_path
 
 
 def handle_exception(exc_info, src_file, script_vars, gallery_conf):

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -420,8 +420,12 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
     subsection_index_content += THUMBNAIL_PARENT_DIV_CLOSE
 
     # Create toctree for index file
-    # with all gallery items which belong to current subsection
-    subsection_index_toctree = """
+    # with all gallery items which belong to current subsection.
+    # The toctree string should be empty if there are no subsections
+    # or related files, as it will be returned at the end of this function.
+    subsection_index_toctree = ""
+    if len(subsection_toctree_filenames) > 0:
+        subsection_index_toctree = """
 .. toctree::
    :hidden:
 
@@ -436,7 +440,7 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
         ))
         findex.write(subsection_index_content)
 
-        # add toctree to file only if it's not empty
+        # add toctree to file only if toctree is not empty
         if len(subsection_toctree_filenames) > 0:
             findex.write(subsection_index_toctree)
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -412,7 +412,7 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
    /%s\n""" % "\n   /".join(subsection_toctree_filenames)
 
     # Write subsection index file
-    subsection_index_path = os.path.join(target_dir, 'index.rst')
+    subsection_index_path = os.path.join(target_dir, 'index.rst.new')
     with codecs.open(subsection_index_path, 'w', encoding='utf-8') as findex:
         findex.write(subsection_index_content)
         findex.write(subsection_index_toctree)

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -418,7 +418,8 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
         findex.write(subsection_index_content)
         findex.write(subsection_index_toctree)
 
-    return subsection_index_content, costs, subsection_index_toctree, subsection_index_path
+    return subsection_index_content, costs, subsection_index_toctree, \
+        subsection_index_path
 
 
 def handle_exception(exc_info, src_file, script_vars, gallery_conf):

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -27,7 +27,7 @@ N_TOT = 13
 
 N_FAILING = 2
 N_GOOD = N_TOT - N_FAILING
-N_RST = 15 + N_TOT
+N_RST = 15 + N_TOT + 1
 N_RST = '(%s|%s)' % (N_RST, N_RST - 1)  # AppVeyor weirdness
 
 
@@ -614,7 +614,7 @@ def _rerun(how, src_dir, conf_dir, out_dir, toctrees_dir,
     # Windows: always 9 for some reason
     lines = [line for line in status.split('\n') if 'changed,' in line]
     lines = '\n'.join([how] + lines)
-    n_ch = '[8|9]'
+    n_ch = '(8|9|10)'
     want = '.*updating environment:.*0 added, %s changed, 0 removed.*' % n_ch
     assert re.match(want, status, flags) is not None, lines
     want = ('.*executed 1 out of %s.*after excluding %s files.*based on MD5.*'
@@ -695,7 +695,6 @@ def test_error_messages(sphinx_app, name, want):
     example_rst = op.join(src_dir, 'auto_examples', name + '.rst')
     with codecs.open(example_rst, 'r', 'utf-8') as fid:
         rst = fid.read()
-    print(rst)
     rst = rst.replace('\n', ' ')
     assert re.match(want, rst) is not None
 

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -27,7 +27,7 @@ N_TOT = 13  # examples (plot_*.py in examples/**)
 
 N_FAILING = 2
 N_GOOD = N_TOT - N_FAILING
-N_RST = 16 + N_TOT  + 1 # includes module API pages, etc.
+N_RST = 16 + N_TOT + 1  # includes module API pages, etc.
 N_RST = '(%s|%s)' % (N_RST, N_RST - 1)  # AppVeyor weirdness
 
 

--- a/sphinx_gallery/tests/tinybuild/examples/future/README.rst
+++ b/sphinx_gallery/tests/tinybuild/examples/future/README.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. _future_examples:
+
 Future examples
 ===============
 


### PR DESCRIPTION
Fixes #855.

Let's assume the gallery structure is the following (note the new `readme.rst` files in each subsection):

```
- top_level
   - readme.rst
   - subdir
      - readme.rst
      - example.rst
      - example2.rst
   - subdir2
      - readme.rst
      - example1.rst
      - example2.rst
```

This PR:
- generates an `index.rst` file for each subsection; it contains `readme.rst`, the gallery items, and a hidden toctree of the gallery items
- includes each subsection's index file in a hidden toctree appended at the end of the main sections index file

On-going tasks:
- [x] passing tests
- [x] try more levels of nesting (EDIT: outcome is it currently works for 2, doesn't work for more)