### PR TITLE
Adds `plot_gallery` as a string by default

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1197,7 +1197,7 @@ a default::
 
     sphinx_gallery_conf = {
         ...
-        'plot_gallery': False,
+        'plot_gallery': 'False',
     }
 
 The highest precedence is always given to the `-D` flag of the
@@ -1458,8 +1458,8 @@ so they will not be overwritten.
 
 .. note::
     This configuration **only** works when the example is set to not execute
-    (i.e., the ``plot_gallery`` is False, the example is in `ignore_pattern`
-    or the example is not in ``filename_pattern`` - see
+    (i.e., the ``plot_gallery`` is ``'False'``, the example is in
+    `ignore_pattern` or the example is not in ``filename_pattern`` - see
     :ref:`filename/ignore patterns <build_pattern>`). This means that you will
     not need to remove any ``sphinx_gallery_dummy_images`` lines in your
     examples when you switch to building your gallery with execution.

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -68,7 +68,7 @@ DEFAULT_GALLERY_CONF = {
     # 'plot_gallery' also accepts strings that evaluate to a bool, e.g. "True",
     # "False", "1", "0" so that they can be easily set via command line
     # switches of sphinx-build
-    'plot_gallery': True,
+    'plot_gallery': 'True',
     'download_all_examples': True,
     'abort_on_example_error': False,
     'only_warn_on_example_error': False,


### PR DESCRIPTION
Prevents warning about `plot_gallery` being a str but defaulting to bool when invoking with `-D plot_gallery=0 -b html $(ALLSPHINXOPTS)`.

Fixes gh-913