### PR TITLE
MNT: Fix required sphinx version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ Sphinx-Gallery will not manage its dependencies when installing, thus
 you are required to install them manually. Our minimal dependency
 is:
 
-* Sphinx >= 1.8.3
+* Sphinx >= 3
 
 Sphinx-Gallery has also support for packages like:
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=3
+sphinx >= 3, != 5.2.1
 sphinx_rtd_theme
 pytest
 pytest-coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+# update README.rst when changing something here
 sphinx>=3


### PR DESCRIPTION
- docs don't build with sphinx 5.2.1
- fix minimum required sphinx version in README.rst acc. to a6317fe7

Closes #1017. 

Not sure if https://github.com/sphinx-gallery/sphinx-gallery/blob/master/azure-pipelines.yml and https://github.com/sphinx-gallery/sphinx-gallery/blob/master/continuous_integration/azure/install.sh need to be updated too?