### PR TITLE
FIX: Fix for dep

### DIFF
--- a/continuous_integration/azure/install.sh
+++ b/continuous_integration/azure/install.sh
@@ -27,7 +27,7 @@ if [ "$DISTRIB" == "conda" ]; then
         # It is a mystery to me why we need black, but we get an error with sphinx that it's needed at the end of the build...
         PIP_DEPENDENCIES="${PIP_DEPENDENCIES} https://api.github.com/repos/sphinx-doc/sphinx/zipball/master black"
     else
-        PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx==${SPHINX_VERSION} \"jinja2<=3.0.3\""
+        PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx==${SPHINX_VERSION} jinja2<=3.0.3"
     fi
     source activate base
     conda install --yes -c conda-forge $CONDA_TO_INSTALL
@@ -66,7 +66,7 @@ elif [ "$DISTRIB" == "ubuntu" ]; then
     python3 -m pip install -r dev-requirements.txt | cat
     python3 -m pip install --upgrade pytest pytest-cov coverage
     # test show_memory=True without memory_profiler by not installing it (not in req)
-    python3 -m pip install sphinx==1.8.3
+    python3 -m pip install sphinx==1.8.3 "jinja2<=3.0.3"
     python3 setup.py install --user
     python3 -m pip list
 else

--- a/continuous_integration/azure/install.sh
+++ b/continuous_integration/azure/install.sh
@@ -22,12 +22,12 @@ if [ "$DISTRIB" == "conda" ]; then
         CONDA_TO_INSTALL="$CONDA_TO_INSTALL mayavi memory_profiler ipython pypandoc"
     fi
     if [ "$SPHINX_VERSION" == "" ]; then
-        PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx"
+        PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx \"jinja2<=3.0.3\""
     elif [ "$SPHINX_VERSION" == "dev" ]; then
         # It is a mystery to me why we need black, but we get an error with sphinx that it's needed at the end of the build...
         PIP_DEPENDENCIES="${PIP_DEPENDENCIES} https://api.github.com/repos/sphinx-doc/sphinx/zipball/master black"
     else
-        PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx==${SPHINX_VERSION}"
+        PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx==${SPHINX_VERSION} \"jinja2<=3.0.3\""
     fi
     source activate base
     conda install --yes -c conda-forge $CONDA_TO_INSTALL
@@ -55,7 +55,7 @@ elif [ "$DISTRIB" == "nightly" ]; then
     # pip install --no-use-pep517 -q https://api.github.com/repos/matplotlib/matplotlib/zipball/master
     #
     # So for now we'll just live without NumPy.
-    pip install -q --upgrade --pre sphinx joblib pytest-cov pygments colorama jinja2>=2.3 markupsafe>=1.1
+    pip install -q --upgrade --pre sphinx joblib pytest-cov pygments colorama "jinja2>=2.3" markupsafe>=1.1
     pip install -q .
     pip list
 elif [ "$DISTRIB" == "minimal" ]; then

--- a/continuous_integration/azure/install.sh
+++ b/continuous_integration/azure/install.sh
@@ -22,7 +22,7 @@ if [ "$DISTRIB" == "conda" ]; then
         CONDA_TO_INSTALL="$CONDA_TO_INSTALL mayavi memory_profiler ipython pypandoc"
     fi
     if [ "$SPHINX_VERSION" == "" ]; then
-        PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx \"jinja2<=3.0.3\""
+        PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx jinja2<=3.0.3"
     elif [ "$SPHINX_VERSION" == "dev" ]; then
         # It is a mystery to me why we need black, but we get an error with sphinx that it's needed at the end of the build...
         PIP_DEPENDENCIES="${PIP_DEPENDENCIES} https://api.github.com/repos/sphinx-doc/sphinx/zipball/master black"

--- a/sphinx_gallery/utils.py
+++ b/sphinx_gallery/utils.py
@@ -61,7 +61,11 @@ def scale_image(in_fname, out_fname, max_width, max_height):
     # resize the image using resize; if using .thumbnail and the image is
     # already smaller than max_width, max_height, then this won't scale up
     # at all (maybe could be an option someday...)
-    img = img.resize((width_sc, height_sc), Image.BICUBIC)
+    try:  # Pillow 9+
+        bicubic = Image.Resampling.BICUBIC
+    except Exception:
+        bicubic = Image.BICUBIC
+    img = img.resize((width_sc, height_sc), bicubic)
     # img.thumbnail((width_sc, height_sc), Image.BICUBIC)
     # width_sc, height_sc = img.size  # necessary if using thumbnail
 


### PR DESCRIPTION
Fixes warnings of the form:
```
/home/circleci/python_env/lib/python3.8/site-packages/sphinx_gallery/utils.py:64: DeprecationWarning: BICUBIC is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BICUBIC instead.
  img = img.resize((width_sc, height_sc), Image.BICUBIC)
```
Will merge once it comes back green to avoid these warnings