### PR TITLE
Use descriptive link text for example page header

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1128,7 +1128,7 @@ EXAMPLE_HEADER = """
     .. note::
         :class: sphx-glr-download-link-note
 
-        Click :ref:`here <sphx_glr_download_{1}>`
+        :ref:`Go to the end <sphx_glr_download_{1}>`
         to download the full example code{2}
 
 .. rst-class:: sphx-glr-example-title


### PR DESCRIPTION
Instead of using "here" as link text, tell the user what will happen if they click the link.

For example in the scikit-learn documentation the header looks like this:
![image](https://user-images.githubusercontent.com/1448859/196475310-a01ac26f-fb93-47be-9e0b-97b6894bbbd2.png)

There are two things that I think this PR improves:
1. Tell the user what will happen when they click the link. When I haven't looked at the example gallery for a while and come back as a "new user" (no memory of the past) I read the header and think "ok, so clicking will start a download, I don't want that. But then how do I get to the binder? It can't be downloading the binder. Weird. Well, let's start scrolling". Instead of realising what the link actually does, which is take you to the bottom of the page.
1. it uses the link text to tell the user something, compared to "click here". I think these days people know that they should click things that look like a link, if they want to follow the link. This means we can use the link text to tell the reader something informative.