### PR TITLE
WIP: Log implicit refs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,12 +67,7 @@ stages:
       displayName: Install sphinx-gallery
     - script: pytest --tb=short sphinx_gallery
       displayName: pytest
-    - bash: |
-        set -e
-        sed -i '/show_memory/d' doc/conf.py
-        sed -i '/compress_images/d' doc/conf.py
-      displayName: Remove keys incompatible with this Windows build
-    - bash: make -C doc html
+    - bash: make -C doc html SPHINXOPTS="-nWT --keep-going -D sphinx_gallery_conf.compress_images='' -D sphinx_gallery_conf.show_memory=0"
       displayName: make html
     - task: PublishTestResults@2
       inputs:

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -358,9 +358,11 @@ THUMBNAIL_PARENT_DIV_CLOSE = """
 """
 
 
-def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
+def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs, *,
+                     implicit_count=None):
     """Generate the gallery reStructuredText for an example directory."""
     head_ref = os.path.relpath(target_dir, gallery_conf['src_dir'])
+    implicit_count = dict() if implicit_count is None else implicit_count
 
     subsection_index_content = ""
     subsection_readme_fname = _get_readme(src_dir, gallery_conf)
@@ -400,7 +402,8 @@ def generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs):
         length=len(sorted_listdir))
     for fname in iterator:
         intro, title, cost = generate_file_rst(
-            fname, target_dir, src_dir, gallery_conf, seen_backrefs)
+            fname, target_dir, src_dir, gallery_conf, seen_backrefs,
+            implicit_count=implicit_count)
         src_file = os.path.normpath(os.path.join(src_dir, fname))
         costs.append((cost, src_file))
         gallery_item_filename = os.path.join(
@@ -923,7 +926,7 @@ def execute_script(script_blocks, script_vars, gallery_conf, file_conf):
 
 
 def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
-                      seen_backrefs=None):
+                      seen_backrefs=None, *, implicit_count=None):
     """Generate the rst file for a given example.
 
     Parameters
@@ -938,6 +941,8 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
         Contains the configuration of Sphinx-Gallery
     seen_backrefs : set
         The seen backreferences.
+    implicit_count : dict
+        The count of implicit backreferences.
 
     Returns
     -------
@@ -947,6 +952,8 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
         A tuple containing the ``(time, memory)`` required to run the script.
     """
     seen_backrefs = set() if seen_backrefs is None else seen_backrefs
+    implicit_count = dict() if implicit_count is None else implicit_count
+
     src_file = os.path.normpath(os.path.join(src_dir, fname))
     target_file = os.path.join(target_dir, fname)
     _replace_md5(src_file, target_file, 'copy', mode='t')
@@ -1049,16 +1056,21 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
             pickle.dump(example_code_obj, fid, pickle.HIGHEST_PROTOCOL)
         _replace_md5(codeobj_fname)
     exclude_regex = gallery_conf['exclude_implicit_doc_regex']
-    backrefs = set(
-        '{module_short}.{name}'.format(**cobj)
-        for cobjs in example_code_obj.values()
-        for cobj in cobjs
-        if cobj['module'].startswith(gallery_conf['doc_module']) and (
-            cobj['is_explicit'] or
-            (not exclude_regex) or
-            (not exclude_regex.search('{module}.{name}'.format(**cobj)))
-        )
-    )
+    backrefs = set()
+    for cobjs in example_code_obj.values():
+        for cobj in cobjs:
+            long_name = '{module}.{name}'.format(**cobj)
+            if cobj['module'].startswith(gallery_conf['doc_module']):
+                if cobj['is_explicit'] or \
+                        (not exclude_regex) or \
+                        (not exclude_regex.search(long_name)):
+                    backrefs.add('{module_short}.{name}'.format(**cobj))
+                if not cobj['is_explicit']:
+                    implicit_count[cobj['name']] = \
+                        implicit_count.get(cobj['name'], 0) + 1
+            del cobj
+        del cobjs
+    del example_code_obj
 
     # Write backreferences
     _write_backreferences(backrefs, seen_backrefs, gallery_conf, target_dir,

--- a/sphinx_gallery/tests/tinybuild/conf.py
+++ b/sphinx_gallery/tests/tinybuild/conf.py
@@ -101,6 +101,7 @@ sphinx_gallery_conf = {
     'pypandoc': True,
     'image_srcset': ["2x"],
     'exclude_implicit_doc': ['figure_rst'],
+    'log_implicit_limit': 10,
 }
 nitpicky = True
 highlight_language = 'python3'


### PR DESCRIPTION
@StefRe working on using the exclusion of implicit refs for MNE-Python, it occurred to me that it would be nice to have a way for SG to tell me what its most common implicit refs are. This PR adds support for this via:
```
    'log_implicit_limit': 10,
```
For example, this is what `tinybuild` now gives:
```
most common implicit backreferences (10 most):
    - 5: DummyClass
    - 3: ExplicitOrder
    - 2: DummyClass.prop
    - 2: DummyClass.run
    - 1: identify_names
    - 1: clean_modules
    - 1: figure_rst
```
And for MNE-Python running a subset of our docs (after excluding a few):
```
    - 176: data_path
    - 94: Epochs
    - 89: read_raw_fif
    - 51: pick_types
    - 45: find_events
    - 32: Raw
    ...
```
WDYT @StefRe ?

One problem is that exclusion currently works when creating the set of possible references to resolve. We do this for example by adding both `mne.epochs.Epochs` and `mne.Epochs` to the list of backreferences, then figuring out which is actually documented in the API docs later. My ugly workaround for now is just to keep count based on the `name` rather than the `module.name`. A better fix would be to delay the counting/printing until later, when we resolve which one is actually correct. Then we can give the name as it shows up in the API docs. So that's going in the TODO...

Todo:
- [x] Fix some `-D`-incompatible gallery conf switches
- [x] Implement counting and writing out
- [ ] Make exclusion work at the level of replacement / with full API names, not backref generation / just the obj/method
- [ ] Document feature
- [ ] Add tests

Another option would be to write these to a file at the end of the build like we do for `sg_execution_times.rst`, which would also be easy. Not sure which is better.