### PR TITLE
Add flag to ignore code blocks in Python source parser

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -67,6 +67,10 @@ Some options can be set on a per-code-block basis in a file:
 See also :ref:`removing_config_comments` to hide config comments in files from
 the rendered examples.
 
+Some options can be set on a per-line basis in a file:
+- ``# sphinx_gallery_start_ignore`` (:ref:`hiding_code_blocks`)
+- ``# sphinx_gallery_end_ignore`` (:ref:`hiding_code_blocks`)
+
 Some options can be set during the build execution step, e.g. using a Makefile:
 
 - ``make html-noplot`` (:ref:`without_execution`)
@@ -1288,6 +1292,46 @@ further deferred, if desired).  The following produces only one plot::
 
   plt.plot([2, 2])
   plt.show()
+
+.. _hiding_code_blocks:
+
+Hiding code blocks
+==================
+
+Normally, Sphinx-Gallery will render every line of Python code when building
+HTML and iPython notebooks. This is usually desirable, as we want to ensure the
+Python source files, HTML, and iPython notebooks all do the same thing.
+
+However, it is sometimes useful to have Python code that runs, but is not
+included in any user-facing documentation. For example, suppose we wanted to
+add some ``assert`` statements to verify the docs were built successfully, but
+did not want these shown to users. We could use the ``sphinx_gallery_start_ignore``
+and ``sphinx_gallery_end_ignore`` flags to achieve this::
+
+    model.compile()
+    # sphinx_gallery_start_ignore
+    assert len(model.layers) == 5
+    assert model.count_params() == 219058
+    # sphinx_gallery_end_ignore
+    model.fit()
+
+When the HTML or iPython notebooks are built, this code block will be shown as::
+
+    model.compile()
+    model.fit()
+
+The ``sphinx_gallery_start_ignore`` and ``sphinx_gallery_end_ignore`` flags may
+be used in any code block, and multiple pairs of flags may be used in the same
+block. Every start flag must always have a corresponding end flag, or an error
+will be raised during doc generation. These flags and the code between them are
+always removed, regardless of what ``remove_config_comments`` is set to.
+
+Note that any output from the ignored code will still be captured.
+
+.. warning::
+  This flag should be used sparingly, as it makes the ``.py`` source files less
+  equivalent to the generated ``.html`` and ``.ipynb`` files. It is bad practice
+  to use this when other methods that preserve this relationship are possible.
 
 .. _dummy_images:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -9,6 +9,11 @@ dictionary specified in your ``conf.py`` file. A list of the possible
 keys are listed :ref:`below <list_of_options>` and explained in
 greater detail in subsequent sections.
 
+When using these flags, it is good practice to make sure the source Python files
+are equivalent to the generated HTML and iPython notebooks (i.e. make sure
+``.py == .html == .ipynb``). This principle should be violated only when
+necessary, and on a case-by-case basis.
+
 .. _list_of_options:
 
 List of config options

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -73,8 +73,7 @@ See also :ref:`removing_config_comments` to hide config comments in files from
 the rendered examples.
 
 Some options can be set on a per-line basis in a file:
-- ``# sphinx_gallery_start_ignore`` (:ref:`hiding_code_blocks`)
-- ``# sphinx_gallery_end_ignore`` (:ref:`hiding_code_blocks`)
+- ``# sphinx_gallery_start_ignore`` and ``# sphinx_gallery_end_ignore`` (:ref:`hiding_code_blocks`)
 
 Some options can be set during the build execution step, e.g. using a Makefile:
 
@@ -1300,8 +1299,8 @@ further deferred, if desired).  The following produces only one plot::
 
 .. _hiding_code_blocks:
 
-Hiding code blocks
-==================
+Hiding lines of code
+====================
 
 Normally, Sphinx-Gallery will render every line of Python code when building
 HTML and iPython notebooks. This is usually desirable, as we want to ensure the

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -45,7 +45,8 @@ from .backreferences import (_write_backreferences, _thumbnail_div,
                              identify_names)
 from .downloads import CODE_DOWNLOAD
 from .py_source_parser import (split_code_and_text_blocks,
-                               remove_config_comments)
+                               remove_config_comments,
+                               remove_ignore_blocks)
 
 from .notebook import jupyter_notebook, save_notebook
 from .binder import check_binder_conf, gen_binder_rst
@@ -1014,6 +1015,11 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
             (label, remove_config_comments(content), line_number)
             for label, content, line_number in script_blocks
         ]
+
+    script_blocks = [
+        (label, remove_ignore_blocks(content), line_number)
+        for label, content, line_number in script_blocks
+    ]
 
     # Remove final empty block, which can occur after config comments
     # are removed

--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -226,7 +226,10 @@ def remove_ignore_blocks(code_block):
     num_start_flags = len(re.findall(START_IGNORE_FLAG, code_block))
     num_end_flags = len(re.findall(END_IGNORE_FLAG, code_block))
 
-    assert num_start_flags == num_end_flags, "start/end ignore block mismatch!"
+    assert num_start_flags == num_end_flags, (
+        'All "sphinx_gallery_start_ignore" flags must have a matching '
+        '"sphinx_gallery_end_ignore" flag!'
+    )
     return re.subn(IGNORE_BLOCK_PATTERN, '', code_block)[0]
 
 

--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -226,10 +226,11 @@ def remove_ignore_blocks(code_block):
     num_start_flags = len(re.findall(START_IGNORE_FLAG, code_block))
     num_end_flags = len(re.findall(END_IGNORE_FLAG, code_block))
 
-    assert num_start_flags == num_end_flags, (
-        'All "sphinx_gallery_start_ignore" flags must have a matching '
-        '"sphinx_gallery_end_ignore" flag!'
-    )
+    if num_start_flags != num_end_flags:
+        raise ExtensionError(
+            'All "sphinx_gallery_start_ignore" flags must have a matching '
+            '"sphinx_gallery_end_ignore" flag!'
+        )
     return re.subn(IGNORE_BLOCK_PATTERN, '', code_block)[0]
 
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -42,6 +42,9 @@ CONTENT = [
     '# sphinx_gallery_thumbnail_number = 1',
     '# sphinx_gallery_defer_figures',
     '# and now comes the module code',
+    '# sphinx_gallery_start_ignore',
+    'pass # Will be run but not rendered',
+    '# sphinx_gallery_end_ignore',
     'import logging',
     'import sys',
     'from warnings import warn',
@@ -455,6 +458,15 @@ def test_remove_config_comments(gallery_conf, req_pil):
     rst = _generate_rst(gallery_conf, 'test.py', CONTENT)
     assert '# sphinx_gallery_thumbnail_number = 1' not in rst
     assert '# sphinx_gallery_defer_figures' not in rst
+
+
+def test_remove_ignore_blocks(gallery_conf, req_pil):
+    """Test removal of ignore blocks."""
+    rst = _generate_rst(gallery_conf, 'test.py', CONTENT)
+    assert 'pass # Will be run but not rendered' in CONTENT
+    assert 'pass # Will be run but not rendered' not in rst
+    assert '# sphinx_gallery_start_ignore' in CONTENT
+    assert '# sphinx_gallery_start_ignore' not in rst
 
 
 def test_dummy_image_error(gallery_conf, req_pil):

--- a/sphinx_gallery/tests/test_py_source_parser.py
+++ b/sphinx_gallery/tests/test_py_source_parser.py
@@ -12,6 +12,7 @@ from __future__ import division, absolute_import, print_function
 
 import os.path as op
 import pytest
+import textwrap
 from sphinx.errors import ExtensionError
 import sphinx_gallery.py_source_parser as sg
 
@@ -82,3 +83,33 @@ def test_extract_file_config(content, file_conf, log_collector):
 ])
 def test_remove_config_comments(contents, result):
     assert sg.remove_config_comments(contents) == result
+
+
+def test_remove_ignore_comments():
+    print(sg.IGNORE_BLOCK_PATTERN)
+    normal_code = "# Regular code\n# should\n# be untouched!"
+    assert sg.remove_ignore_blocks(normal_code) == normal_code
+
+    mismatched_code = "# sphinx_gallery_start_ignore"
+    with pytest.raises(AssertionError) as error:
+        sg.remove_ignore_blocks(mismatched_code)
+    assert "mismatch" in str(error)
+
+    code_with_ignores = textwrap.dedent("""\
+    # Indented ignores should work
+        # sphinx_gallery_start_ignore
+        # The variable name should do nothing
+        sphinx_gallery_end_ignore = 0
+        # sphinx_gallery_end_ignore
+
+    # New line above should stay intact
+    # sphinx_gallery_start_ignore
+    # sphinx_gallery_end_ignore
+    # Empty ignore blocks are fine too
+    """)
+    assert sg.remove_ignore_blocks(code_with_ignores) == textwrap.dedent("""\
+    # Indented ignores should work
+
+    # New line above should stay intact
+    # Empty ignore blocks are fine too
+    """)

--- a/sphinx_gallery/tests/test_py_source_parser.py
+++ b/sphinx_gallery/tests/test_py_source_parser.py
@@ -90,7 +90,7 @@ def test_remove_ignore_comments():
     assert sg.remove_ignore_blocks(normal_code) == normal_code
 
     mismatched_code = "# sphinx_gallery_start_ignore"
-    with pytest.raises(AssertionError) as error:
+    with pytest.raises(ExtensionError) as error:
         sg.remove_ignore_blocks(mismatched_code)
     assert "must have a matching" in str(error)
 

--- a/sphinx_gallery/tests/test_py_source_parser.py
+++ b/sphinx_gallery/tests/test_py_source_parser.py
@@ -86,14 +86,13 @@ def test_remove_config_comments(contents, result):
 
 
 def test_remove_ignore_comments():
-    print(sg.IGNORE_BLOCK_PATTERN)
     normal_code = "# Regular code\n# should\n# be untouched!"
     assert sg.remove_ignore_blocks(normal_code) == normal_code
 
     mismatched_code = "# sphinx_gallery_start_ignore"
     with pytest.raises(AssertionError) as error:
         sg.remove_ignore_blocks(mismatched_code)
-    assert "mismatch" in str(error)
+    assert "must have a matching" in str(error)
 
     code_with_ignores = textwrap.dedent("""\
     # Indented ignores should work


### PR DESCRIPTION
## What this PR does
This PR adds the flags `# sphinx_gallery_start_ignore` and `# sphinx_gallery_end_ignore`, which can be used in Python source files. For example, consider the following snippet of a source Python file:
```python
# Finding Connected Arduino Boards
# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Suppose we want a tutorial showing how to get a list of all connected Arduino 
# boards. We'd like it to work for the user, but we would also like people to
# be able to build the docs even if they don't have an Arduino. Using these
# flags, we can add code to mock the output of subprocess so the docs build
# correctly, all without confusing the end user.
#

import subprocess
# sphinx_gallery_start_ignore
from unittest.mock import create_autospec, MagicMock
subprocess.run = create_autospec(subprocess.run, return_value="nano33ble\n")
# sphinx_gallery_end_ignore

arduino_board = subprocess.run(
    ["arduino-cli", "board", "list], check=True, stdout=subprocess.PIPE
)
```
In this example, the code between `start_ignore` and `end_ignore` **will** be run when the `.py` file is executed. However, when an HTML page is built from the `.py` script, those flags and the lines between them will be ignored. Hence the code block as seen from the webpage would look like this:
```python
import subprocess

arduino_board = subprocess.run(
    ["arduino-cli", "board", "list], check=True, stdout=subprocess.PIPE
)
```

## Why is this useful?
Previously, there was no good way to do "mocking" in Python source files with Sphinx Gallery. For example, imagine the Python source file was a tutorial, and consider the following use cases:
- The tutorial requires some connected hardware (say, an Arduino board), but you don't want to force people to connect an Arduino to build the documentation.
- The tutorial has some non-Python component - for example, running some `bash` commands or downloading a dataset from the Internet. You *could* use Python to do these things, I suppose (use `subprocess` for `bash` commands and `requests` to download the dataset), but it would be much easier to allow the user to do them the "normal way" and mock them in the `.py` file.
- After building the docs, we want some `assert` sanity checks to make sure the tutorial ran correctly and isn't bugged. However, we don't expect the user to run these test cases, and thus should not include them in the `.html` page.

I'm part of the [Apache TVM](https://github.com/apache/tvm) community (which [uses Sphinx Gallery for tutorials](https://tvm.apache.org/docs/how_to/work_with_microtvm/index.html)), and we've run into all of the issues mentioned above. This feature is a small change that would alleviate all of these issues. We're also not the first ones to request this feature - [here's a previous issue](https://github.com/sphinx-gallery/sphinx-gallery/issues/361) and [a pull request](https://github.com/ajtritt/sphinx-galleria/pull/1), though that user fixed his use case a different way.

Yes, it's true that in general using `sphinx_gallery_start_ignore` might be a little gross, as we do want the generated HTML to match the Python source file. However, Apache TVM has a lot of use cases it would really help with, and I imagine other projects might have similar needs. 

## How is it tested?

I've added unit tests for this feature to `test_py_source_parser.py`, and integration tests to `test_gen_rst.py`. I've also verified that `flake8` lints without errors.