### PR TITLE
Allow 2 decimal places in srcset

### DIFF
--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -485,7 +485,7 @@ def _get_srcset_st(sources_dir, hinames):
         if k == 0:
             srcst += ', '
         else:
-            srcst += f' {k:1.1f}x, '
+            srcst += f' {k:1.2f}x, '
     if srcst[-2:] == ', ':
         srcst = srcst[:-2]
     srcst += ''


### PR DESCRIPTION
e.g. `srcset="img.png 1.25x`. Browsers on my system default to zooming in by 80%, which is only undone by 1.25x.