### PR TITLE
MAINT: Clean up namespace

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1026,6 +1026,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
     _write_backreferences(backrefs, seen_backrefs, gallery_conf, target_dir,
                           fname, intro, title)
 
+    del script_vars, global_variables  # don't keep these during reset
     if executable and gallery_conf['reset_modules_order'] in ['after', 'both']:
         clean_modules(gallery_conf, fname, 'after')
 


### PR DESCRIPTION
When running `reset_modules` in the `after` case, we need to `del script_vars, global_vars` in order to ensure a `gc.collect()` that follows will actually be able to collect the variables from the script that ran. A bit of a corner case, but it's easy to implement and hard to test, so I think this is probably good enough as is.

Okay for you @lucyleeow ?