### PR TITLE
[MAINT, MRG] A few small leftovers from API usage

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -826,7 +826,7 @@ def write_api_entry_usage(app, docname, source):
 
     example_files = set.union(
         *[gallery_conf['api_entries'][obj_type]
-          for obj_type in ('class', 'function')
+          for obj_type in ('class', 'method', 'function')
           if obj_type in gallery_conf['api_entries']])
 
     if len(example_files) == 0:
@@ -835,8 +835,6 @@ def write_api_entry_usage(app, docname, source):
     def get_entry_type(entry):
         if entry in gallery_conf['api_entries']['class']:
             return 'class'
-        # TO DO: add support for method when examples that they are
-        # used in are properly traced
         elif entry in gallery_conf['api_entries']['method']:
             return 'meth'
         else:

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -826,7 +826,7 @@ def write_api_entry_usage(app, docname, source):
 
     example_files = set.union(
         *[gallery_conf['api_entries'][obj_type]
-          for obj_type in ('class', 'method', 'function')
+          for obj_type in ('class', 'function')
           if obj_type in gallery_conf['api_entries']])
 
     if len(example_files) == 0:
@@ -835,6 +835,8 @@ def write_api_entry_usage(app, docname, source):
     def get_entry_type(entry):
         if entry in gallery_conf['api_entries']['class']:
             return 'class'
+        # TO DO: add support for method when examples that they are
+        # used in are properly traced
         elif entry in gallery_conf['api_entries']['method']:
             return 'meth'
         else:


### PR DESCRIPTION
I wrote a quick function to just basically grep the example files for matches with the functions/classes/methods. There was an issue with methods in particular not being found because they are called from a variable name e.g. (`brain = mne.viz.Brain(...)` `brain.add_skull(...)`) how the example matching is done currently. Searching for just the function/class/method e.g. `add_skull` could be a false-positive because other modules have the same functions/classes/methods. The ubiquitous `fit(...)` comes to mind as something that would cause the method in this PR real trouble with false-positives. However, if you've seen one `fit`, you've kind of seen them all so perhaps for `sg_api_usage`, we could take a less-conservative approach to match methods like in this PR. It actually gives a very rosy account of the MNE example coverage with only 176/644 API entries not in examples (relative to the 204/644 for the current method using a pretty extensive `api_usage_ignore` docstring which this method would not need). What do you think @larsoner?

[test_api_entries.pdf](https://github.com/sphinx-gallery/sphinx-gallery/files/9436151/test_api_entries.pdf)