### PR TITLE
Possibility to exclude implicit backreferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ sphinx_gallery/tests/tinybuild/gen_modules/
 sphinx_gallery/tests/tinybuild/auto_examples/
 sphinx_gallery/tests/tinybuild/_build/
 sphinx_gallery/tests/tinybuild/tiny_html/
+junit-results.xml
 
 # PyBuilder
 target/

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -24,7 +24,8 @@ file:
 - ``subsection_order`` (:ref:`sub_gallery_order`)
 - ``within_subsection_order`` (:ref:`within_gallery_order`)
 - ``reference_url`` (:ref:`link_to_documentation`)
-- ``backreferences_dir``, ``doc_module``, and ``inspect_global_variables`` (:ref:`references_to_examples`)
+- ``backreferences_dir``, ``doc_module``, ``exclude_implicit_doc``,
+  and ``inspect_global_variables`` (:ref:`references_to_examples`)
 - ``default_thumb_file`` (:ref:`custom_default_thumb`)
 - ``thumbnail_size`` (:ref:`setting_thumbnail_size`)
 - ``line_numbers`` (:ref:`adding_line_numbers`)
@@ -411,10 +412,11 @@ enables you to link to any examples that either:
    block.
 
 The former is useful for auto-documenting functions that are used and classes
-that are explicitly instantiated. The latter is useful for classes that are
-typically implicitly returned rather than explicitly instantiated (e.g.,
+that are explicitly instantiated. The generated links are called implicit
+backreferences. The latter is useful for classes that are typically implicitly
+returned rather than explicitly instantiated (e.g.,
 :class:`matplotlib.axes.Axes` which is most often instantiated only indirectly
-within function calls).
+within function calls). Such links are called explicit backreferences.
 
 For example, we can embed a small gallery of all examples that use or
 refer to :obj:`numpy.exp`, which looks like this:
@@ -432,7 +434,12 @@ your Sphinx-Gallery configuration ``conf.py`` file with::
 
         # Modules for which function/class level galleries are created. In
         # this case sphinx_gallery and numpy in a tuple of strings.
-        'doc_module'          : ('sphinx_gallery', 'numpy')}
+        'doc_module'          : ('sphinx_gallery', 'numpy')
+
+        # objects to exclude from implicit backreferences. The default option
+        # is an empty set, i.e. exclude nothing.
+        'exclude_implicit_doc': {}
+    }
 
 The path you specify in ``backreferences_dir`` (here we choose
 ``gen_modules/backreferences``) will be populated with
@@ -442,7 +449,7 @@ and belonging to the modules listed in ``doc_module``.
 ``backreferences_dir`` should be a string or ``pathlib.Path`` object that is
 **relative** to the ``conf.py`` file, or ``None``. It is ``None`` by default.
 
-Within your sphinx documentation ``.rst`` files, you can use easily
+Within your sphinx documentation ``.rst`` files, you can easily
 add this reduced version of the Gallery. For example, the rst below adds
 the reduced version of the Gallery for ``numpy.exp``, which includes all
 examples that use the specific function ``numpy.exp``:
@@ -451,6 +458,19 @@ examples that use the specific function ``numpy.exp``:
 
     .. minigallery:: numpy.exp
         :add-heading:
+
+Sometimes, there are functions that are being used in practically every example
+for the given module, for instance the ``pyplot.show`` or ``pyplot.subplots``
+functions in Matplotlib, so that a large number of often spurious examples will
+be linked to these functions. To prevent this, you can exclude implicit
+backreferences for certain objects by including them as regular expressions
+in ``exclude_implicit_doc``. The following setting will exclude any implicit
+backreferences so that examples galleries are only created for objects
+explicitly mentioned by Sphinx markup in a documentation block: ``{'.*'}``.
+To exclude the functions mentioned above you would use
+``{r'pyplot\.show', r'pyplot\.subplots'}`` (note the escape to match a dot
+instead of any character, if the name is unambiguous you can also write
+``pyplot.show`` or just ``show``).
 
 The ``add-heading`` option adds a heading for the mini-gallery, which will be a
 default generated message if no string is provided as an argument.  The example

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -434,11 +434,11 @@ your Sphinx-Gallery configuration ``conf.py`` file with::
 
         # Modules for which function/class level galleries are created. In
         # this case sphinx_gallery and numpy in a tuple of strings.
-        'doc_module'          : ('sphinx_gallery', 'numpy')
+        'doc_module'          : ('sphinx_gallery', 'numpy'),
 
         # objects to exclude from implicit backreferences. The default option
         # is an empty set, i.e. exclude nothing.
-        'exclude_implicit_doc': {}
+        'exclude_implicit_doc': {},
     }
 
 The path you specify in ``backreferences_dir`` (here we choose

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -128,7 +128,8 @@ class NameFinder(ast.NodeVisitor):
                                 full_name = '.'.join(
                                     module[:depth] + [class_name] + method)
                                 options.append(
-                                    (name, full_name, class_attr, is_class))
+                                    (name, full_name, class_attr, is_class,
+                                        False))
             # second pass: by import (can't resolve as well without doing
             # some actions like actually importing the modules, so use it
             # as a last resort)
@@ -139,7 +140,7 @@ class NameFinder(ast.NodeVisitor):
                     full_name = self.imported_names[local_name] + remainder
                     is_class = class_attr = False  # can't tell without import
                     options.append(
-                        (name, full_name, class_attr, is_class))
+                        (name, full_name, class_attr, is_class, False))
         return options
 
 
@@ -200,18 +201,18 @@ def identify_names(script_blocks, global_variables=None, node=''):
     if node == '':  # mostly convenience for testing functions
         c = '\n'.join(txt for kind, txt, _ in script_blocks if kind == 'code')
         node = ast.parse(c)
-    # Get matches from the code (AST)
+    # Get matches from the code (AST, implicit matches)
     finder = NameFinder(global_variables)
     if node is not None:
         finder.visit(node)
     names = list(finder.get_mapping())
-    # Get matches from docstring inspection
+    # Get matches from docstring inspection (explicit matches)
     text = '\n'.join(txt for kind, txt, _ in script_blocks if kind == 'text')
-    names.extend((x, x, False, False) for x in re.findall(_regex, text))
+    names.extend((x, x, False, False, True) for x in re.findall(_regex, text))
     example_code_obj = collections.OrderedDict()  # order is important
     # Make a list of all guesses, in `_embed_code_links` we will break
     # when we find a match
-    for name, full_name, class_like, is_class in names:
+    for name, full_name, class_like, is_class, is_explicit in names:
         if name not in example_code_obj:
             example_code_obj[name] = list()
         # name is as written in file (e.g. np.asarray)
@@ -230,7 +231,8 @@ def identify_names(script_blocks, global_variables=None, node=''):
         # get shortened module name
         module_short = _get_short_module_name(module, attribute)
         cobj = {'name': attribute, 'module': module,
-                'module_short': module_short or module, 'is_class': is_class}
+                'module_short': module_short or module, 'is_class': is_class,
+                'is_explicit': is_explicit}
         example_code_obj[name].append(cobj)
     return example_code_obj
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -58,6 +58,7 @@ DEFAULT_GALLERY_CONF = {
     'gallery_dirs': 'auto_examples',
     'backreferences_dir': None,
     'doc_module': (),
+    'exclude_implicit_doc': {},
     'reference_url': {},
     'capture_repr': ('_repr_html_', '__repr__'),
     'ignore_repr_types': r'',
@@ -127,6 +128,17 @@ def parse_config(app, check_keys=True):
     app.config.sphinx_gallery_conf = gallery_conf
     app.config.html_static_path.append(glr_path_static())
     return gallery_conf
+
+
+def _update_gallery_conf(gallery_conf):
+    """Update gallery config.
+
+    This is separate function for better testability.
+    """
+    # prepare regex for exclusions from implicit documentation
+    exclude_regex = re.compile('|'.join(gallery_conf['exclude_implicit_doc']))\
+        if gallery_conf['exclude_implicit_doc'] else False
+    gallery_conf['exclude_implicit_doc_regex'] = exclude_regex
 
 
 def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
@@ -362,6 +374,8 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
                               % (css, _KNOWN_CSS))
         if gallery_conf['app'] is not None:  # can be None in testing
             gallery_conf['app'].add_css_file(css + '.css')
+
+    _update_gallery_conf(gallery_conf)
 
     return gallery_conf
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -999,15 +999,17 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
         with open(codeobj_fname, 'wb') as fid:
             pickle.dump(example_code_obj, fid, pickle.HIGHEST_PROTOCOL)
         _replace_md5(codeobj_fname)
-    backrefs = set('{module_short}.{name}'.format(**cobj)
-                   for cobjs in example_code_obj.values()
-                   for cobj in cobjs
-                   if cobj['module'].startswith(gallery_conf['doc_module'])
-                   and (cobj['is_explicit']
-                        or not (gallery_conf['exclude_implicit_doc_regex']
-                                .search('{module}.{name}'.format(**cobj))
-                                if gallery_conf['exclude_implicit_doc_regex']
-                                else False)))
+    exclude_regex = gallery_conf['exclude_implicit_doc_regex']
+    backrefs = set(
+        '{module_short}.{name}'.format(**cobj)
+        for cobjs in example_code_obj.values()
+        for cobj in cobjs
+        if cobj['module'].startswith(gallery_conf['doc_module']) and (
+            cobj['is_explicit'] or
+            (not exclude_regex) or
+            (not exclude_regex.search('{module}.{name}'.format(**cobj)))
+        )
+    )
 
     # Write backreferences
     _write_backreferences(backrefs, seen_backrefs, gallery_conf, target_dir,

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1002,7 +1002,13 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
     backrefs = set('{module_short}.{name}'.format(**cobj)
                    for cobjs in example_code_obj.values()
                    for cobj in cobjs
-                   if cobj['module'].startswith(gallery_conf['doc_module']))
+                   if cobj['module'].startswith(gallery_conf['doc_module'])
+                   and (cobj['is_explicit']
+                        or not (gallery_conf['exclude_implicit_doc_regex']
+                                .search('{module}.{name}'.format(**cobj))
+                                if gallery_conf['exclude_implicit_doc_regex']
+                                else False)))
+
     # Write backreferences
     _write_backreferences(backrefs, seen_backrefs, gallery_conf, target_dir,
                           fname, intro, title)

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -75,6 +75,7 @@ def test_identify_names(unicode_sample):
                 'module': 'os.path',
                 'module_short': 'os.path',
                 'is_class': False,
+                'is_explicit': False,
             }],
         'br.identify_names':
             [{
@@ -82,6 +83,7 @@ def test_identify_names(unicode_sample):
                 'module': 'sphinx_gallery.back_references',
                 'module_short': 'sphinx_gallery.back_references',
                 'is_class': False,
+                'is_explicit': False,
             }],
         'identify_names':
             [{
@@ -89,6 +91,7 @@ def test_identify_names(unicode_sample):
                 'module': 'sphinx_gallery.back_references',
                 'module_short': 'sphinx_gallery.back_references',
                 'is_class': False,
+                'is_explicit': False,
              }],
     }
     _, script_blocks = split_code_and_text_blocks(unicode_sample)
@@ -121,6 +124,7 @@ h.i.j()
             'module': 'a.b',
             'module_short': 'a.b',
             'is_class': False,
+            'is_explicit': False,
         }],
         'e.HelloWorld':
         [{
@@ -128,6 +132,7 @@ h.i.j()
             'module': 'd',
             'module_short': 'd',
             'is_class': False,
+            'is_explicit': False,
         }],
         'h.i.j':
         [{
@@ -135,6 +140,7 @@ h.i.j()
             'module': 'h.i',
             'module_short': 'h.i',
             'is_class': False,
+            'is_explicit': False,
         }],
     }
 
@@ -155,9 +161,9 @@ This example uses :func:`k.l` and :meth:`~m.n`.
 '''
 """ + code_str.split(b"'''")[-1]
     expected['k.l'] = [{u'module': u'k', u'module_short': u'k', u'name': u'l',
-                        'is_class': False}]
+                        'is_class': False, 'is_explicit': True}]
     expected['m.n'] = [{u'module': u'm', u'module_short': u'm', u'name': u'n',
-                        'is_class': False}]
+                        'is_class': False, 'is_explicit': True}]
 
     fname = tmpdir.join("identify_names.py")
     fname.write(code_str, 'wb')

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -23,11 +23,11 @@ from sphinx_gallery.utils import (_get_image, scale_image, _has_optipng,
 
 import pytest
 
-N_TOT = 13
+N_TOT = 13  # examples (plot_*.py in examples/**)
 
 N_FAILING = 2
 N_GOOD = N_TOT - N_FAILING
-N_RST = 15 + N_TOT
+N_RST = 16 + N_TOT  # includes module API pages, etc.
 N_RST = '(%s|%s)' % (N_RST, N_RST - 1)  # AppVeyor weirdness
 
 
@@ -379,6 +379,14 @@ def test_backreferences(sphinx_app):
         lines = fid.read()
     assert 'NameFinder' in lines  # in API doc
     assert 'plot_future_imports.html' in lines  # backref via doc block
+    # rendered file
+    html = op.join(out_dir, 'auto_examples', 'plot_second_future_imports.html')
+    assert op.isfile(html)
+    with codecs.open(html, 'r', 'utf-8') as fid:
+        html = fid.read()
+    assert 'sphinx_gallery.sorting.html#sphinx_gallery.sorting.ExplicitOrder' in html  # noqa: E501
+    assert 'sphinx_gallery.scrapers.html#sphinx_gallery.scrapers.clean_modules' in html  # noqa: E501
+    assert 'figure_rst.html' not in html  # excluded
 
 
 @pytest.mark.parametrize('rst_file, example_used_in', [

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -13,6 +13,7 @@ import tempfile
 import re
 import os
 import shutil
+import sys
 from unittest import mock
 import zipfile
 import codeop
@@ -516,7 +517,11 @@ numpy.e
         'exclude implicit backref',
     ],
 )
-def test_exclude_implicit(gallery_conf, exclusion, expected, monkeypatch):
+def test_exclude_implicit(gallery_conf,
+                          exclusion,
+                          expected,
+                          monkeypatch,
+                          req_pil):
     mock_write_backreferences = mock.create_autospec(sg._write_backreferences)
     monkeypatch.setattr(sg, '_write_backreferences', mock_write_backreferences)
     gallery_conf['doc_module'] = ('numpy',)
@@ -524,7 +529,10 @@ def test_exclude_implicit(gallery_conf, exclusion, expected, monkeypatch):
         gallery_conf['exclude_implicit_doc'] = exclusion
         _update_gallery_conf(gallery_conf)
     _generate_rst(gallery_conf, 'test_exclude_implicit.py', EXCLUDE_CONTENT)
-    assert mock_write_backreferences.call_args.args[0] == expected
+    if sys.version_info >= (3, 8, 0):
+        assert mock_write_backreferences.call_args.args[0] == expected
+    else:
+        assert mock_write_backreferences.call_args[0][0] == expected
 
 
 @pytest.mark.parametrize('ext', ('.txt', '.rst', '.bad'))

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -99,7 +99,8 @@ sphinx_gallery_conf = {
     'junit': op.join('sphinx-gallery', 'junit-results.xml'),
     'matplotlib_animations': True,
     'pypandoc': True,
-    'image_srcset': ["2x"]
+    'image_srcset': ["2x"],
+    'exclude_implicit_doc': ['figure_rst'],
 }
 nitpicky = True
 highlight_language = 'python3'

--- a/sphinx_gallery/tests/tinybuild/examples/plot_second_future_imports.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_second_future_imports.py
@@ -1,24 +1,21 @@
 """
-Testing future statements across examples
------------------------------------------
+Testing backreferences
+----------------------
 
 This example runs after plot_future_statements.py (alphabetical ordering within
 subsection) and should be unaffected by the __future__ import in
-plot_future_statements.py.
+plot_future_statements.py. We should eventually update this script to actually
+test this... we require Python 3 nowadays so the __future__ statements there
+don't do anything. So for now let's repurpose this to look at some
+backreferences. We should probably also change the filename in another PR!
 """
 # sphinx_gallery_thumbnail_path = '_static_nonstandard/demo.png'
 
-import sys
 from sphinx_gallery.sorting import ExplicitOrder
+from sphinx_gallery.scrapers import figure_rst, clean_modules
 
 ExplicitOrder([])  # must actually be used to become a backref target!
 
-PY2 = sys.version_info[0] == 2
-
-expected = 1 if PY2 else 1.5
-assert 3/2 == expected
-
-# Make sure print is a keyword not a function. Note: need to use exec because
-# otherwise you get a SyntaxError on Python 3
-if PY2:
-    exec('print "test"')
+assert 3 / 2 == 1.5
+assert figure_rst([], '') == ''
+assert clean_modules(dict(reset_modules=[]), '', 'before') is None

--- a/sphinx_gallery/tests/tinybuild/index.rst
+++ b/sphinx_gallery/tests/tinybuild/index.rst
@@ -16,14 +16,14 @@ every module. Examples `here <auto_examples/index.html>`_.
    :toctree: gen_modules/
    :template: module.rst
 
-   gen_gallery
    backreferences
-   gen_rst
-   py_source_parser
    docs_resolv
-   notebook
    downloads
-   docs_resolv
+   gen_gallery
+   gen_rst
+   notebook
+   py_source_parser
+   scrapers
    sorting
 
 Examples


### PR DESCRIPTION
New configuration key 'exclude_implicit_doc' to prevent generation of
backreferences for the names given in this key. This only affects
implicite backreferences, i.e. names extracted from the code. Explicit
backreferences given the sphinx directives are not affected.

Closes #898.

I tried my best to write a readable and concise documentation section but this should certainly streamlined a bit by native speakers.