### PR TITLE
ENH: Better dark mode support

### DIFF
--- a/sphinx_gallery/_static/sg_gallery-dataframe.css
+++ b/sphinx_gallery/_static/sg_gallery-dataframe.css
@@ -1,17 +1,27 @@
 /* Pandas dataframe css */
 /* Taken from: https://github.com/spatialaudio/nbsphinx/blob/fb3ba670fc1ba5f54d4c487573dbc1b4ecf7e9ff/src/nbsphinx.py#L587-L619 */
+html[data-theme="light"] {
+  --sg-text-color: #000;
+  --sg-tr-odd-color: #f5f5f5;
+  --sg-tr-hover-color: rgba(66, 165, 245, 0.2);
+}
+html[data-theme="dark"] {
+  --sg-text-color: #fff;
+  --sg-tr-odd-color: #373737;
+  --sg-tr-hover-color: rgba(30, 81, 122, 0.2);
+}
 
 table.dataframe {
   border: none !important;
   border-collapse: collapse;
   border-spacing: 0;
   border-color: transparent;
-  color: black;
+  color: var(--sg-text-color);
   font-size: 12px;
   table-layout: fixed;
 }
 table.dataframe thead {
-  border-bottom: 1px solid black;
+  border-bottom: 1px solid var(--sg-text-color);
   vertical-align: bottom;
 }
 table.dataframe tr,
@@ -29,8 +39,8 @@ table.dataframe th {
   font-weight: bold;
 }
 table.dataframe tbody tr:nth-child(odd) {
-  background: #f5f5f5;
+  background: var(--sg-tr-odd-color);
 }
 table.dataframe tbody tr:hover {
-  background: rgba(66, 165, 245, 0.2);
+  background: var(--sg-tr-hover-color);
 }

--- a/sphinx_gallery/_static/sg_gallery-rendered-html.css
+++ b/sphinx_gallery/_static/sg_gallery-rendered-html.css
@@ -1,7 +1,21 @@
 /* Adapted from notebook/static/style/style.min.css */
+html[data-theme="light"] {
+  --sg-text-color: #000;
+  --sg-background-color: #ffffff;
+  --sg-code-background-color: #eff0f1;
+  --sg-tr-hover-color: rgba(66, 165, 245, 0.2);
+  --sg-tr-odd-color: #f5f5f5;
+}
+html[data-theme="dark"] {
+  --sg-text-color: #fff;
+  --sg-background-color: #121212;
+  --sg-code-background-color: #2f2f30;
+  --sg-tr-hover-color: rgba(66, 165, 245, 0.2);
+  --sg-tr-odd-color: #1f1f1f;
+}
 
 .rendered_html {
-  color: #000;
+  color: var(--sg-text-color);
   /* any extras will just be numbers: */
 }
 .rendered_html em {
@@ -112,27 +126,27 @@
   margin-top: 1em;
 }
 .rendered_html hr {
-  color: black;
-  background-color: black;
+  color: var(--sg-text-color);
+  background-color: var(--sg-text-color);
 }
 .rendered_html pre {
   margin: 1em 2em;
   padding: 0px;
-  background-color: #fff;
+  background-color: var(--sg-background-color);
 }
 .rendered_html code {
-  background-color: #eff0f1;
+  background-color: var(--sg-code-background-color);
 }
 .rendered_html p code {
   padding: 1px 5px;
 }
 .rendered_html pre code {
-  background-color: #fff;
+  background-color: var(--sg-background-color);
 }
 .rendered_html pre,
 .rendered_html code {
   border: 0;
-  color: #000;
+  color: var(--sg-text-color);
   font-size: 100%;
 }
 .rendered_html blockquote {
@@ -144,12 +158,12 @@
   border: none;
   border-collapse: collapse;
   border-spacing: 0;
-  color: black;
+  color: var(--sg-text-color);
   font-size: 12px;
   table-layout: fixed;
 }
 .rendered_html thead {
-  border-bottom: 1px solid black;
+  border-bottom: 1px solid var(--sg-text-color);
   vertical-align: bottom;
 }
 .rendered_html tr,
@@ -167,10 +181,11 @@
   font-weight: bold;
 }
 .rendered_html tbody tr:nth-child(odd) {
-  background: #f5f5f5;
+  background: var(--sg-tr-odd-color);
 }
 .rendered_html tbody tr:hover {
-  background: rgba(66, 165, 245, 0.2);
+  color: var(--sg-text-color);
+  background: var(--sg-tr-hover-color);
 }
 .rendered_html * + table {
   margin-top: 1em;

--- a/sphinx_gallery/_static/sg_gallery.css
+++ b/sphinx_gallery/_static/sg_gallery.css
@@ -3,6 +3,46 @@ Sphinx-Gallery has compatible CSS to fix default sphinx themes
 Tested for Sphinx 1.3.1 for all themes: default, alabaster, sphinxdoc,
 scrolls, agogo, traditional, nature, haiku, pyramid
 Tested for Read the Docs theme 0.1.7 */
+
+html[data-theme="light"] {
+  --sg-tooltip-foreground: #fff;
+  --sg-tooltip-background: rgba(0, 0, 0, 0.8);
+  --sg-tooltip-border: #ccc transparent;
+  --sg-thumb-box-shadow-color: #6c757d40;
+  --sg-thumb-hover-border: #0069d9;
+  --sg-script-out: #888;
+  --sg-script-pre: #fafae2;
+  --sg-pytb-foreground: #000;
+  --sg-pytb-background: #ffe4e4;
+  --sg-pytb-border-color: #f66;
+  --sg-download-a-background-color: #ffc;
+  --sg-download-a-background-image: linear-gradient(to bottom, #ffc, #d5d57e);
+  --sg-download-a-border-color: 1px solid #c2c22d;
+  --sg-download-a-color: #000;
+  --sg-download-a-hover-background-color: #d5d57e;
+  --sg-download-a-hover-box-shadow-1: rgba(255, 255, 255, 0.1);
+  --sg-download-a-hover-box-shadow-2: rgba(0, 0, 0, 0.25);
+}
+html[data-theme="dark"] {
+  --sg-tooltip-foreground: #212529;
+  --sg-tooltip-background: rgba(255, 255, 255, 0.8);
+  --sg-tooltip-border: #333 transparent;
+  --sg-thumb-box-shadow-color: #79848d40;
+  --sg-thumb-hover-border: #003975;
+  --sg-script-out: rgb(179, 179, 179);
+  --sg-script-pre: #2e2e22;
+  --sg-pytb-foreground: #fff;
+  --sg-pytb-background: #1b1717;
+  --sg-pytb-border-color: #622;
+  --sg-download-a-background-color: #443;
+  --sg-download-a-background-image: linear-gradient(to bottom, #443, #221);
+  --sg-download-a-border-color: 1px solid #3a3a0d;
+  --sg-download-a-color: #fff;
+  --sg-download-a-hover-background-color: #616135;
+  --sg-download-a-hover-box-shadow-1: rgba(0, 0, 0, 0.1);
+  --sg-download-a-hover-box-shadow-2: rgba(255, 255, 255, 0.25);
+}
+
 .sphx-glr-thumbnails {
   width: 100%;
 
@@ -26,7 +66,7 @@ Tested for Read the Docs theme 0.1.7 */
   -moz-border-radius: 5px;
   -webkit-border-radius: 5px;
   border-radius: 5px;
-  box-shadow: 0 0 10px #6c757d40;
+  box-shadow: 0 0 10px var(--sg-thumb-box-shadow-color);
 
   /* useful to absolutely position link in div */
   position: relative;
@@ -61,7 +101,8 @@ Tested for Read the Docs theme 0.1.7 */
   display: none;
 }
 .sphx-glr-thumbcontainer:hover {
-  border: 1px solid #0069d9;
+  border: 1px solid;
+  border-color: var(--sg-thumb-hover-border);
   cursor: pointer;
 }
 .sphx-glr-thumbcontainer a.internal {
@@ -93,11 +134,11 @@ thumbnail with its default link Background color */
   max-width: 160px;
 }
 .sphx-glr-thumbcontainer[tooltip]:hover:after {
-  background: rgba(0, 0, 0, 0.8);
+  background: var(--sg-tooltip-background);
   -webkit-border-radius: 5px;
   -moz-border-radius: 5px;
   border-radius: 5px;
-  color: #fff;
+  color: var(--sg-tooltip-foreground);
   content: attr(tooltip);
   left: 95%;
   padding: 5px 15px;
@@ -108,7 +149,7 @@ thumbnail with its default link Background color */
 }
 .sphx-glr-thumbcontainer[tooltip]:hover:before {
   border: solid;
-  border-color: #333 transparent;
+  border-color: var(--sg-tooltip-border);
   border-width: 18px 0 0 20px;
   bottom: 58%;
   content: "";
@@ -118,7 +159,7 @@ thumbnail with its default link Background color */
 }
 
 .sphx-glr-script-out {
-  color: #888;
+  color: var(--sg-script-out);
   display: flex;
   gap: 0.5em;
 }
@@ -140,7 +181,7 @@ thumbnail with its default link Background color */
   overflow: auto;
 }
 .sphx-glr-script-out .highlight pre {
-  background-color: #fafae2;
+  background-color: var(--sg-script-pre);
   border: 0;
   max-height: 30em;
   overflow: auto;
@@ -158,9 +199,9 @@ blockquote.sphx-glr-script-out {
   margin-left: 0pt;
 }
 .sphx-glr-script-out.highlight-pytb .highlight pre {
-  color: #000;
-  background-color: #ffe4e4;
-  border: 1px solid #f66;
+  color: var(--sg-pytb-foreground);
+  background-color: var(--sg-pytb-background);
+  border: 1px solid var(--sg-pytb-border-color);
   margin-top: 10px;
   padding: 7px;
 }
@@ -175,11 +216,11 @@ div.sphx-glr-download {
 }
 
 div.sphx-glr-download a {
-  background-color: #ffc;
-  background-image: linear-gradient(to bottom, #ffc, #d5d57e);
+  background-color: var(--sg-download-a-background-color);
+  background-image: var(--sg-download-a-background-image);
   border-radius: 4px;
-  border: 1px solid #c2c22d;
-  color: #000;
+  border: 1px solid var(--sg-download-a-border-color);
+  color: var(--sg-download-a-color);
   display: inline-block;
   font-weight: bold;
   padding: 1ex;
@@ -197,11 +238,10 @@ div.sphx-glr-download code.download {
 }
 
 div.sphx-glr-download a:hover {
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1),
-    0 1px 5px rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 1px 0 var(--sg-download-a-hover-box-shadow-1), 0 1px 5px var(--sg-download-a-hover-box-shadow-2);
   text-decoration: none;
   background-image: none;
-  background-color: #d5d57e;
+  background-color: var(--sg-download-a-hover-background-color);
 }
 
 .sphx-glr-example-title:target::before {


### PR DESCRIPTION
Following https://github.com/pydata/pydata-sphinx-theme/pull/629 users of pydata-sphinx-theme (so far) can opt in to having dark mode. This just makes SG's CSS compatible with `data-theme="dark"` mode. It does this by using CSS variables, which I think is helpful for customization and understanding the colors that actually get used.

| Before | After |
| -- | -- |
| ![Screenshot from 2022-04-20 11-17-17](https://user-images.githubusercontent.com/2365790/164265377-ecd70a58-beb2-4b87-ae3e-d03a54b63444.png) | ![Screenshot from 2022-04-20 11-17-54](https://user-images.githubusercontent.com/2365790/164265398-c86480a9-969e-4010-9ae2-e2c04c7eee36.png) |
| ![Screenshot from 2022-04-20 11-38-52](https://user-images.githubusercontent.com/2365790/164270098-c4174382-741c-43bc-b26b-67944e915a4d.png) | ![Screenshot from 2022-04-20 11-38-13](https://user-images.githubusercontent.com/2365790/164270073-c2978015-f911-4971-ad11-b1b785e2a981.png) |
 