### PR TITLE
MNT: Fix erroneous commit c6ed4e

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-sphinx >= 3, != 5.2.1
+sphinx >= 3, != 5.2.0
 sphinx_rtd_theme
 pytest
 pytest-coverage


### PR DESCRIPTION
I'm terribly sorry, but I made a mistake in  #1019: it must read _"...don't build with sphinx 5.2.0"_. Sphinx 5.2.1 fixes the issue, so in requirements it must be of course `sphinx >= 3, != 5.2.0` instead of `!= 5.2.1`.