### PR TITLE
Add support for include directive in notebook.py

### DIFF
--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -118,6 +118,17 @@ def rst2md(text, gallery_conf, target_dir, heading_levels):
         Note that ``over_char`` is `None` when only underline is present.
     """
 
+    include_re = re.compile(r"^([ \t]*)\.\. include::\s*(.+)\n", flags=re.M)
+
+    def load_include(match):
+        full_path = os.path.join(target_dir, match.group(2))
+        with open(full_path) as file:
+            lines = file.read()
+        indented = textwrap.indent(lines, match.group(1))
+        return indented
+
+    text = re.sub(include_re, load_include, text)
+
     # Characters recommended for use with headings
     # https://docutils.readthedocs.io/en/sphinx-docs/user/rst/quickstart.html#sections
     adornment_characters = "=`:.'\"~^_*+#<>-"


### PR DESCRIPTION
reStructuredText supports [an include directive](https://docutils.sourceforge.io/docs/ref/rst/directives.html#include) that can be used to insert reStructuredText data from another file. This behavior is also [supported by sphinx](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html). This pull request adds support for this directive to `sphinx-gallery`!

An example helps to demonstrate the syntax. Suppose `include.txt` contains the text `Data from included file!\n`. We can use it in an `rst` document like this:

```rst
Include blocks can be used without indentation. They may
contain additional directives inside themselves.

.. include:: inclusion.txt

Back in the main document.

    If an include directive is indented, this indent will
    be preserved.

    .. include:: inclusion.txt

```

The document will then be templated as follows:


```rst
Include blocks can be used without indentation. They may
contain additional directives inside themselves.

Data from included file!

Back in the main document.

    If an include directive is indented, this indent will
    be preserved.

    Data from included file!

```

@larsoner please take a look!