### PR TITLE
MAINT: Remove LooseVersion

### DIFF
--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -10,7 +10,6 @@ from __future__ import division, absolute_import, print_function
 
 import codecs
 import ast
-from distutils.version import LooseVersion
 from io import BytesIO
 import re
 import sys
@@ -102,26 +101,21 @@ def _get_docstring_and_rest(filename):
             'unless the file is ignored by "ignore_pattern"'
             .format(filename))
 
-    if LooseVersion(sys.version) >= LooseVersion('3.7'):
-        docstring = ast.get_docstring(node)
-        assert docstring is not None  # should be guaranteed above
-        # This is just for backward compat
-        if len(node.body[0].value.s) and node.body[0].value.s[0] == '\n':
-            # just for strict backward compat here
-            docstring = '\n' + docstring
-        ts = tokenize.tokenize(BytesIO(content.encode()).readline)
-        # find the first string according to the tokenizer and get its end row
-        for tk in ts:
-            if tk.exact_type == 3:
-                lineno, _ = tk.end
-                break
-        else:
-            lineno = 0
+    # Python 3.7+ way
+    docstring = ast.get_docstring(node)
+    assert docstring is not None  # should be guaranteed above
+    # This is just for backward compat
+    if len(node.body[0].value.s) and node.body[0].value.s[0] == '\n':
+        # just for strict backward compat here
+        docstring = '\n' + docstring
+    ts = tokenize.tokenize(BytesIO(content.encode()).readline)
+    # find the first string according to the tokenizer and get its end row
+    for tk in ts:
+        if tk.exact_type == 3:
+            lineno, _ = tk.end
+            break
     else:
-        # this block can be removed when python 3.6 support is dropped
-        docstring_node = node.body[0]
-        docstring = docstring_node.value.s
-        lineno = docstring_node.lineno  # The last line of the string.
+        lineno = 0
 
     # This get the content of the file after the docstring last line
     # Note: 'maxsplit' argument is not a keyword argument in python2

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -18,7 +18,6 @@ import inspect
 import os
 import sys
 import re
-from distutils.version import LooseVersion
 from textwrap import indent
 from pathlib import PurePosixPath
 from warnings import filterwarnings
@@ -225,9 +224,7 @@ def _anim_rst(anim, image_path, gallery_conf):
     thumb_size = gallery_conf['thumbnail_size']
     use_dpi = round(
         min(t_s / f_s for t_s, f_s in zip(thumb_size, fig_size)))
-    # FFmpeg is buggy for GIFs before Matplotlib 3.3.1
-    if LooseVersion(matplotlib.__version__) >= LooseVersion('3.3.1') and \
-            FFMpegWriter.isAvailable():
+    if FFMpegWriter.isAvailable():
         writer = 'ffmpeg'
     elif ImageMagickWriter.isAvailable():
         writer = 'imagemagick'


### PR DESCRIPTION
I don't like seeing in my Python 3.10 builds:
```
/home/larsoner/python/sphinx-gallery/sphinx_gallery/py_source_parser.py:105: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.           
```
So I removed one unnecessary comparison about python version (we require 3.7 already), and another involving matplotlib version that just triaged which GIF writer to use -- 3.3.1 is almost 2 years old, and the GIF-writing bug will only happen if someone actually uses GIFs in their docs *and* uses a quite old matplotlib version, which I think is rare enough not to worry about.