### PR TITLE
Fix rendering of embedded URIs in Python notebooks

### DIFF
--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -124,8 +124,11 @@ def rst2md(text, gallery_conf, target_dir, heading_levels):
         text = re.sub(directive_re,
                       partial(directive_fun, directive=directive), text)
 
-    links = re.compile(r'^ *\.\. _.*:.*$\n', flags=re.M)
-    text = re.sub(links, '', text)
+    footnote_links = re.compile(r'^ *\.\. _.*:.*$\n', flags=re.M)
+    text = re.sub(footnote_links, '', text)
+
+    embedded_uris = re.compile(r'`([^`]*?)\s*<([^`]*)>`_')
+    text = re.sub(embedded_uris, r'[\1](\2)', text)
 
     refs = re.compile(r':ref:`')
     text = re.sub(refs, '`', text)

--- a/sphinx_gallery/tests/test_notebook.py
+++ b/sphinx_gallery/tests/test_notebook.py
@@ -65,6 +65,8 @@ For more details on interpolation see the page :ref:`channel_interpolation`.
   :whatever: you
   :width: 200px
   :class: img_class
+
+`See more  <https://en.wikipedia.org/wiki/Interpolation>`_.
 """
 
     markdown = """hello
@@ -79,6 +81,8 @@ This is $some$ math $stuff$.
 For more details on interpolation see the page `channel_interpolation`.
 
 <img src="file://foobar" alt="me" whatever="you" width="200px" class="img_class">
+
+[See more](https://en.wikipedia.org/wiki/Interpolation).
 """  # noqa
     assert rst2md(rst, gallery_conf, "", {}) == markdown
 


### PR DESCRIPTION
Currently, embedded URIs do not render correctly when converted to `.ipynb` notebooks. Here's one example of the `.ipynb` you can download from the [Executing a Tiny Model with TVMC Micro]:(https://tvm.apache.org/docs/how_to/work_with_microtvm/micro_tvmc.html#sphx-glr-how-to-work-with-microtvm-micro-tvmc-py)




![image](https://user-images.githubusercontent.com/3069006/163536575-e4385efa-b498-47ba-9453-b1ad214d48af.png)

The fix for this is pretty straightforward, and just involves using a Regex to find and replace these with the Markdown format of links. Should be a pretty straightforward suggestion!