### PR TITLE
[MAINT, MRG] Add unused option for API usage, set as default

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1869,20 +1869,21 @@ actual section / folder structure.
 Showing API Usage
 =================
 
-Optionally, graphs can be made of the usage of each API entry in examples,
-grouped by module. In large projects, there are many modules so this is
-set to ``False`` by default. Setting ``show_api_usage`` to ``True``
-will make one graph per module showing all of the API entries connected to
-the example that they are used in. This could be helpful for making a map
-of which examples to look at if you want to learn about a particular
-module. Note: documentation and graphs of which API examples are unused
-will always be made, only the documentation and graphs of which
-examples each API entry are used in is controlled by this configuration
-parameter. ``graphviz`` is required for making the unused and used API
-entry graphs. See the
+Graphs and documentation of both unused API entries and the examples that
+each API entry is used in are generated in the sphinx output directory under
+``sg_api_usage.html``. See the
 `Sphinx-Gallery API usage documentation and graphs <sg_api_usage.html>`_
-for example. This report can be found in the sphinx output directory under
-``sg_api_usage.html``.
+for example. In large projects, there are many modules and, since a graph
+of API usage is generated for each module, this can use a lot of resources
+so ``show_api_usage`` is set to ``'unused'`` by default. The unused API
+entries are all shown in one graph so this scales much better for large
+projects. Setting ``show_api_usage`` to ``True`` will make one graph per
+module showing all of the API entries connected to the example that they
+are used in. This could be helpful for making a map of which examples to
+look at if you want to learn about a particular module. Setting
+``show_api_usage`` to ``False`` will not make any graphs or documentation
+about API usage. Note, ``graphviz`` is required for making the unused and
+used API entry graphs. 
 
 .. _api_usage_ignore:
 

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -119,7 +119,8 @@ def test_bad_api():
     with pytest.raises(ConfigError, match='.*must be str.*'):
         _complete_gallery_conf(sphinx_gallery_conf, '', True, False)
     sphinx_gallery_conf = dict(show_api_usage='foo')
-    with pytest.raises(ConfigError, match='.*must be bool.*'):
+    with pytest.raises(ConfigError,
+                       match='.*must be True, False or "unused".*'):
         _complete_gallery_conf(sphinx_gallery_conf, '', True, False)
 
 


### PR DESCRIPTION
This allows turning off of the API usage altogether, hopefully fixing the last issue with this new feature https://github.com/mne-tools/mne-python/pull/11132.

I looked into the other point, about suppressing the warnings but it looks like from the Sphinx-Gallery documentation that that has to be in the `conf.py` file, specific to that project so as far as I know it can't be done in an extension, unfortunately I think it just has to be done per-project.

cc @larsoner