### PR TITLE
MAINT: Remove lingering ref

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1106,6 +1106,9 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
     _write_backreferences(backrefs, seen_backrefs, gallery_conf, target_dir,
                           fname, intro, title)
 
+    # This can help with garbage collection in some instances
+    if global_variables is not None and '___' in global_variables:
+        del global_variables['___']
     del script_vars, global_variables  # don't keep these during reset
     if executable and gallery_conf['reset_modules_order'] in ['after', 'both']:
         clean_modules(gallery_conf, fname, 'after')


### PR DESCRIPTION
In MNE-Python in our `resetter` we garbage collect and assert that no instances of some plotting classes remain anymore. Without this change, sometimes they would linger. With this change, they can be GC'ed correctly.

It's a bit of a mystery to me why this is the case, but it must create some bad circular reference that `gc` can't resolve somehow...