### PR TITLE
Fix broken links when using dirhtml builder

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -27,7 +27,7 @@ help you get started.
 .. note::
    Working `sphinx
    builders <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#options>`_
-   for sphinx_gallery include `html` and `latex`.
+   for sphinx_gallery include `html`, `dirhtml` and `latex`.
 
 
 .. _set_up_your_project:

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -25,11 +25,9 @@ with sample example galleries and basic configurations is also available to
 help you get started.
 
 .. note::
-   Working `sphinx 
-   builders <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#options>`_ 
-   for sphinx_gallery include `html` and `latex`. Support for other builders
-   is not guaranteed (e.g., `dirhtml` is known to be broken and will cause
-   broken image links.).
+   Working `sphinx
+   builders <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#options>`_
+   for sphinx_gallery include `html` and `latex`.
 
 
 .. _set_up_your_project:

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -205,7 +205,7 @@ def visit_imgsg_html(self, node):
     imagerel = os.path.relpath(imagedir, os.path.dirname(dest))
     if self.builder.name == "dirhtml":
         imagerel = os.path.join('..', imagerel, '')
-    else: # html
+    else:  # html
         imagerel = os.path.join(imagerel, '')
 
     if '\\' in imagerel:

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -201,9 +201,13 @@ def visit_imgsg_html(self, node):
     # /doc/build/html/examples/subd
     dest = os.path.join(desttop, relsource)
 
-    # ../../_images/
+    # ../../_images/ for dirhtml and ../_images/ for html
     imagerel = os.path.relpath(imagedir, os.path.dirname(dest))
-    imagerel = os.path.join(imagerel, '')
+    if self.builder.name == "dirhtml":
+        imagerel = os.path.join('..', imagerel, '')
+    else: # html
+        imagerel = os.path.join(imagerel, '')
+
     if '\\' in imagerel:
         imagerel = imagerel.replace('\\', '/')
     # make srcset str.  Need to change all the prefixes!

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -464,13 +464,13 @@ def generate_gallery_rst(app):
     Eventually, we create a toctree in the current index file
     which points to section index files.
     """
-    blocked_builder = ['dirhtml']
-    if app.builder.name in blocked_builder:
-        msg = (
-            f'Builder is set to {repr(app.builder.name)}. sphinx_gallery does '
-            f'not work for any of the following: {[blocked_builder]}'
-        )
-        raise ConfigError(msg)
+    # blocked_builder = ['dirhtml']
+    # if app.builder.name in blocked_builder:
+    #     msg = (
+    #         f'Builder is set to {repr(app.builder.name)}. sphinx_gallery does '
+    #         f'not work for any of the following: {[blocked_builder]}'
+    #     )
+    #     raise ConfigError(msg)
 
     logger.info('generating gallery...', color='white')
     gallery_conf = parse_config(app)

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -464,13 +464,6 @@ def generate_gallery_rst(app):
     Eventually, we create a toctree in the current index file
     which points to section index files.
     """
-    # blocked_builder = ['dirhtml']
-    # if app.builder.name in blocked_builder:
-    #     msg = (
-    #         f'Builder is set to {repr(app.builder.name)}. sphinx_gallery does '
-    #         f'not work for any of the following: {[blocked_builder]}'
-    #     )
-    #     raise ConfigError(msg)
 
     logger.info('generating gallery...', color='white')
     gallery_conf = parse_config(app)

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -64,6 +64,36 @@ def sphinx_app(tmpdir_factory, req_mpl, req_pil):
     return app
 
 
+@pytest.fixture(scope='module')
+def sphinx_dirhtml_app(tmpdir_factory, req_mpl, req_pil):
+    # Skip if numpy not installed
+    pytest.importorskip("numpy")
+
+    temp_dir = (tmpdir_factory.getbasetemp() / 'root_dirhtml').strpath
+    src_dir = op.join(op.dirname(__file__), 'tinybuild')
+
+    def ignore(src, names):
+        return ('_build', 'gen_modules', 'auto_examples')
+
+    shutil.copytree(src_dir, temp_dir, ignore=ignore)
+    # For testing iteration, you can get similar behavior just doing `make`
+    # inside the tinybuild directory
+    src_dir = temp_dir
+    conf_dir = temp_dir
+    out_dir = op.join(temp_dir, '_build', 'dirhtml')
+    toctrees_dir = op.join(temp_dir, '_build', 'toctrees')
+    # Avoid warnings about re-registration, see:
+    # https://github.com/sphinx-doc/sphinx/issues/5038
+    with docutils_namespace():
+        app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
+                     buildername='dirhtml', status=StringIO(),
+                     warning=StringIO())
+        # need to build within the context manager
+        # for automodule and backrefs to work
+        app.build(False, [])
+    return app
+
+
 def test_timings(sphinx_app):
     """Test that a timings page is created."""
     out_dir = sphinx_app.outdir
@@ -782,6 +812,20 @@ def test_error_messages(sphinx_app, name, want):
     rst = rst.replace('\n', ' ')
     assert re.match(want, rst) is not None
 
+@pytest.mark.parametrize('name, want', [
+    ('future/plot_future_imports_broken',
+     '.*RuntimeError.*Forcing this example to fail on Python 3.*'),
+    ('plot_scraper_broken',
+     '.*ValueError.*zero-size array to reduction.*'),
+])
+def test_error_messages_dirhtml(sphinx_dirhtml_app, name, want):
+    """Test that informative error messages are added."""
+    src_dir = sphinx_dirhtml_app.srcdir
+    example_rst = op.join(src_dir, 'auto_examples', name + '.rst')
+    with codecs.open(example_rst, 'r', 'utf-8') as fid:
+        rst = fid.read()
+    rst = rst.replace('\n', ' ')
+    assert re.match(want, rst) is not None
 
 def test_alt_text_image(sphinx_app):
     """Test alt text for matplotlib images in html and rst"""

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -36,40 +36,19 @@ N_RST = '(%s|%s)' % (N_RST, N_RST - 1)  # AppVeyor weirdness
 
 @pytest.fixture(scope='module')
 def sphinx_app(tmpdir_factory, req_mpl, req_pil):
-    # Skip if numpy not installed
-    pytest.importorskip("numpy")
-
-    temp_dir = (tmpdir_factory.getbasetemp() / 'root').strpath
-    src_dir = op.join(op.dirname(__file__), 'tinybuild')
-
-    def ignore(src, names):
-        return ('_build', 'gen_modules', 'auto_examples')
-
-    shutil.copytree(src_dir, temp_dir, ignore=ignore)
-    # For testing iteration, you can get similar behavior just doing `make`
-    # inside the tinybuild directory
-    src_dir = temp_dir
-    conf_dir = temp_dir
-    out_dir = op.join(temp_dir, '_build', 'html')
-    toctrees_dir = op.join(temp_dir, '_build', 'toctrees')
-    # Avoid warnings about re-registration, see:
-    # https://github.com/sphinx-doc/sphinx/issues/5038
-    with docutils_namespace():
-        app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
-                     buildername='html', status=StringIO(),
-                     warning=StringIO())
-        # need to build within the context manager
-        # for automodule and backrefs to work
-        app.build(False, [])
-    return app
+    return _sphinx_app(tmpdir_factory, 'html')
 
 
 @pytest.fixture(scope='module')
 def sphinx_dirhtml_app(tmpdir_factory, req_mpl, req_pil):
+    return _sphinx_app(tmpdir_factory, 'dirhtml')
+
+
+def _sphinx_app(tmpdir_factory, buildername):
     # Skip if numpy not installed
     pytest.importorskip("numpy")
 
-    temp_dir = (tmpdir_factory.getbasetemp() / 'root_dirhtml').strpath
+    temp_dir = (tmpdir_factory.getbasetemp() / f'root_{buildername}').strpath
     src_dir = op.join(op.dirname(__file__), 'tinybuild')
 
     def ignore(src, names):
@@ -80,13 +59,13 @@ def sphinx_dirhtml_app(tmpdir_factory, req_mpl, req_pil):
     # inside the tinybuild directory
     src_dir = temp_dir
     conf_dir = temp_dir
-    out_dir = op.join(temp_dir, '_build', 'dirhtml')
+    out_dir = op.join(temp_dir, '_build', buildername)
     toctrees_dir = op.join(temp_dir, '_build', 'toctrees')
     # Avoid warnings about re-registration, see:
     # https://github.com/sphinx-doc/sphinx/issues/5038
     with docutils_namespace():
         app = Sphinx(src_dir, conf_dir, out_dir, toctrees_dir,
-                     buildername='dirhtml', status=StringIO(),
+                     buildername=buildername, status=StringIO(),
                      warning=StringIO())
         # need to build within the context manager
         # for automodule and backrefs to work

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -791,6 +791,7 @@ def test_error_messages(sphinx_app, name, want):
     rst = rst.replace('\n', ' ')
     assert re.match(want, rst) is not None
 
+
 @pytest.mark.parametrize('name, want', [
     ('future/plot_future_imports_broken',
      '.*RuntimeError.*Forcing this example to fail on Python 3.*'),
@@ -805,6 +806,7 @@ def test_error_messages_dirhtml(sphinx_dirhtml_app, name, want):
         rst = fid.read()
     rst = rst.replace('\n', ' ')
     assert re.match(want, rst) is not None
+
 
 def test_alt_text_image(sphinx_app):
     """Test alt text for matplotlib images in html and rst"""

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -28,13 +28,6 @@ def test_bad_config():
         _complete_gallery_conf(sphinx_gallery_conf, '', True, False)
 
 
-# def test_bad_builder(sphinx_app_wrapper):
-#     """Test that we raise an error for a bad builder."""
-#     sphinx_app_wrapper.buildername = 'dirhtml'
-#     with pytest.raises(ConfigError, match=".*dirhtml.*sphinx_gallery does not work.*"):  # noqa: E501
-#         sphinx_app_wrapper.create_sphinx_app()
-
-
 def test_default_config(sphinx_app_wrapper):
     """Test the default Sphinx-Gallery configuration is loaded
 

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -28,11 +28,11 @@ def test_bad_config():
         _complete_gallery_conf(sphinx_gallery_conf, '', True, False)
 
 
-def test_bad_builder(sphinx_app_wrapper):
-    """Test that we raise an error for a bad builder."""
-    sphinx_app_wrapper.buildername = 'dirhtml'
-    with pytest.raises(ConfigError, match=".*dirhtml.*sphinx_gallery does not work.*"):  # noqa: E501
-        sphinx_app_wrapper.create_sphinx_app()
+# def test_bad_builder(sphinx_app_wrapper):
+#     """Test that we raise an error for a bad builder."""
+#     sphinx_app_wrapper.buildername = 'dirhtml'
+#     with pytest.raises(ConfigError, match=".*dirhtml.*sphinx_gallery does not work.*"):  # noqa: E501
+#         sphinx_app_wrapper.create_sphinx_app()
 
 
 def test_default_config(sphinx_app_wrapper):


### PR DESCRIPTION
The idea of this PR is to develop a better solution to #921.

* Remove `dirhtml` blocking and associated test
* Add condition to `directives.visit_imgsg_html` to support `dirhtml` special case

I'm unaware of any other problem related to using the `dirhtml` builder.