### PR TITLE
Fix Tensorflow/Abseil compatibility

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,3 +11,4 @@ joblib
 flake8
 check-manifest
 plotly
+absl-py

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -106,6 +106,10 @@ class _LoggingTee(object):
             self.logger.verbose('%s', self.logger_buffer)
             self.logger_buffer = ''
 
+    # Needed to work with Abseil
+    def close(self):
+        pass
+
     # When called from a local terminal seaborn needs it in Python3
     def isatty(self):
         return self.output.isatty()


### PR DESCRIPTION
Currently, `sphinx-gallery` does not work with [`absl`](https://pypi.org/project/absl-py/) (see [an example of the failure here](https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-10516/9/pipeline/#step-838-log-1604)). This is not ideal, as `absl` a popular library, and is used by other popular libraries like Tensorflow. I have a more detailed writeup for why this happens at https://github.com/apache/tvm/issues/11117, but it has to do with the fact `sphinx-gallery` is not able to fix `absl`'s pointers to its `LoggingTee` object when `restore_std` is called.

This PR fixes the issue and adds a unit test to prevent regressions in the future, allowing `sphinx-gallery` to be used with `tensorflow` without issue.