### PR TITLE
Fixed a bug where backslashes in paths could show up in RST files

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -540,7 +540,7 @@ def generate_gallery_rst(app):
                 subsection_index_files.append(
                     '/'.join([
                         '', gallery_dir, subsection, 'index.rst'
-                    ])
+                    ]).replace(os.sep, '/')  # forward slashes needed inside rst
                 )
 
                 (

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -540,7 +540,7 @@ def generate_gallery_rst(app):
                 subsection_index_files.append(
                     '/'.join([
                         '', gallery_dir, subsection, 'index.rst'
-                    ]).replace(os.sep, '/')  # forward slashes needed inside rst
+                    ]).replace(os.sep, '/')  # fwd slashes needed inside rst
                 )
 
                 (


### PR DESCRIPTION
When the gallery directory path has an OS path separator in it, the separators need to be sanitized (on Windows) to be all forward slashes before the path is inserted into RST files.  This PR fixes a missing sanitization.

For comparison, here is another place in the codebase where the sanitization is performed:
https://github.com/sphinx-gallery/sphinx-gallery/blob/15ec1f945f21a8bf38645ffe6aab6e92f2f90170/sphinx_gallery/backreferences.py#L299-L300