### PR TITLE
BUG: Remove ignore blocks when remove_config_comments=True

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1046,16 +1046,18 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
                 if not os.path.isfile(path):
                     copyfile(stock_img, path)
 
+    # Ignore blocks must be processed before the
+    # remaining config comments are removed.
+    script_blocks = [
+        (label, remove_ignore_blocks(content), line_number)
+        for label, content, line_number in script_blocks
+    ]
+
     if gallery_conf['remove_config_comments']:
         script_blocks = [
             (label, remove_config_comments(content), line_number)
             for label, content, line_number in script_blocks
         ]
-
-    script_blocks = [
-        (label, remove_ignore_blocks(content), line_number)
-        for label, content, line_number in script_blocks
-    ]
 
     # Remove final empty block, which can occur after config comments
     # are removed

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -461,8 +461,10 @@ def test_remove_config_comments(gallery_conf, req_pil):
     assert '# sphinx_gallery_defer_figures' not in rst
 
 
-def test_remove_ignore_blocks(gallery_conf, req_pil):
+@pytest.mark.parametrize("remove_config_comments", [True, False])
+def test_remove_ignore_blocks(gallery_conf, req_pil, remove_config_comments):
     """Test removal of ignore blocks."""
+    gallery_conf['remove_config_comments'] = remove_config_comments
     rst = _generate_rst(gallery_conf, 'test.py', CONTENT)
     assert 'pass # Will be run but not rendered' in CONTENT
     assert 'pass # Will be run but not rendered' not in rst


### PR DESCRIPTION
sphinx-gallery currently supports inline config options (e.g. `# sphinx_gallery_line_numbers = True`) as well as block ignore directives (i.e. `# sphinx_gallery_start_ignore` followed by `# sphinx_gallery_end_ignore`). By default, inline config options are left in place and included in the built documentation - but they can be removed by setting `"remove_config_comments": True`.

Currently, if `remove_config_comments = True`, inline config options are removed **before** block ignores are processed. This causes a bug. Suppose we have the following in our documentation:

```python
# sphinx_gallery_requires_cuda = True
# sphinx_gallery_start_ignore
from tvm import testing

testing.utils.install_request_hook(depth=3)
# sphinx_gallery_end_ignore
```

If `remove_config_comments = False`, this will be correctly processed into:

```python
# sphinx_gallery_requires_cuda = True
```

But if `remove_config_comments = True`, it instead turns into:

```python
from tvm import testing

testing.utils.install_request_hook(depth=3)
```

This pull request fixes this bug by changing block ignores to be processed **before** config comments are removed. It also adds a regression test for this issue.

cc @larsoner 
