### PR TITLE
MNT: fix subfolder README detection

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -585,6 +585,9 @@ def generate_gallery_rst(app):
                 ] + [''])
 
                 indexst += subsection_index_content
+                has_readme_subsection = True
+            else:
+                has_readme_subsection = False
 
             # Write subsection toctree in main file only if
             # nested_sections is False or None, and
@@ -596,7 +599,7 @@ def generate_gallery_rst(app):
                     indexst += subsection_index_toctree
             # Otherwise, a new index.rst.new file should
             # have been created and it needs to be parsed
-            elif has_readme:
+            elif has_readme_subsection:
                 _replace_md5(subsection_index_path, mode='t')
 
             costs += subsection_costs

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -213,6 +213,13 @@ def test_run_sphinx(sphinx_app):
     assert 'auto_examples_rst_index' in out_files
     generated_examples_dir = op.join(out_dir, 'auto_examples')
     assert op.isdir(generated_examples_dir)
+    # make sure that indices are properly being passed forward...
+    files_to_check = ['auto_examples_rst_index/examp_subdir1/index.html',
+                      'auto_examples_rst_index/examp_subdir2/index.html',
+                      'auto_examples_rst_index/index.html',
+                      ]
+    for f in files_to_check:
+        assert op.isfile(out_dir + '/' + f)
     status = sphinx_app._status.getvalue()
     assert 'executed %d out of %d' % (N_GOOD, N_EXAMPLES) in status
     assert 'after excluding 0' in status


### PR DESCRIPTION
In #1072, if the top level of a gallery had an index.rst instead of a README.txt, any subfolders _also_ had to have an index.rst instead of a README.rst.  The change here checks subdirectories as well for the presence of a README and allows subfolders to have a different README/index choice than the parent.  