### PR TITLE
Fix "`subsection_index_toctree` referenced before assignment"

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -562,17 +562,18 @@ def generate_gallery_rst(app):
 
                 fhindex.write(subsection_index_content)
 
-                # Write subsection toctree in main file
-                # only if nested_sections is False or None
-                if (not gallery_conf["nested_sections"] and
-                        len(subsection_toctree_filenames) > 0):
-                    subsection_index_toctree = """
+                # Write subsection toctree in main file only if
+                # nested_sections is False or None, and
+                # toctree filenames were generated for the subsection.
+                if not gallery_conf["nested_sections"]:
+                    if len(subsection_toctree_filenames) > 0:
+                        subsection_index_toctree = """
 .. toctree::
    :hidden:
 
    %s\n
 """ % "\n   ".join(subsection_toctree_filenames)
-                    fhindex.write(subsection_index_toctree)
+                        fhindex.write(subsection_index_toctree)
                 # Otherwise, a new index.rst.new file should
                 # have been created and it needs to be parsed
                 else:

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -564,9 +564,9 @@ def generate_gallery_rst(app):
 
                 # Write subsection toctree in main file
                 # only if nested_sections is False or None
-                if not gallery_conf["nested_sections"]:
-                    if len(subsection_toctree_filenames) > 0:
-                        subsection_index_toctree = """
+                if (not gallery_conf["nested_sections"] and
+                        len(subsection_toctree_filenames) > 0):
+                    subsection_index_toctree = """
 .. toctree::
    :hidden:
 


### PR DESCRIPTION
Produced with `'nested_sections': False`:

```
Handler <function generate_gallery_rst at 0x0000021152A7A440> for event 'builder-inited' threw an exception 
(exception: local variable 'subsection_index_toctree' referenced before assignment)
```

Unsure if this reflects intent, feel free to edit.