### PR TITLE
Add Apache TVM to user projects list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,7 @@ Who uses Sphinx-Gallery
 * `TorchIO <https://torchio.readthedocs.io/auto_examples/index.html>`_
 * `Neuraxle <https://www.neuraxle.org/stable/examples/index.html>`_
 * `Biotite <https://www.biotite-python.org/examples/gallery/index.html>`_
+* `Apache TVM <https://tvm.apache.org/docs/tutorial/index.html>`_
 
 .. installation-begin-content
 


### PR DESCRIPTION
[Apache TVM](https://tvm.apache.org/) is an open source machine learning compiler framework that's able to compile neural networks for a variety of backends, including CPUs, GPUs, accelerators, and microcontrollers. We use Sphinx-Gallery for our [how-to tutorials page](https://tvm.apache.org/docs/how_to/index.html), and it works well.

Would be cool to add it to the project list!