### PR TITLE
BUG: Hotfix for docopts_url

### DIFF
--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -150,7 +150,7 @@ class SphinxDocLinkResolver(object):
                     'URLs (doc_url cannot be absolute)')
             index_url = doc_url + '/'
             searchindex_url = doc_url + '/searchindex.js'
-            docopts_url = doc_url + '_static/documentation_options.js'
+            docopts_url = doc_url + '/_static/documentation_options.js'
         else:
             index_url = os.path.join(doc_url, 'index.html')
             searchindex_url = os.path.join(doc_url, 'searchindex.js')


### PR DESCRIPTION
The fix discussed in https://github.com/sphinx-gallery/sphinx-gallery/issues/967

I don't see a quick way to add a test here so let's just get this in as a hotfix. (If it's wrong, I don't think the extra slash would break anything anyway.)

Will merge then cut a release assuming this is green

Closes #967