### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,9 @@ setup(
     ]},
     scripts=['bin/copy_sphinxgallery.sh', 'bin/sphx_glr_python_to_jupyter.py'],
     url="https://sphinx-gallery.github.io",
+    project_urls={
+        "Source": "https://github.com/sphinx-gallery/sphinx-gallery",
+    },
     author="Óscar Nájera",
     author_email='najera.oscar@gmail.com',
     install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     url="https://sphinx-gallery.github.io",
     project_urls={
         "Source": "https://github.com/sphinx-gallery/sphinx-gallery",
+        "Documentation": "https://sphinx-gallery.github.io",
     },
     author="Óscar Nájera",
     author_email='najera.oscar@gmail.com',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)