### PR TITLE
API: Deprecate mayavi scraper

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -326,6 +326,8 @@ output formats. To use SVG, you can do::
 You can also use different formats on a per-image basis, but this requires
 writing a customized scraper class or function.
 
+.. _mayavi_scraper:
+
 Example 4: Mayavi scraper
 -------------------------
 Historically, sphinx-gallery supported scraping Mayavi figures as well as

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -140,9 +140,8 @@ Write a custom image scraper
 
 .. warning:: The API for custom scrapers is currently experimental.
 
-By default, Sphinx-Gallery supports image scrapers for Matplotlib
-(:func:`~sphinx_gallery.scrapers.matplotlib_scraper`) and Mayavi
-(:func:`~sphinx_gallery.scrapers.mayavi_scraper`). If you wish to capture
+By default, Sphinx-Gallery supports image scraping for Matplotlib
+(:func:`~sphinx_gallery.scrapers.matplotlib_scraper`). If you wish to capture
 output from other python packages, first determine if the object you wish to
 capture has a ``_repr_html_`` method. If so, you can use the configuration
 ``capture_repr`` (:ref:`capture_repr`) to control the display of the object,
@@ -204,38 +203,43 @@ SVG images are copied.
 .. warning:: SVG images do not work with ``latex`` build modes, thus will not
              work while building a PDF version of your documentation.
 
-Example 1: a Matplotlib and Mayavi-style scraper
-------------------------------------------------
+Example 1: a Matplotlib-style scraper
+-------------------------------------
 
 For example, we will show sample code for a scraper for a hypothetical package.
-It uses an approach similar to what :func:`sphinx_gallery.scrapers.matplotlib_scraper`
-and :func:`sphinx_gallery.scrapers.mayavi_scraper` do under the hood, which
+It uses an approach similar to what
+:func:`sphinx_gallery.scrapers.matplotlib_scraper` does under the hood, which
 use the helper function :func:`sphinx_gallery.scrapers.figure_rst` to
-create the standardized rST. If your package will be used to write an image file
-to disk (e.g., PNG or JPEG), we recommend you use a similar approach. ::
+create the standardized rST. If your package will be used to write an image
+file to disk (e.g., PNG or JPEG), we recommend you use a similar approach,
+but via a class so that the ``__repr__`` can remain stable across Sphinx runs::
 
-   def my_module_scraper(block, block_vars, gallery_conf):
-       import mymodule
-       # We use a list to collect references to image names
-       image_names = list()
-       # The `image_path_iterator` is created by Sphinx-Gallery, it will yield
-       # a path to a file name that adheres to Sphinx-Gallery naming convention.
-       image_path_iterator = block_vars['image_path_iterator']
+    class MyModuleScraper():
+        def __repr__(self):
+            return 'MyModuleScraper'
 
-       # Define a list of our already-created figure objects.
-       list_of_my_figures = mymodule.get_figures()
-
-       # Iterate through figure objects, save to disk, and keep track of paths.
-       for fig, image_path in zip(list_of_my_figures, image_path_iterator):
-           fig.save_png(image_path)
-           image_names.append(image_path)
-
-       # Close all references to figures so they aren't used later.
-       mymodule.close('all')
-
-       # Use the `figure_rst` helper function to generate the rST for this
-       # code block's figures. Alternatively you can define your own rST.
-       return figure_rst(image_names, gallery_conf['src_dir'])
+        def __call__(self, block, block_vars, gallery_conf):
+            import mymodule
+            # We use a list to collect references to image names
+            image_names = list()
+            # The `image_path_iterator` is created by Sphinx-Gallery, it will yield
+            # a path to a file name that adheres to Sphinx-Gallery naming convention.
+            image_path_iterator = block_vars['image_path_iterator']
+     
+            # Define a list of our already-created figure objects.
+            list_of_my_figures = mymodule.get_figures()
+     
+            # Iterate through figure objects, save to disk, and keep track of paths.
+            for fig, image_path in zip(list_of_my_figures, image_path_iterator):
+                fig.save_png(image_path)
+                image_names.append(image_path)
+     
+            # Close all references to figures so they aren't used later.
+            mymodule.close('all')
+     
+            # Use the `figure_rst` helper function to generate the rST for this
+            # code block's figures. Alternatively you can define your own rST.
+            return figure_rst(image_names, gallery_conf['src_dir'])
 
 This code would be defined either in your ``conf.py`` file, or as a module that
 you import into your ``conf.py`` file. The configuration needed to use this
@@ -243,7 +247,7 @@ scraper would look like::
 
     sphinx_gallery_conf = {
         ...
-        'image_scrapers': ('matplotlib', my_module_scraper),
+        'image_scrapers': ('matplotlib', MyModuleScraper()),
     }
 
 Example 2: detecting image files on disk
@@ -258,35 +262,35 @@ don't need to be produced during the execution.
 We'll use a callable class in this case, and assume it is defined within your
 package in a module called ``scraper``. Here is the scraper code::
 
-   from glob import glob
-   import shutil
-   import os
-   from sphinx_gallery.scrapers import figure_rst
+    from glob import glob
+    import shutil
+    import os
+    from sphinx_gallery.scrapers import figure_rst
 
-   class PNGScraper(object):
-       def __init__(self):
-           self.seen = set()
-
-       def __repr__(self):
-           return 'PNGScraper'
-
-       def __call__(self, block, block_vars, gallery_conf):
-           # Find all PNG files in the directory of this example.
-           path_current_example = os.path.dirname(block_vars['src_file'])
-           pngs = sorted(glob(os.path.join(path_current_example, '*.png')))
-
-           # Iterate through PNGs, copy them to the sphinx-gallery output directory
-           image_names = list()
-           image_path_iterator = block_vars['image_path_iterator']
-           for png in pngs:
-               if png not in self.seen:
-                   self.seen |= set(png)
-                   this_image_path = image_path_iterator.next()
-                   image_names.append(this_image_path)
-                   shutil.move(png, this_image_path)
-           # Use the `figure_rst` helper function to generate rST for image files
-           return figure_rst(image_names, gallery_conf['src_dir'])
-
+    class PNGScraper(object):
+        def __init__(self):
+            self.seen = set()
+ 
+        def __repr__(self):
+            return 'PNGScraper'
+ 
+        def __call__(self, block, block_vars, gallery_conf):
+            # Find all PNG files in the directory of this example.
+            path_current_example = os.path.dirname(block_vars['src_file'])
+            pngs = sorted(glob(os.path.join(path_current_example, '*.png')))
+ 
+            # Iterate through PNGs, copy them to the sphinx-gallery output directory
+            image_names = list()
+            image_path_iterator = block_vars['image_path_iterator']
+            for png in pngs:
+                if png not in self.seen:
+                    self.seen |= set(png)
+                    this_image_path = image_path_iterator.next()
+                    image_names.append(this_image_path)
+                    shutil.move(png, this_image_path)
+            # Use the `figure_rst` helper function to generate rST for image files
+            return figure_rst(image_names, gallery_conf['src_dir'])
+ 
 
 Then, in our ``conf.py`` file, we include the following code::
 
@@ -307,7 +311,6 @@ output formats. To use SVG, you can do::
     from sphinx_gallery.scrapers import matplotlib_scraper
 
     class matplotlib_svg_scraper(object):
-
         def __repr__(self):
             return self.__class__.__name__
 
@@ -323,12 +326,44 @@ output formats. To use SVG, you can do::
 You can also use different formats on a per-image basis, but this requires
 writing a customized scraper class or function.
 
+Example 4: Mayavi scraper
+-------------------------
+Historically, sphinx-gallery supported scraping Mayavi figures as well as
+matplotlib figures. However, due to the complexity of maintaining the scraper,
+support was deprecated in version 0.12.0. To continue using a Mayavi scraping,
+consider using something like the following::
+
+    from sphinx_gallery.scrapers import figure_rst
+
+    class MayaviScraper():
+        def __repr__(self):
+            return 'MyModuleScraper'
+
+        def __call__(self, block, block_vars, gallery_conf):
+            from mayavi import mlab
+            image_path_iterator = block_vars['image_path_iterator']
+            image_paths = list()
+            e = mlab.get_engine()
+            for scene, image_path in zip(e.scenes, image_path_iterator):
+                try:
+                    mlab.savefig(image_path, figure=scene)
+                except Exception:
+                    mlab.close(all=True)
+                    raise
+                # make sure the image is not too large
+                scale_image(image_path, image_path, 850, 999)
+                if 'images' in gallery_conf['compress_images']:
+                    optipng(image_path, gallery_conf['compress_images_args'])
+                image_paths.append(image_path)
+            mlab.close(all=True)
+            return figure_rst(image_paths, gallery_conf['src_dir'])
+
 Integrate custom scrapers with Sphinx-Gallery
 ---------------------------------------------
 
-Sphinx-Gallery plans to internally maintain only two scrapers: matplotlib and
-mayavi. If you have extended or fixed bugs with these scrapers, we welcome PRs
-to improve them!
+Sphinx-Gallery plans to internally maintain only one scraper: matplotlib.
+If you have extended or fixed bugs with this scraper, we welcome PRs
+to improve it!
 
 On the other hand, if you have developed a custom scraper for a different
 plotting library that would be useful to the broader community, we encourage
@@ -342,7 +377,7 @@ it with Sphinx-Gallery. You can:
    Taking PyVista as an example, adding ``pyvista._get_sg_image_scraper()``
    that returns the ``callable`` scraper to be used by Sphinx-Gallery allows
    PyVista users to just use strings as they already can for
-   ``'matplotlib'`` and ``'mayavi'``::
+   ``'matplotlib'``::
 
        sphinx_gallery_conf = {
            ...

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,6 +19,7 @@ import warnings
 
 import sphinx_gallery
 from sphinx_gallery.sorting import FileNameSortKey
+from sphinx_gallery.scrapers import _MayaviScraper
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -341,7 +342,7 @@ try:
 except Exception:  # can raise all sorts of errors
     image_scrapers = ('matplotlib',)
 else:
-    image_scrapers += ('mayavi',)
+    image_scrapers += (_MayaviScraper(),)
     examples_dirs.append('../mayavi_examples')
     gallery_dirs.append('auto_mayavi_examples')
     # Do not pop up any mayavi windows while running the

--- a/mayavi_examples/README.rst
+++ b/mayavi_examples/README.rst
@@ -3,6 +3,10 @@
 Mayavi Gallery
 ==============
 
+.. warning:: Mayavi scraping is deprecated and will be removed in 0.13.0. See
+             :ref:`mayavi_scraper` for how to continue using Mayavi scraping
+             if it's part of your sphinx-gallery builds.
+
 .. _general_mayavi_examples:
 
 Mayavi examples

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -30,7 +30,7 @@ from .backreferences import _finalize_backreferences
 from .gen_rst import (generate_dir_rst, SPHX_GLR_SIG, _get_memory_base,
                       _get_readme)
 from .scrapers import (
-    _scraper_dict, _reset_dict, _import_matplotlib, _mayavi_warn)
+    _scraper_dict, _reset_dict, _import_matplotlib, _MAYAVI_WARN)
 from .docs_resolv import embed_code_links
 from .downloads import generate_zipfiles
 from .sorting import NumberOfCodeLinesSortKey
@@ -237,7 +237,7 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
         if isinstance(scraper, str):
             if scraper in _scraper_dict:
                 if scraper == 'mayavi':
-                    _mayavi_warn()
+                    logger.warning(_MAYAVI_WARN)
                 scraper = _scraper_dict[scraper]
             else:
                 orig_scraper = scraper
@@ -859,9 +859,9 @@ def write_api_entry_usage(app, docname, source):
         return
 
     def get_entry_type(entry):
-        if entry in gallery_conf['api_entries']['class']:
+        if entry in gallery_conf['api_entries'].get('class', []):
             return 'class'
-        elif entry in gallery_conf['api_entries']['method']:
+        elif entry in gallery_conf['api_entries'].get('method', []):
             return 'meth'
         else:
             assert entry in gallery_conf['api_entries']['function']

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -29,7 +29,8 @@ from .utils import _replace_md5, _has_optipng, _has_pypandoc, _has_graphviz
 from .backreferences import _finalize_backreferences
 from .gen_rst import (generate_dir_rst, SPHX_GLR_SIG, _get_memory_base,
                       _get_readme)
-from .scrapers import _scraper_dict, _reset_dict, _import_matplotlib
+from .scrapers import (
+    _scraper_dict, _reset_dict, _import_matplotlib, _mayavi_warn)
 from .docs_resolv import embed_code_links
 from .downloads import generate_zipfiles
 from .sorting import NumberOfCodeLinesSortKey
@@ -235,6 +236,8 @@ def _complete_gallery_conf(sphinx_gallery_conf, src_dir, plot_gallery,
     for si, scraper in enumerate(scrapers):
         if isinstance(scraper, str):
             if scraper in _scraper_dict:
+                if scraper == 'mayavi':
+                    _mayavi_warn()
                 scraper = _scraper_dict[scraper]
             else:
                 orig_scraper = scraper

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -240,6 +240,11 @@ def _anim_rst(anim, image_path, gallery_conf):
 def mayavi_scraper(block, block_vars, gallery_conf):
     """Scrape Mayavi images.
 
+    .. warning::
+         mayavi_scraper is deprecated and will be removed in 0.13.0.
+         Use custom scraping code instead -- see the updated sphinx_gallery
+         documentation for details.
+
     Parameters
     ----------
     block : tuple
@@ -255,40 +260,44 @@ def mayavi_scraper(block, block_vars, gallery_conf):
         The ReSTructuredText that will be rendered to HTML containing
         the images. This is often produced by :func:`figure_rst`.
     """
-    _mayavi_warn()
-    return _mayavi_scraper(block, block_vars, gallery_conf)
+    warn(_MAYAVI_WARN, FutureWarning, stacklevel=2)
+    return _MayaviScraper()(block, block_vars, gallery_conf)
 
 
-def _mayavi_warn():
-    warn(
-        'mayavi_scraper is deprecated and will be removed in 0.12.0. '
-        'Use custom scraping code instead -- see our updated documentation.',
-        DeprecationWarning, stacklevel=4)
+_MAYAVI_WARN = (
+    'mayavi_scraper is deprecated and will be removed in 0.13.0. '
+    'Use custom scraping code instead -- see the updated sphinx_gallery '
+    'documentation for details.'
+)
 
 
-def _mayavi_scraper(block, block_vars, gallery_conf):
-    from mayavi import mlab
-    image_path_iterator = block_vars['image_path_iterator']
-    image_paths = list()
-    e = mlab.get_engine()
-    for scene, image_path in zip(e.scenes, image_path_iterator):
-        try:
-            mlab.savefig(image_path, figure=scene)
-        except Exception:
-            mlab.close(all=True)
-            raise
-        # make sure the image is not too large
-        scale_image(image_path, image_path, 850, 999)
-        if 'images' in gallery_conf['compress_images']:
-            optipng(image_path, gallery_conf['compress_images_args'])
-        image_paths.append(image_path)
-    mlab.close(all=True)
-    return figure_rst(image_paths, gallery_conf['src_dir'])
+class _MayaviScraper():
+    def __repr__(self):
+        return 'MayaviScraper'
+
+    def __call__(self, block, block_vars, gallery_conf):
+        from mayavi import mlab
+        image_path_iterator = block_vars['image_path_iterator']
+        image_paths = list()
+        e = mlab.get_engine()
+        for scene, image_path in zip(e.scenes, image_path_iterator):
+            try:
+                mlab.savefig(image_path, figure=scene)
+            except Exception:
+                mlab.close(all=True)
+                raise
+            # make sure the image is not too large
+            scale_image(image_path, image_path, 850, 999)
+            if 'images' in gallery_conf['compress_images']:
+                optipng(image_path, gallery_conf['compress_images_args'])
+            image_paths.append(image_path)
+        mlab.close(all=True)
+        return figure_rst(image_paths, gallery_conf['src_dir'])
 
 
 _scraper_dict = dict(
     matplotlib=matplotlib_scraper,
-    mayavi=mayavi_scraper,
+    mayavi=_MayaviScraper(),
 )
 
 

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -20,7 +20,7 @@ import sys
 import re
 from textwrap import indent
 from pathlib import PurePosixPath
-from warnings import filterwarnings
+from warnings import filterwarnings, warn
 
 from sphinx.errors import ExtensionError
 from .utils import scale_image, optipng
@@ -255,6 +255,18 @@ def mayavi_scraper(block, block_vars, gallery_conf):
         The ReSTructuredText that will be rendered to HTML containing
         the images. This is often produced by :func:`figure_rst`.
     """
+    _mayavi_warn()
+    return _mayavi_scraper(block, block_vars, gallery_conf)
+
+
+def _mayavi_warn():
+    warn(
+        'mayavi_scraper is deprecated and will be removed in 0.12.0. '
+        'Use custom scraping code instead -- see our updated documentation.',
+        DeprecationWarning, stacklevel=4)
+
+
+def _mayavi_scraper(block, block_vars, gallery_conf):
     from mayavi import mlab
     image_path_iterator = block_vars['image_path_iterator']
     image_paths = list()

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -125,7 +125,8 @@ def test_save_mayavi_figures(gallery_conf, req_mpl, req_pil):
     plt.axes([-0.1, -0.1, 1.2, 1.2])
     plt.pcolor([[0]], cmap='Greens')
     mlab.test_plot3d()
-    image_rst = save_figures(block, block_vars, gallery_conf)
+    with pytest.deprecated_call(match=r'mayavi_scraper.*removed in 0\.12*'):
+        image_rst = save_figures(block, block_vars, gallery_conf)
     assert len(plt.get_fignums()) == 0
     assert len(image_path_iterator) == 2
     assert '/image0.png' not in image_rst

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -125,7 +125,7 @@ def test_save_mayavi_figures(gallery_conf, req_mpl, req_pil):
     plt.axes([-0.1, -0.1, 1.2, 1.2])
     plt.pcolor([[0]], cmap='Greens')
     mlab.test_plot3d()
-    with pytest.warns(FutureWarning, match=r'mayavi_scraper.* in 0\.12*'):
+    with pytest.warns(FutureWarning, match=r'mayavi_scraper.* in 0\.13*'):
         image_rst = save_figures(block, block_vars, gallery_conf)
     assert len(plt.get_fignums()) == 0
     assert len(image_path_iterator) == 2

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -125,7 +125,7 @@ def test_save_mayavi_figures(gallery_conf, req_mpl, req_pil):
     plt.axes([-0.1, -0.1, 1.2, 1.2])
     plt.pcolor([[0]], cmap='Greens')
     mlab.test_plot3d()
-    with pytest.deprecated_call(match=r'mayavi_scraper.*removed in 0\.12*'):
+    with pytest.warns(FutureWarning, match=r'mayavi_scraper.* in 0\.12*'):
         image_rst = save_figures(block, block_vars, gallery_conf)
     assert len(plt.get_fignums()) == 0
     assert len(image_path_iterator) == 2


### PR DESCRIPTION
Closes #1075

1. Add a note in the documentation about how people can add their own mayavi scraper (copy-pasted version of our scraper, basically)
2. Add a warning in the Mayavi examples README about deprecation
3. Add a FutureWarning if they try to call `mayavi_scraper` themselves (rare probably, but why not)
4. Add a Sphinx warning on config resolution when `'mayavi'` is in the list of scrapers
5. Internally use `_MayaviScraper()` to avoid the deprecation warnings in our own builds

I think we should merge this and cut 0.12.0 (with a warning about the API change). Then the next PR after we change the version number to 0.13.dev0 can actually remove all Mayavi-related code.