### PR TITLE
BUG: Fix bug with clicking examples

### DIFF
--- a/sphinx_gallery/_static/sg_gallery.css
+++ b/sphinx_gallery/_static/sg_gallery.css
@@ -190,6 +190,7 @@ thumbnail with its default link Background color */
   width: 100%;
   height: 100%;
   position: absolute;
+  pointer-events: none;
   top: 0;
   box-sizing: border-box;
   overflow: hidden;


### PR DESCRIPTION
cc @alexisthual none of the examples here are clickable, this seems to fix it. Do you agree it's the right fix?

https://sphinx-gallery.github.io/dev/auto_examples/index.html