### PR TITLE
DOC: Add note for html-noplot to suppress config warning.

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1204,6 +1204,12 @@ a default::
 The highest precedence is always given to the `-D` flag of the
 ``sphinx-build`` command.
 
+.. note::
+
+   If adding ``html-noplot`` to your ``Makefile``, you will also need to
+   explicitly set the default value for ``plot_gallery`` in the
+   ``sphinx_gallery_conf`` dictionary inside your ``conf.py`` file to avoid
+   a sphinx configuration warning.
 
 .. _compress_images:
 


### PR DESCRIPTION
Adds a note to the Building without executing examples section on how to effectively configure a project that includes the html-noplot option in the Makefile.

Related to #913 and a minor doc followup to #1062. I ran into this as well w/ sphinx-gallery v0.11.1 and stumbled upon solutions in other projects e.g. scikit-learn/scikit-learn#22869, matplotlib/matplotlib#23870 so I figured it might be worth documenting here.