### PR TITLE
Add multiline flag when searching for ignore flags

### DIFF
--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -223,8 +223,9 @@ def remove_ignore_blocks(code_block):
     code_block : str
         A code segment.
     """
-    num_start_flags = len(re.findall(START_IGNORE_FLAG, code_block))
-    num_end_flags = len(re.findall(END_IGNORE_FLAG, code_block))
+    num_start_flags = len(
+        re.findall(START_IGNORE_FLAG, code_block, re.MULTILINE))
+    num_end_flags = len(re.findall(END_IGNORE_FLAG, code_block, re.MULTILINE))
 
     if num_start_flags != num_end_flags:
         raise ExtensionError(


### PR DESCRIPTION
This follows on #941, I noticed that it wouldn't detect `sphinx_gallery_end_ignore` comments in the middle of a block. I wasn't able to reproduce this in the unit tests however, but I noticed it when editing [this Python file](https://github.com/apache/tvm/blob/be8e92211e3eebb7700c915a00b43c4c7c80a818/gallery/how_to/compile_models/from_oneflow.py)
