### PR TITLE
Improve Jupyter notebook converter's handling of code blocks

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -389,6 +389,7 @@ sphinx_gallery_conf = {
                'use_jupyter_lab': True,
                },
     'show_memory': True,
+    'promote_jupyter_magic': False,
     'junit': os.path.join('sphinx-gallery', 'junit-results.xml'),
     # capture raw HTML or, if not present, __repr__ of last expression in
     # each code block

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -50,7 +50,7 @@ file:
 - ``show_memory`` (:ref:`show_memory`)
 - ``show_signature`` (:ref:`show_signature`)
 - ``binder`` (:ref:`binder_links`)
-- ``promote_jupyter_magic`` (:ref: `promote_jupyter_magic`)
+- ``promote_jupyter_magic`` (:ref:`promote_jupyter_magic`)
 - ``first_notebook_cell`` and ``last_notebook_cell`` (:ref:`own_notebook_cell`)
 - ``notebook_images`` (:ref:`notebook_images`)
 - ``pypandoc`` (:ref:`use_pypandoc`)
@@ -1090,8 +1090,8 @@ for an example that uses the `public Binder server <http://mybinder.org>`_.
 
 .. _promote_jupyter_magic:
 
-Make Jupyter cell magic compile as code
-=======================================
+Making cell magic executable in notebooks
+=========================================
 
 Often times, tutorials will include bash scripts for the user to copy/paste into
 their terminal. These scripts are not intended to be run when someone is
@@ -1139,7 +1139,7 @@ and only affects the creation of Jupyter notebooks.
 .. warning::
   It is good practice to ensure the ``.py`` and ``.html`` files match the ``.ipynb``
   files as closely as possible. This flag (and Jupyter cell magics) should only
-  be used when the relevant code is already intended to be executed by the end
+  be used when the relevant code is intended to be executed by the end
   user.
 
 .. _without_execution:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -50,6 +50,7 @@ file:
 - ``show_memory`` (:ref:`show_memory`)
 - ``show_signature`` (:ref:`show_signature`)
 - ``binder`` (:ref:`binder_links`)
+- ``promote_jupyter_magic`` (:ref: `promote_jupyter_magic`)
 - ``first_notebook_cell`` and ``last_notebook_cell`` (:ref:`own_notebook_cell`)
 - ``notebook_images`` (:ref:`notebook_images`)
 - ``pypandoc`` (:ref:`use_pypandoc`)
@@ -1086,6 +1087,60 @@ Binder links will point to these notebooks.
 
 See the Sphinx-Gallery `Sphinx configuration file <https://github.com/sphinx-gallery/sphinx-gallery/blob/master/doc/conf.py>`_
 for an example that uses the `public Binder server <http://mybinder.org>`_.
+
+.. _promote_jupyter_magic:
+
+Make Jupyter cell magic compile as code
+=======================================
+
+Often times, tutorials will include bash scripts for the user to copy/paste into
+their terminal. These scripts are not intended to be run when someone is
+building the documentation, as they will already have those dependencies in
+their environment. Hence they are normally written as code blocks inside text::
+
+  #%%
+  # Installing dependencies
+  #
+  #     .. code-block:: bash
+  #
+  #       pip install -q tensorflow
+  #       apt-get -qq install curl
+
+This works fine for the ``.py`` and ``.html`` files, but causes problems when
+rendered as an Jupyter notebook. The downloaded ``.ipynb`` file will not have
+those dependencies installed, and thus will not work without running the script.
+
+To fix this, we can set the ``promote_jupyter_magic`` flag in ``conf.py``::
+
+  sphinx_gallery_conf = {
+      ...
+      'promote_jupyter_magic': True,
+  }
+
+If this flag is ``True``, then when a Jupyter notebook is being built, any code
+block starting with a `Jupyter cell magic <https://ipython.readthedocs.io/en/stable/interactive/magics.html>`_ (e.g. ``%%bash`` or ``%%writefile``)
+will be turned into a runnable code block.
+
+For our earlier example, we could change the Markdown text to::
+
+  #%%
+  # Installing dependencies
+  #
+  #     .. code-block:: bash
+  #
+  #       %%bash
+  #       pip install -q tensorflow
+  #       apt-get -qq install curl
+
+Then, TensorFlow and Curl would be automatically installed upon running the
+Jupyter notebook. This works for any cell magic (not just those mentioned above)
+and only affects the creation of Jupyter notebooks.
+
+.. warning::
+  It is good practice to ensure the ``.py`` and ``.html`` files match the ``.ipynb``
+  files as closely as possible. This flag (and Jupyter cell magics) should only
+  be used when the relevant code is already intended to be executed by the end
+  user.
 
 .. _without_execution:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1093,10 +1093,10 @@ for an example that uses the `public Binder server <http://mybinder.org>`_.
 Making cell magic executable in notebooks
 =========================================
 
-Often times, tutorials will include bash scripts for the user to copy/paste into
-their terminal. These scripts are not intended to be run when someone is
-building the documentation, as they will already have those dependencies in
-their environment. Hence they are normally written as code blocks inside text::
+Often times, tutorials will include bash code for the user to copy/paste into
+their terminal. This code should not be run when someone is building the
+documentation, as they will already have those dependencies in their
+environment. Hence they are normally written as code blocks inside text::
 
   #%%
   # Installing dependencies
@@ -1108,7 +1108,7 @@ their environment. Hence they are normally written as code blocks inside text::
 
 This works fine for the ``.py`` and ``.html`` files, but causes problems when
 rendered as an Jupyter notebook. The downloaded ``.ipynb`` file will not have
-those dependencies installed, and thus will not work without running the script.
+those dependencies installed, and will not work without running the bash code.
 
 To fix this, we can set the ``promote_jupyter_magic`` flag in ``conf.py``::
 
@@ -1118,7 +1118,7 @@ To fix this, we can set the ``promote_jupyter_magic`` flag in ``conf.py``::
   }
 
 If this flag is ``True``, then when a Jupyter notebook is being built, any code
-block starting with a `Jupyter cell magic <https://ipython.readthedocs.io/en/stable/interactive/magics.html>`_ (e.g. ``%%bash`` or ``%%writefile``)
+block starting with `Jupyter cell magics <https://ipython.readthedocs.io/en/stable/interactive/magics.html>`_ (e.g. ``%%bash`` or ``%%writefile``)
 will be turned into a runnable code block.
 
 For our earlier example, we could change the Markdown text to::
@@ -1132,15 +1132,14 @@ For our earlier example, we could change the Markdown text to::
   #       pip install -q tensorflow
   #       apt-get -qq install curl
 
-Then, TensorFlow and Curl would be automatically installed upon running the
+meaning TensorFlow and Curl would be automatically installed upon running the
 Jupyter notebook. This works for any cell magic (not just those mentioned above)
 and only affects the creation of Jupyter notebooks.
 
 .. warning::
   It is good practice to ensure the ``.py`` and ``.html`` files match the ``.ipynb``
-  files as closely as possible. This flag (and Jupyter cell magics) should only
-  be used when the relevant code is intended to be executed by the end
-  user.
+  files as closely as possible. This functionality should only be used when the
+  relevant code is intended to be executed by the end user.
 
 .. _without_execution:
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -79,6 +79,7 @@ DEFAULT_GALLERY_CONF = {
     'thumbnail_size': (400, 280),  # Default CSS does 0.4 scaling (160, 112)
     'min_reported_time': 0,
     'binder': {},
+    'promote_jupyter_magic': False,
     'image_scrapers': ('matplotlib',),
     'compress_images': (),
     'reset_modules': ('matplotlib', 'seaborn'),

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -171,7 +171,7 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
     gallery_conf.update(abort_on_example_error=abort_on_example_error)
     # XXX anything that can only be a bool (rather than str) should probably be
     # evaluated this way as it allows setting via -D on the command line
-    for key in ('run_stale_examples',):
+    for key in ('promote_jupyter_magic', 'run_stale_examples',):
         gallery_conf[key] = _bool_eval(gallery_conf[key])
     gallery_conf['src_dir'] = src_dir
     gallery_conf['app'] = app
@@ -375,12 +375,6 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
                               % (css, _KNOWN_CSS))
         if gallery_conf['app'] is not None:  # can be None in testing
             gallery_conf['app'].add_css_file(css + '.css')
-
-    # jupyter magics
-    if not isinstance(gallery_conf['promote_jupyter_magic'], bool):
-        raise ConfigError('gallery_conf["promote_jupyter_magic"] must be of '
-                          'type bool, got: %s.'
-                          % type(gallery_conf['promote_jupyter_magic']))
 
     _update_gallery_conf(gallery_conf)
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -376,6 +376,12 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
         if gallery_conf['app'] is not None:  # can be None in testing
             gallery_conf['app'].add_css_file(css + '.css')
 
+    # jupyter magics
+    if not isinstance(gallery_conf['promote_jupyter_magic'], bool):
+        raise ConfigError('gallery_conf["promote_jupyter_magic"] must be of '
+                          'type bool, got: %s.'
+                          % type(gallery_conf['promote_jupyter_magic']))
+
     _update_gallery_conf(gallery_conf)
 
     return gallery_conf

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -71,16 +71,23 @@ def directive_fun(match, directive):
 
 
 def convert_code_to_md(text):
-    code_regex = r'[ \t]*\.\. code-block::[ \t]*([a-z]*)\n[ \t]*\n'
-    indent_regex = re.compile(r'[ \t]*')
+    """Rewrites code blocks using the code-block notation to use Markdown's
+    preferred backtick notation, which preserves syntax highlighting.
+
+    Parameters
+    ----------
+    text: str
+        A mostly converted string of markdown text. May contain zero, one,
+        or multiple code blocks in code-block format.
+    """
+
+    code_regex = r'[ \t]*\.\. code-block::[ \t]*(\S*)\n[ \t]*\n([ \t]+)'
     while True:
         code_block = re.search(code_regex, text)
         if not code_block:
             break
-        start_index = code_block.span()[1]
-        indent = indent_regex.search(text, start_index).group(0)
-        if not indent:
-            continue
+        indent = code_block.group(2)
+        start_index = code_block.span()[1] - len(indent)
 
         # Find first non-empty, non-indented line
         end = re.compile(fr'^(?!{re.escape(indent)})[ \t]*\S+', re.MULTILINE)
@@ -271,6 +278,17 @@ def add_markdown_cell(work_notebook, markdown):
 
 
 def promote_jupyter_cell_magic(work_notebook, markdown):
+    """Parses a block of markdown text looking for code blocks starting with a
+    Jupyter cell magic (e.g. %%bash). Whenever one is found, the text before it
+    and the code (as a runnable code block) are added to work_notebook. Any
+    remaining text is returned.
+
+    Parameters
+    ----------
+    markdown : str
+        Markdown cell content.
+    """
+
     # Regex detects all code blocks that use %% Jupyter cell magic
     cell_magic_regex = r'\n?```\s*[a-z]*\n(%%(?:[\s\S]*?))\n?```\n?'
 

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -73,7 +73,10 @@ def directive_fun(match, directive):
 def convert_code_to_md(text):
     code_regex = r'[ \t]*\.\. code-block::[ \t]*([a-z]*)\n[ \t]*\n'
     indent_regex = re.compile(r'[ \t]*')
-    while code_block := re.search(code_regex, text):
+    while True:
+        code_block = re.search(code_regex, text)
+        if not code_block:
+            break
         start_index = code_block.span()[1]
         indent = indent_regex.search(text, start_index).group(0)
         if not indent:

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -315,9 +315,12 @@ def fill_notebook(work_notebook, script_blocks, gallery_conf, target_dir):
                     bcontent, to='md', format='rst', **gallery_conf["pypandoc"]
                 )
 
-            remaining = promote_jupyter_cell_magic(work_notebook, markdown)
-            if remaining and not remaining.isspace():
-                add_markdown_cell(work_notebook, remaining)
+            if gallery_conf["promote_jupyter_magic"]:
+                remaining = promote_jupyter_cell_magic(work_notebook, markdown)
+                if remaining and not remaining.isspace():
+                    add_markdown_cell(work_notebook, remaining)
+            else:
+                add_markdown_cell(work_notebook, markdown)
 
 
 def save_notebook(work_notebook, write_file):

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -15,12 +15,13 @@ from functools import partial
 from itertools import count
 import argparse
 import base64
+import copy
 import json
 import mimetypes
 import os
 import re
 import sys
-import copy
+import textwrap
 
 from sphinx.errors import ExtensionError
 
@@ -67,6 +68,26 @@ def directive_fun(match, directive):
     return ('<div class="alert alert-{0}"><h4>{1}</h4><p>{2}</p></div>'
             .format(directive_to_alert[directive], directive.capitalize(),
                     match.group(1).strip()))
+
+
+def convert_code_to_md(text):
+    code_regex = r'[ \t]*\.\. code-block::[ \t]*([a-z]*)\n[ \t]*\n'
+    indent_regex = re.compile(r'[ \t]*')
+    while code_block := re.search(code_regex, text):
+        start_index = code_block.span()[1]
+        indent = indent_regex.search(text, start_index).group(0)
+        if not indent:
+            continue
+
+        # Find first non-empty, non-indented line
+        end = re.compile(fr'^(?!{re.escape(indent)})[ \t]*\S+', re.MULTILINE)
+        code_end_match = end.search(text, start_index)
+        end_index = code_end_match.start() if code_end_match else len(text)
+
+        contents = textwrap.dedent(text[start_index:end_index]).rstrip()
+        new_code = (f'```{code_block.group(1)}\n{contents}\n```\n')
+        text = text[:code_block.span()[0]] + new_code + text[end_index:]
+    return text
 
 
 def rst2md(text, gallery_conf, target_dir, heading_levels):
@@ -148,6 +169,8 @@ def rst2md(text, gallery_conf, target_dir, heading_levels):
                 match.group(1).strip(), gallery_conf, target_dir),
             re.sub(image_opts, r' \1="\2"', match.group(2) or '')),
         text)
+
+    text = convert_code_to_md(text)
 
     return text
 

--- a/sphinx_gallery/tests/reference_parse.txt
+++ b/sphinx_gallery/tests/reference_parse.txt
@@ -99,6 +99,13 @@
   '\n# another way to separate code blocks shown above\nB = 1\n\n',
   86),
 ('text',
+  'Code blocks containing Jupyter magic are executable\n'
+  '    .. code-block:: bash\n'
+  '\n'
+  '      %%bash\n'
+  '      # This could be run!\n\n',
+  91),
+('text',
   'Last text block.\n'
   '\n'
   "That's all folks !\n"
@@ -106,4 +113,4 @@
   '.. literalinclude:: plot_parse.py\n'
   '\n'
   '\n',
-  91)]
+  99)]

--- a/sphinx_gallery/tests/test_notebook.py
+++ b/sphinx_gallery/tests/test_notebook.py
@@ -41,6 +41,36 @@ def test_latex_conversion(gallery_conf):
     assert align_eq_jmd == rst2md(align_eq, gallery_conf, "", {})
 
 
+def test_code_conversion():
+    """Use the ``` code format so Jupyter syntax highlighting works"""
+    rst = (
+        "\n"
+        "Regular text\n"
+        "    .. code-block:: bash\n"
+        "  \n"
+        "       # Bash code\n"
+        "\n"
+        "  More regular text\n"
+        ".. code-block:: cpp\n"
+        "\n"
+        "  //cpp code\n"
+        "\n"
+        "  //more cpp code\n"
+    )
+    assert rst2md(rst, {}, "", {}) == textwrap.dedent("""
+        Regular text
+        ```bash
+        # Bash code
+        ```
+          More regular text
+        ```cpp
+        //cpp code
+
+        //more cpp code
+        ```
+    """)
+
+
 def test_convert(gallery_conf):
     """Test ReST conversion"""
     rst = """hello

--- a/sphinx_gallery/tests/test_notebook.py
+++ b/sphinx_gallery/tests/test_notebook.py
@@ -44,23 +44,26 @@ def test_latex_conversion(gallery_conf):
 
 def test_code_conversion():
     """Use the ``` code format so Jupyter syntax highlighting works"""
-    rst = (
-        "\n"
-        "Regular text\n"
-        "    .. code-block:: bash\n"
-        "  \n"
-        "       # Bash code\n"
-        "\n"
-        "  More regular text\n"
-        ".. code-block:: cpp\n"
-        "\n"
-        "  //cpp code\n"
-        "\n"
-        "  //more cpp code\n"
-    )
+    rst = textwrap.dedent("""
+        Regular text
+            .. code-block::
+
+               # Bash code
+
+          More regular text
+        .. code-block:: cpp
+
+          //cpp code
+
+          //more cpp code
+        non-indented code blocks are not valid
+        .. code-block:: cpp
+
+        // not a real code block
+    """)
     assert rst2md(rst, {}, "", {}) == textwrap.dedent("""
         Regular text
-        ```bash
+        ```
         # Bash code
         ```
           More regular text
@@ -69,6 +72,10 @@ def test_code_conversion():
 
         //more cpp code
         ```
+        non-indented code blocks are not valid
+        .. code-block:: cpp
+
+        // not a real code block
     """)
 
 

--- a/sphinx_gallery/tests/test_notebook.py
+++ b/sphinx_gallery/tests/test_notebook.py
@@ -353,6 +353,8 @@ def test_jupyter_notebook(gallery_conf):
     assert re.match("^Last text block.\n\nThat[\\\\]?'s all folks !", cell_src)
 
     # Test Jupyter magic code blocks are promoted
+    gallery_conf['promote_jupyter_magic'] = True
+    example_nb = jupyter_notebook(blocks, gallery_conf, target_dir)
     bash_block = example_nb.get('cells')[-2]
     assert bash_block['cell_type'] == 'code'
     assert bash_block['source'][0] == '%%bash\n# This could be run!'

--- a/sphinx_gallery/tests/test_notebook.py
+++ b/sphinx_gallery/tests/test_notebook.py
@@ -21,7 +21,8 @@ from sphinx.errors import ExtensionError
 
 import sphinx_gallery.gen_rst as sg
 from sphinx_gallery.notebook import (rst2md, jupyter_notebook, save_notebook,
-                                     python_to_jupyter_cli)
+                                     promote_jupyter_cell_magic,
+                                     python_to_jupyter_cli,)
 
 
 def test_latex_conversion(gallery_conf):
@@ -200,6 +201,43 @@ def test_headings():
     assert "# White space above\n" in text
 
 
+def test_cell_magic_promotion():
+    markdown = textwrap.dedent("""\
+    # Should be rendered as text
+    ``` bash
+    # This should be rendered as normal
+    ```
+    ``` bash
+    %%bash
+    # bash magic
+    ```
+    ```cpp
+    %%writefile out.cpp
+    // This c++ cell magic will write a file
+    // There should NOT be a text block above this
+    ```
+    Interspersed text block
+    ```javascript
+    %%javascript
+    // Should also be a code block
+    // There should NOT be a trailing text block after this
+    ```
+    """)
+    work_notebook = {"cells": []}
+    promote_jupyter_cell_magic(work_notebook, markdown)
+    cells = work_notebook["cells"]
+
+    assert len(cells) == 5
+    assert cells[0]["cell_type"] == "markdown"
+    assert "``` bash" in cells[0]["source"][0]
+    assert cells[1]["cell_type"] == "code"
+    assert cells[1]["source"][0] == "%%bash\n# bash magic"
+    assert cells[2]["cell_type"] == "code"
+    assert cells[3]["cell_type"] == "markdown"
+    assert cells[3]["source"][0] == "Interspersed text block"
+    assert cells[4]["cell_type"] == "code"
+
+
 @pytest.mark.parametrize(
     'rst_path,md_path,prefix_enabled',
     (('../_static/image.png', 'file://../_static/image.png', False),
@@ -313,6 +351,16 @@ def test_jupyter_notebook(gallery_conf):
     example_nb = jupyter_notebook(blocks, gallery_conf, target_dir)
     cell_src = example_nb.get('cells')[-1]['source'][0]
     assert re.match("^Last text block.\n\nThat[\\\\]?'s all folks !", cell_src)
+
+    # Test Jupyter magic code blocks are promoted
+    bash_block = example_nb.get('cells')[-2]
+    assert bash_block['cell_type'] == 'code'
+    assert bash_block['source'][0] == '%%bash\n# This could be run!'
+
+    # Test text above Jupyter magic code blocks is intact
+    md_above_bash_block = example_nb.get('cells')[-3]
+    assert md_above_bash_block['cell_type'] == 'markdown'
+    assert 'Code blocks containing' in md_above_bash_block['source'][0]
 
 
 ###############################################################################

--- a/tutorials/plot_parse.py
+++ b/tutorials/plot_parse.py
@@ -88,6 +88,14 @@ print('one')
 B = 1
 
 # %%
+# Code blocks containing Jupyter magic are executable
+#     .. code-block:: bash
+#
+#       %%bash
+#       # This could be run!
+#
+
+# %%
 # Last text block.
 #
 # That's all folks !


### PR DESCRIPTION
## What this PR does
This pull request improves the way `notebook.py` creates Jupyter notebooks by introducing two changes. First, when generating code blocks in Markdown, we now use the ```[language] format instead of indenting. This causes one-line code blocks to render correctly, and also makes syntax highlighting work correctly. For example, consider the lines:
```
    .. code-block:: bash

      flatc --version
```
Many Jupyter notebook editors (like [Google Colab](https://colab.research.google.com/) do not render this as code as all! With this change, it would instead be translated like the following, which both renders correctly and has syntax highlighting:
````
```bash
flatc --version
```
````
Additionally, this PR makes `notebook.py` recognize so-called [Jupyter magic commands](https://ipython.readthedocs.io/en/stable/interactive/magics.html). These commands (like `%%bash`) allow code in other languages to be executed in Jupyter. If the notebook converter sees a code block that starts with a Jupyter cell magic command, we will now turn it into a runnable code block.

## Why is this useful?

I'm a contributor on [Apache TVM](https://github.com/apache/tvm), which uses Sphinx Gallery for our [tutorials](https://tvm.apache.org/docs/how_to/work_with_microtvm/index.html). Having these features would make the notebooks generated from the "Download Jupyter notebook" button work "out of the box". 

## How is it tested?

This PR also adds both unit tests and integration tests for both of these features (for the integration tests, I added a few lines to `plot_parse.py`). I've also verified that `flake8` passes without errors.