### PR TITLE
FIX: role names

### DIFF
--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -208,10 +208,10 @@ def _get_short_module_name(module_name, obj_name):
 
 # keep in synch w/ configuration.rst "Add mini-galleries for API documentation"
 _regex = re.compile(r':(?:'
-                    r'func(?:tion)?|'
-                    r'meth(?:od)?|'
-                    r'attr(?:ibute)?|'
-                    r'obj(?:ect)?|'
+                    r'func|'
+                    r'meth|'
+                    r'attr|'
+                    r'obj|'
                     r'class):`~?(\S*)`'
                     )
 


### PR DESCRIPTION
The regex in `identify_names` also covered fully spelled out role names (`object` instead of `obj` etc.) which are however not recognized by sphinx.  

The [documentation](https://sphinx-gallery.github.io/stable/configuration.html#add-mini-galleries-for-api-documentation) lists only the correct short forms.

Closes #1008.