### PR TITLE
Remove test examples for seaborn warning

### DIFF
--- a/examples/plot_seaborn_import_1.py
+++ b/examples/plot_seaborn_import_1.py
@@ -1,8 +1,0 @@
-r"""
-Seaborn import 1
-================
-
-Seaborn 1
-"""
-
-import seaborn

--- a/examples/plot_seaborn_import_2.py
+++ b/examples/plot_seaborn_import_2.py
@@ -1,8 +1,0 @@
-r"""
-Seaborn import 2
-================
-
-Seaborn import 2
-"""
-
-import seaborn


### PR DESCRIPTION
Follow-up of #969. I added test examples to trigger the warnings and test the fix, but forgot to say that they needed to be removed before the PR is merged.

This PR removes the test examples.