### PR TITLE
add show_code_download conf.py option

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -59,6 +59,7 @@ file:
 - ``capture_repr`` and ``ignore_repr_types`` (:ref:`capture_repr`)
 - ``nested_sections`` (:ref:`nested_sections`)
 - ``api_usage_ignore`` (:ref:`api_usage_ignore`)
+- ``show_code_download`` (:ref:`show_code_download`)
 - ``show_api_usage`` (:ref:`show_api_usage`)
 
 Some options can also be set or overridden on a file-by-file basis:
@@ -367,6 +368,23 @@ In addition, multiple convenience classes are provided for use with
 - :class:`sphinx_gallery.sorting.FileSizeSortKey` to sort by file size.
 - :class:`sphinx_gallery.sorting.FileNameSortKey` to sort by file name.
 - :class:`sphinx_gallery.sorting.ExampleTitleSortKey` to sort by example title.
+
+.. _show_code_download:
+
+Download Python/Jupyter source code
+====================================
+To not have the two download buttons::
+
+    Download Python source code: <Python_file.py>
+
+    Download Jupyter notebook: <Jupyter_file.ipynb>
+
+You can use the configuration key ``show_code_download``::
+
+    sphinx_gallery_conf = {
+        ...
+        'show_code_download'  : False,
+    }
 
 
 .. _link_to_documentation:

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -50,6 +50,7 @@ class DefaultResetArgv:
 
 
 DEFAULT_GALLERY_CONF = {
+    'show_code_download': True,
     'filename_pattern': re.escape(os.sep) + 'plot',
     'ignore_pattern': r'__init__\.py',
     'examples_dirs': os.path.join('..', 'examples'),

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1246,10 +1246,11 @@ def save_rst_example(example_rst, example_file, time_elapsed,
         binder_badge_rst = indent(binder_badge_rst, '  ')  # need an extra two
 
     fname = os.path.basename(example_file)
-    example_rst += CODE_DOWNLOAD.format(fname,
-                                        replace_py_ipynb(fname),
-                                        binder_badge_rst,
-                                        ref_fname)
+    if gallery_conf['show_code_download']:
+        example_rst += CODE_DOWNLOAD.format(fname,
+                                            replace_py_ipynb(fname),
+                                            binder_badge_rst,
+                                            ref_fname)
     if gallery_conf['show_signature']:
         example_rst += SPHX_GLR_SIG
 


### PR DESCRIPTION
Related to https://github.com/sphinx-gallery/sphinx-gallery/issues/1069

provide a show_code_download key to conf.py, if False do not expose "Download Python source code" neither Jupyter notebook