### PR TITLE
DOC: fix 'Who uses Sphinx-Gallery' list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,25 +23,30 @@ Who uses Sphinx-Gallery
 =======================
 
 * `Sphinx-Gallery <https://sphinx-gallery.github.io/stable/auto_examples/index.html>`_
-* `Scikit-learn <http://scikit-learn.org/dev/auto_examples/index.html>`_
-* `Nilearn <https://nilearn.github.io/auto_examples/index.html>`_
-* `MNE-python <https://www.martinos.org/mne/stable/auto_examples/index.html>`_
+
+.. projects_list_start
+
+* `Scikit-learn <http://scikit-learn.org/stable/auto_examples/index.html>`_
+* `Nilearn <https://nilearn.github.io/stable/auto_examples/index.html>`_
+* `MNE-python <https://mne.tools/stable/auto_examples/index.html>`_
 * `PyStruct <https://pystruct.github.io/auto_examples/index.html>`_
-* `GIMLi <http://www.pygimli.org/_examples_auto/index.html>`_
-* `Nestle <https://kbarbary.github.io/nestle/examples/index.html>`_
+* `GIMLi <https://www.pygimli.org/_examples_auto/index.html>`_
+* `Nestle <http://kylebarbary.com/nestle/examples/index.html>`_
 * `pyRiemann <https://pyriemann.readthedocs.io/en/latest/index.html>`_
-* `scikit-image <http://scikit-image.org/docs/dev/auto_examples/>`_
-* `Astropy <http://docs.astropy.org/en/stable/generated/examples/index.html>`_
-* `SunPy <http://docs.sunpy.org/en/stable/generated/gallery/index.html>`_
+* `scikit-image <https://scikit-image.org/docs/dev/auto_examples/>`_
+* `Astropy <https://docs.astropy.org/en/stable/generated/examples/index.html>`_
+* `SunPy <https://docs.sunpy.org/en/stable/generated/gallery/index.html>`_
 * `PySurfer <https://pysurfer.github.io/>`_
-* `Matplotlib <https://matplotlib.org/index.html>`_ `Examples <https://matplotlib.org/gallery/index.html>`_ and `Tutorials  <https://matplotlib.org/tutorials/index.html>`__
-* `PyTorch tutorials <http://pytorch.org/tutorials>`_
-* `Cartopy <http://scitools.org.uk/cartopy/docs/latest/gallery/>`_
+* `Matplotlib <https://matplotlib.org/stable/index.html>`_:
+  `Examples <https://matplotlib.org/stable/gallery/index.html>`_ and
+  `Tutorials <https://matplotlib.org/stable/tutorials/index.html>`_
+* `PyTorch tutorials <https://pytorch.org/tutorials>`_
+* `Cartopy <https://scitools.org.uk/cartopy/docs/latest/gallery/>`_
 * `PyVista <https://docs.pyvista.org/examples/>`_
-* `SimPEG <http://docs.simpeg.xyz/content/examples/>`_
+* `SimPEG <https://docs.simpeg.xyz/content/examples/>`_
 * `PlasmaPy <https://docs.plasmapy.org/en/latest/examples.html>`_
-* `Fury <http://fury.gl/latest/auto_examples/index.html>`_
-* `NetworkX <https://networkx.github.io/documentation/stable/auto_examples/index.html>`_
+* `Fury <https://fury.gl/latest/auto_examples/index.html>`_
+* `NetworkX <https://networkx.org/documentation/stable/auto_examples/index.html>`_
 * `Optuna <https://optuna.readthedocs.io/en/stable/tutorial/index.html>`_
 * `Auto-sklearn <https://automl.github.io/auto-sklearn/master/examples/index.html>`_
 * `OpenML-Python <https://openml.github.io/openml-python/main/examples/index.html>`_
@@ -51,6 +56,9 @@ Who uses Sphinx-Gallery
 * `Apache TVM <https://tvm.apache.org/docs/tutorial/index.html>`_
 * `Tonic <https://tonic.readthedocs.io/en/latest/auto_examples/index.html>`_
 * `Radis <https://radis.readthedocs.io/en/latest/auto_examples/index.html>`_
+
+.. projects_list_end
+
 
 .. installation-begin-content
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -532,9 +532,9 @@ Auto-documenting your API with links to examples
 
 The previous feature can be automated for all your modules combining
 it with the standard sphinx extensions `autodoc
-<http://sphinx-doc.org/ext/autodoc.html>`_ and `autosummary
-<http://sphinx-doc.org/ext/autosummary.html>`_. First enable them in your
-``conf.py`` extensions list::
+<https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html>`_ and
+`autosummary <https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html>`_.
+First enable them in your ``conf.py`` extensions list::
 
     import sphinx_gallery
     extensions = [
@@ -547,10 +547,10 @@ it with the standard sphinx extensions `autodoc
     # generate autosummary even if no references
     autosummary_generate = True
 
-`autodoc <http://sphinx-doc.org/ext/autodoc.html>`_ and `autosummary
-<http://sphinx-doc.org/ext/autosummary.html>`_ are very powerful
-extensions, please read about them. In this example we'll explain how
-the :ref:`sphx_glr_api_reference` is automatically generated. The
+`autodoc <https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html>`_ and
+`autosummary <https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html>`_
+are very powerful extensions, please read about them. In this example we'll
+explain how the :ref:`sphx_glr_api_reference` is automatically generated. The
 documentation is done at the module level. We first start with the
 ``reference.rst`` file
 
@@ -1019,7 +1019,7 @@ If you host your documentation on a GitHub repository, it is possible to
 auto-generate a Binder link for each notebook. Clicking this link will
 take users to a live version of the Jupyter notebook where they may
 run the code interactively. For more information see the `Binder documentation
-<https://docs.mybinder.org>`__.
+<https://mybinder.readthedocs.io/en/latest/>`__.
 
 .. warning::
 
@@ -1084,7 +1084,7 @@ dependencies (type: list)
   ``requirements.txt`` file. These will be copied into a folder  called
   ``binder/`` in your built documentation folder. For a list of all the possible
   dependency files you can use, see `the Binder configuration documentation
-  <https://mybinder.readthedocs.io/en/latest/config_files.html#config-files>`_.
+  <https://mybinder.readthedocs.io/en/latest/using/config_files.html>`_.
 filepath_prefix (type: string | None, default: ``None``)
   A prefix to append to the filepath in the Binder links. You should use this if
   you will store your built documentation in a sub-folder of a repository,
@@ -1112,8 +1112,9 @@ Binder links will point to these notebooks.
    independently build your documentation and host it on a GitHub branch
    as well as building it with readthedocs.
 
-See the Sphinx-Gallery `Sphinx configuration file <https://github.com/sphinx-gallery/sphinx-gallery/blob/master/doc/conf.py>`_
-for an example that uses the `public Binder server <http://mybinder.org>`_.
+See the Sphinx-Gallery `Sphinx configuration file
+<https://github.com/sphinx-gallery/sphinx-gallery/blob/master/doc/conf.py>`_
+for an example that uses the `public Binder server <https://mybinder.org>`_.
 
 .. _promote_jupyter_magic:
 
@@ -1802,7 +1803,7 @@ method which would thus be captured. You can prevent this by:
 The unwanted string output will not occur if ``'capture_repr'`` is an empty
 tuple or does not contain ``__repr__`` or ``__str__``.
 
-.. _regular expressions: https://docs.python.org/library/re.html
+.. _regular expressions: https://docs.python.org/3/library/re.html
 
 Prevent capture of certain classes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -18,7 +18,7 @@ using the Sphinx extension Sphinx-Gallery, which will do the following:
   download.
 * Create a gallery with thumbnails for each of these examples
   (such as `the one that scikit-learn
-  <http://scikit-learn.org/stable/auto_examples/index.html>`_ uses).
+  <https://scikit-learn.org/stable/auto_examples/index.html>`_ uses).
 
 A `template repository <https://github.com/sphinx-gallery/sample-project>`_,
 with sample example galleries and basic configurations is also available to
@@ -61,7 +61,7 @@ Let's say your Python project has the following structure:
 * ``doc`` is the Sphinx 'source directory'. It contains the Sphinx base
   configuration files. Default versions of these base files can obtained from
   executing ``sphinx-quickstart`` (more details at `Sphinx-quickstart
-  <http://www.sphinx-doc.org/en/master/usage/quickstart.html>`_). Sphinx
+  <https://www.sphinx-doc.org/en/master/usage/quickstart.html>`_). Sphinx
   ``.rst`` source files are generally also placed here (none included in
   our example directory structure above) but these are
   unassociated with Sphinx-Gallery functions.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,7 +8,7 @@ Welcome to Sphinx-Gallery's documentation!
 .. image:: https://circleci.com/gh/sphinx-gallery/sphinx-gallery.svg?style=shield
     :target: https://circleci.com/gh/sphinx-gallery/sphinx-gallery
 
-``Sphinx-Gallery`` is a `Sphinx <http://sphinx-doc.org/>`_ extension that builds an HTML
+``Sphinx-Gallery`` is a `Sphinx <https://www.sphinx-doc.org/en/master/>`_ extension that builds an HTML
 gallery of examples from any set of Python scripts.
 
 .. image:: _static/demo.png

--- a/doc/maintainers.rst
+++ b/doc/maintainers.rst
@@ -39,7 +39,7 @@ Prepare for release
 1. Update ``CHANGES.rst``
 
     1. Use `github_changelog_generator
-       <https://github.com/skywinder/github-changelog-generator#installation>`_ to
+       <https://github.com/github-changelog-generator/github-changelog-generator#installation>`_ to
        gather all merged pull requests and closed issues during the development
        cycle. You will likely need to `generate a Github token <https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token>`_
        as Github only allows 50 unauthenticated requests per hour. In the

--- a/doc/projects_list.rst
+++ b/doc/projects_list.rst
@@ -5,29 +5,7 @@ Who uses Sphinx-Gallery
 Here is a list of projects using `sphinx-gallery`.
 
 * :ref:`Sphinx-Gallery <examples-index>`
-* :doc:`Scikit-learn <sklearn:auto_examples/index>`
-* `Nilearn <https://nilearn.github.io/auto_examples/index.html>`_
-* `MNE-python <https://www.martinos.org/mne/stable/auto_examples/index.html>`_
-* `PyStruct <https://pystruct.github.io/auto_examples/index.html>`_
-* `GIMLi <http://www.pygimli.org/_examples_auto/index.html>`_
-* `Nestle <https://kbarbary.github.io/nestle/examples/index.html>`_
-* `pyRiemann <https://pyriemann.readthedocs.io/en/latest/index.html>`_
-* `scikit-image <http://scikit-image.org/docs/dev/auto_examples/>`_
-* `Astropy <http://docs.astropy.org/en/stable/generated/examples/index.html>`_
-* `SunPy <http://docs.sunpy.org/en/stable/generated/gallery/index.html>`_
-* `PySurfer <https://pysurfer.github.io/>`_
-* :doc:`Matplotlib <matplotlib:index>`: :doc:`Examples <matplotlib:gallery/index>` and :doc:`Tutorials <matplotlib:tutorials/index>`
-* `PyTorch tutorials <http://pytorch.org/tutorials>`_
-* `Cartopy <http://scitools.org.uk/cartopy/docs/latest/gallery/>`_
-* `PyVista <https://docs.pyvista.org/examples/>`_
-* `SimPEG <http://docs.simpeg.xyz/content/examples/>`_
-* `PlasmaPy <https://docs.plasmapy.org/en/latest/examples.html>`_
-* `Fury <http://fury.gl/latest/auto_examples/index.html>`_
-* `NetworkX <https://networkx.github.io/documentation/stable/auto_examples/index.html>`_
-* `Optuna <https://optuna.readthedocs.io/en/stable/tutorial/index.html>`_
-* `Auto-sklearn <https://automl.github.io/auto-sklearn/master/examples/index.html>`_
-* `OpenML-Python <https://openml.github.io/openml-python/main/examples/index.html>`_
-* `TorchIO <https://torchio.readthedocs.io/auto_examples/index.html>`_
-* `Neuraxle <https://www.neuraxle.org/stable/examples/index.html>`_
-* `Biotite <https://www.biotite-python.org/examples/gallery/index.html>`_
-* `Radis <https://radis.readthedocs.io/en/latest/auto_examples/index.html>`_
+
+.. include:: ../README.rst
+   :start-after: projects_list_start
+   :end-before: projects_list_end

--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -80,15 +80,15 @@ The ``#%%`` and ``# %%`` syntax is consistent with the 'code block' (or
 'code cell') separator syntax in `Visual Studio Code Python extension
 <https://code.visualstudio.com/docs/python/jupyter-support-py#_jupyter-code-cells>`_,
 `Visual Studio Python Tools
-<https://docs.microsoft.com/en-us/visualstudio/python/python-interactive-repl-in-visual-studio?view=vs-2019#work-with-code-cells>`_,
+<https://learn.microsoft.com/en-us/visualstudio/python/python-interactive-repl-in-visual-studio?view=vs-2019#work-with-code-cells>`_,
 `Jupytext
 <https://jupytext.readthedocs.io/en/latest/formats.html#the-percent-format>`_,
 `Pycharm Professional
 <https://www.jetbrains.com/help/pycharm/running-jupyter-notebook-cells.html>`_,
 `Hydrogen plugin (for Atom)
-<https://nteract.gitbooks.io/hydrogen/docs/Usage/Cells.html#example-definitions>`_
+<https://nteract.gitbooks.io/hydrogen/content/docs/Usage/Cells.html#example-definitions>`_
 and `Spyder
-<https://docs.spyder-ide.org/editor.html#defining-code-cells>`_.
+<https://docs.spyder-ide.org/current/panes/editor.html#defining-code-cells>`_.
 Note that although the documentation of these editors/IDEs
 may only mention one of ``#%%`` or ``# %%``, in practice both
 work. With these editors/IDEs, ``#%%`` or
@@ -147,4 +147,4 @@ so examples written in plain RST files are not supported.
 If you're looking to generate hyperlinks for functions (linking to their
 corresponding online documentation) in code blocks of ordinary RST
 documentation, you might find
-`sphinx-codeautolink <https://sphinx-codeautolink.rtfd.io>`_ helpful.
+`sphinx-codeautolink <https://sphinx-codeautolink.readthedocs.io/en/latest/>`_ helpful.


### PR DESCRIPTION
the current [link](https://nilearn.github.io/auto_examples/index.html) in https://sphinx-gallery.github.io/stable/projects_list.html results in 404.

- prevent the project lists in README.rst and projects_list.rst from
  becoming out of sync by putting the projects list in a text file
  to include in both rst files (there were already 2 projects more in
  README.rst than in projects_list.rst)
- fix broken and some permanently redirected links reported by linkcheck

Github markup doesn't allow including files into README.rst, so we must
include from README.rst. Github doesn't process :ref: or :doc: roles
(they are shown literally) so we need to handle the Sphinx Gallery link
separately. The intersphinx links were replaced by ordinary links as
it's very unlikely that these targets would be changed without a
redirect in place.