### PR TITLE
Allow 2 decimal places in srcset

### DIFF
--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -216,7 +216,7 @@ def visit_imgsg_html(self, node):
         if mult == 0:
             srcsetst += ', '
         else:
-            srcsetst += f' {mult:1.1f}x, '
+            srcsetst += f' {mult:1.2f}x, '
     # trim trailing comma and space...
     srcsetst = srcsetst[:-2]
 

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -125,14 +125,14 @@ class ImageSg(images.Image):
         .. image-sg:: /plot_types/basic/images/sphx_glr_bar_001.png
             :alt: bar
             :srcset: /plot_types/basic/images/sphx_glr_bar_001.png,
-                     /plot_types/basic/images/sphx_glr_bar_001_2_0x.png 2.0x
+                     /plot_types/basic/images/sphx_glr_bar_001_2_00x.png 2.00x
             :class: sphx-glr-single-img
 
     The resulting html is::
 
         <img src="sphx_glr_bar_001_hidpi.png"
             srcset="_images/sphx_glr_bar_001.png,
-                    _images/sphx_glr_bar_001_2_0x.png 2x",
+                    _images/sphx_glr_bar_001_2_00x.png 2x",
             alt="bar"
             class="sphx-glr-single-img" />
 

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -485,7 +485,7 @@ def _get_srcset_st(sources_dir, hinames):
         if k == 0:
             srcst += ', '
         else:
-            srcst += f' {k:1.1f}x, '
+            srcst += f' {k:1.2f}x, '
     if srcst[-2:] == ', ':
         srcst = srcst[:-2]
     srcst += ''

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -178,7 +178,7 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
             # save other srcset paths, keyed by multiplication factor:
             for mult in srcset_mult_facs:
                 if not (mult == 1):
-                    multst = f'{mult}'.replace('.', '_')
+                    multst = f'{mult:.2f}'.replace('.', '_')
                     name = f"{image_path.stem}_{multst}x{image_path.suffix}"
                     hipath = image_path.parent / PurePosixPath(name)
                     hikwargs = these_kwargs.copy()

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -409,7 +409,7 @@ def figure_rst(figure_list, sources_dir, fig_titles='', srcsetpaths=None):
         empty, then srcset field is populated with the figure path.
         (see ``image_srcset`` configuration option).  Otherwise,
         each dict is of the form
-        {0: /images/image.png, 2.0: /images/image_2_0x.png}
+        {0: /images/image.png, 2.0: /images/image_2_00x.png}
         where the key is the multiplication factor and the contents
         the path to the image created above.
 
@@ -421,7 +421,7 @@ def figure_rst(figure_list, sources_dir, fig_titles='', srcsetpaths=None):
     The rst code will have a custom ``image-sg`` directive that allows
     multiple resolution images to be served e.g.:
     ``:srcset: /plot_types/imgs/img_001.png,
-      /plot_types/imgs/img_2_0x.png 2.0x``
+      /plot_types/imgs/img_2_00x.png 2.00x``
 
     """
 
@@ -472,10 +472,10 @@ def _get_srcset_st(sources_dir, hinames):
     ie. sources_dir might be /home/sample-proj/source,
     hinames posix paths to
     0: /home/sample-proj/source/plot_types/images/img1.png,
-    2.0: /home/sample-proj/source/plot_types/images/img1_2_0x.png,
+    2.0: /home/sample-proj/source/plot_types/images/img1_2_00x.png,
     The result will be:
     '/plot_types/basic/images/sphx_glr_pie_001.png,
-    /plot_types/basic/images/sphx_glr_pie_001_2_0x.png 2.0x'
+    /plot_types/basic/images/sphx_glr_pie_001_2_00x.png 2.00x'
     """
     srcst = ''
     for k in hinames.keys():

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -275,11 +275,11 @@ def test_image_formats(sphinx_app):
             assert op.isfile(file_fname), file_fname
             want_html = 'src="%s"' % (img_fname0,)
             assert want_html in html
-            img_fname2 = ('../_images/sphx_glr_%s_%03d_2_0x.%s' %
+            img_fname2 = ('../_images/sphx_glr_%s_%03d_2_00x.%s' %
                           (ex, num, ext))
             file_fname2 = op.join(generated_examples_dir, img_fname2)
-            want_html = 'srcset="%s, %s 2.0x"' % (img_fname0, img_fname2)
-            if ext in ('png', 'jpg', 'svg'):  # check 2.0x (tests directive)
+            want_html = 'srcset="%s, %s 2.00x"' % (img_fname0, img_fname2)
+            if ext in ('png', 'jpg', 'svg'):  # check 2.00x (tests directive)
                 assert op.isfile(file_fname2), file_fname2
                 assert want_html in html
 

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -80,11 +80,11 @@ def test_save_matplotlib_figures_hidpi(gallery_conf):
 
     fname = f'/image1.{ext}'
     assert fname in image_rst
-    assert f'/image1_2_0x.{ext} 2.0x' in image_rst
+    assert f'/image1_2_00x.{ext} 2.00x' in image_rst
 
     assert len(image_path_iterator) == 1
     fname = gallery_conf['gallery_dir'] + fname
-    fnamehi = gallery_conf['gallery_dir'] + f'/image1_2_0x.{ext}'
+    fnamehi = gallery_conf['gallery_dir'] + f'/image1_2_00x.{ext}'
 
     assert os.path.isfile(fname)
     assert os.path.isfile(fnamehi)
@@ -103,7 +103,7 @@ def test_save_matplotlib_figures_hidpi(gallery_conf):
 
         fname = gallery_conf['gallery_dir'] + fname
         assert os.path.isfile(fname)
-        fname = f'/image{ii}_2_0x.{ext}'
+        fname = f'/image{ii}_2_00x.{ext}'
         assert fname in image_rst
         fname = gallery_conf['gallery_dir'] + fname
         assert os.path.isfile(fname)
@@ -265,17 +265,17 @@ def test_figure_rst(ext):
 def test_figure_rst_srcset(ext):
     """Testing rst of images"""
     figure_list = ['sphx_glr_plot_1.' + ext]
-    hipaths = [{0: 'sphx_glr_plot_1.png', 2.0: 'sphx_glr_plot_1_2_0.png'}]
+    hipaths = [{0: 'sphx_glr_plot_1.png', 2.0: 'sphx_glr_plot_1_2_00.png'}]
     image_rst = figure_rst(figure_list, '.', srcsetpaths=hipaths)
     single_image = f"""
 .. image-sg:: /sphx_glr_plot_1.{ext}
    :alt: pl
-   :srcset: /sphx_glr_plot_1.{ext}, /sphx_glr_plot_1_2_0.{ext} 2.0x
+   :srcset: /sphx_glr_plot_1.{ext}, /sphx_glr_plot_1_2_00.{ext} 2.00x
    :class: sphx-glr-single-img
 """
     assert image_rst == single_image
 
-    hipaths += [{0: 'second.png', 2.0: 'second_2_0.png'}]
+    hipaths += [{0: 'second.png', 2.0: 'second_2_00.png'}]
     image_rst = figure_rst(figure_list + ['second.' + ext], '.',
                            srcsetpaths=hipaths+[])
 
@@ -287,14 +287,14 @@ def test_figure_rst_srcset(ext):
 
       .. image-sg:: /sphx_glr_plot_1.{ext}
           :alt: pl
-          :srcset: /sphx_glr_plot_1.png, /sphx_glr_plot_1_2_0.png 2.0x
+          :srcset: /sphx_glr_plot_1.png, /sphx_glr_plot_1_2_00.png 2.00x
           :class: sphx-glr-multi-img
 
     *
 
       .. image-sg:: /second.{ext}
           :alt: pl
-          :srcset: /second.{ext}, /second_2_0.{ext} 2.0x
+          :srcset: /second.{ext}, /second_2_00.{ext} 2.00x
           :class: sphx-glr-multi-img
 """
     assert image_rst == image_list_rst


### PR DESCRIPTION
e.g. `srcset="img.png 1.25x`. Browsers on my system default to zooming in by 125%, which is only undone by 1.25x. Changes:

  1. `2.0x` -> `2.00x` everywhere
  2. `2_0x` -> `2_00x` everywhere