### PR TITLE
DOC: fix rst link syntax in changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Next version
 
 In this version, the "Out:" prefix applied to code outputs is now created from
 CSS pseudo-elements instead of additional real text. For more details, see
-`#896 <https://github.com/sphinx-gallery/sphinx-gallery/pull/896>`.
+`#896 <https://github.com/sphinx-gallery/sphinx-gallery/pull/896>`__.
 
 **Implemented enhancements:**
 


### PR DESCRIPTION
Fix a trivial formating bug.