### PR TITLE
MAINT: Release 0.12.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+# Upload a Python Package using Twine when a release is created
+# Adapted from mne-bids-pipeline
+
+name: Build
+on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+    - name: Build package
+      run: python -m build --sdist --wheel
+    - name: Check package
+      run: twine check --strict dist/*
+    - name: Check env vars
+      run: |
+        echo "Triggered by: ${{ github.event_name }}"
+    - uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: dist
+
+  # PyPI on release
+  pypi:
+    needs: package
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,0 +1,5 @@
+project=sphinx-gallery
+user=sphinx-gallery
+add-sections={"documentation":{"prefix":"**Documentation**","labels":["documentation"]},"maintenance":{"prefix": "**Project maintenance**","labels":["maintenance"]}}
+max-issues=200
+issues=no

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ coverage.xml
 *.orig
 .pytest_cache
 CHANGELOG.md
+CHANGELOG.rst
 junit-results.xml
 
 # Translations

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,66 @@
 Changelog
 =========
 
+v0.12.0
+-------
+Support for Sphinx < 4 dropped in this release. Requirement is Sphinx >= 4.
+
+**Implemented enhancements:**
+
+-  ENH: allow rst files to pass through `#1071 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1071>`__ (`jklymak <https://github.com/jklymak>`__)
+-  Update advanced usage examples `#1045 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1045>`__ (`HealthyPear <https://github.com/HealthyPear>`__)
+-  Use descriptive link text for example page header `#1040 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1040>`__ (`betatim <https://github.com/betatim>`__)
+-  Expose ``sphinx_gallery_conf`` in ``python_to_jupyter_cli`` `#1027 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1027>`__ (`OverLordGoldDragon <https://github.com/OverLordGoldDragon>`__)
+-  DOC: fix ‘Who uses Sphinx-Gallery’ list `#1015 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1015>`__ (`StefRe <https://github.com/StefRe>`__)
+-  [MAINT, MRG] A few small leftovers from API usage `#997 <https://github.com/sphinx-gallery/sphinx-gallery/pull/997>`__ (`alexrockhill <https://github.com/alexrockhill>`__)
+-  [ENH, MRG] Make orphan of unused API entries `#983 <https://github.com/sphinx-gallery/sphinx-gallery/pull/983>`__ (`alexrockhill <https://github.com/alexrockhill>`__)
+-  Jupyterlite integration `#977 <https://github.com/sphinx-gallery/sphinx-gallery/pull/977>`__ (`amueller <https://github.com/amueller>`__)
+
+**Fixed bugs:**
+
+-  MNT: fix subfolder README detection `#1086 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1086>`__ (`jklymak <https://github.com/jklymak>`__)
+-  API: Deprecate mayavi scraper `#1083 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1083>`__ (`larsoner <https://github.com/larsoner>`__)
+-  FIX: indentation fix `#1077 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1077>`__ (`jklymak <https://github.com/jklymak>`__)
+-  Adds ``plot_gallery`` as a string by default `#1062 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1062>`__ (`melissawm <https://github.com/melissawm>`__)
+-  Fix broken links when using dirhtml builder `#1060 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1060>`__ (`mgoulao <https://github.com/mgoulao>`__)
+-  BUG: Remove ignore blocks when remove_config_comments=True `#1059 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1059>`__ (`guberti <https://github.com/guberti>`__)
+-  Fixed a bug where backslashes in paths could show up in RST files `#1047 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1047>`__ (`ayshih <https://github.com/ayshih>`__)
+-  Allow 2 decimal places in srcset `#1039 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1039>`__ (`OverLordGoldDragon <https://github.com/OverLordGoldDragon>`__)
+-  Fix “``subsection_index_toctree`` referenced before assignment” `#1035 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1035>`__ (`OverLordGoldDragon <https://github.com/OverLordGoldDragon>`__)
+-  [BUG, MRG] fix issue with api usage dict `#1033 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1033>`__ (`alexrockhill <https://github.com/alexrockhill>`__)
+-  MAINT: Remove lingering ref `#1022 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1022>`__ (`larsoner <https://github.com/larsoner>`__)
+-  MNT: Fix erroneous commit c6ed4e `#1021 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1021>`__ (`StefRe <https://github.com/StefRe>`__)
+-  MNT: make “clean” behave the same on Windows as on Linux `#1020 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1020>`__ (`StefRe <https://github.com/StefRe>`__)
+-  DOC Fix typo in scraper doc `#1018 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1018>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
+-  Fix outdated import `#1016 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1016>`__ (`OverLordGoldDragon <https://github.com/OverLordGoldDragon>`__)
+-  FIX: role names `#1012 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1012>`__ (`StefRe <https://github.com/StefRe>`__)
+-  Bugfix thumbnail text formatting `#1005 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1005>`__ (`alexisthual <https://github.com/alexisthual>`__)
+-  [MAINT, MRG] Add unused option for API usage, set as default `#1001 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1001>`__ (`alexrockhill <https://github.com/alexrockhill>`__)
+-  FIX: No orphan `#1000 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1000>`__ (`larsoner <https://github.com/larsoner>`__)
+-  BUG: Short circuit when disabled `#999 <https://github.com/sphinx-gallery/sphinx-gallery/pull/999>`__ (`larsoner <https://github.com/larsoner>`__)
+
+**Documentation**
+
+-  DOC: Add note for html-noplot to suppress config warning. `#1084 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1084>`__ (`rossbar <https://github.com/rossbar>`__)
+-  Reorder paragraphs in the minigallery documentation `#1048 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1048>`__ (`ayshih <https://github.com/ayshih>`__)
+-  DOC: Switch to pydata-sphinx-theme `#1013 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1013>`__ (`larsoner <https://github.com/larsoner>`__)
+-  Fix sphinx link typo in CHANGES `#996 <https://github.com/sphinx-gallery/sphinx-gallery/pull/996>`__ (`alexisthual <https://github.com/alexisthual>`__)
+
+**Project maintenance**
+
+-  MAINT: Fix CIs `#1074 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1074>`__ (`larsoner <https://github.com/larsoner>`__)
+-  TST: gallery inventory/re-structure tinybuild `#1072 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1072>`__ (`jklymak <https://github.com/jklymak>`__)
+-  MAINT: Rotate CircleCI key `#1064 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1064>`__ (`larsoner <https://github.com/larsoner>`__)
+-  MAINT: Update CIs `#1061 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1061>`__ (`larsoner <https://github.com/larsoner>`__)
+-  BUG: Fix full check `#1053 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1053>`__ (`larsoner <https://github.com/larsoner>`__)
+-  MAINT: Work around IPython lexer bug `#1052 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1052>`__ (`larsoner <https://github.com/larsoner>`__)
+-  MAINT: Fix CIs `#1046 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1046>`__ (`larsoner <https://github.com/larsoner>`__)
+-  MAINT: Check CI status `#1028 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1028>`__ (`larsoner <https://github.com/larsoner>`__)
+-  MNT: Fix required sphinx version `#1019 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1019>`__ (`StefRe <https://github.com/StefRe>`__)
+-  BUG: Update for matplotlib `#1010 <https://github.com/sphinx-gallery/sphinx-gallery/pull/1010>`__ (`larsoner <https://github.com/larsoner>`__)
+-  MAINT: Bump to dev `#995 <https://github.com/sphinx-gallery/sphinx-gallery/pull/995>`__ (`larsoner <https://github.com/larsoner>`__)
+
+
 v0.11.1
 -------
 
@@ -14,6 +74,7 @@ Support for Sphinx < 3 dropped in this release. Requirement is Sphinx >= 3.
 
 - Use Mock more in tests `#986 <https://github.com/sphinx-gallery/sphinx-gallery/pull/986>`__ (`QuLogic <https://github.com/QuLogic>`__)
 - Remove old sphinx compatibility code `#985 <https://github.com/sphinx-gallery/sphinx-gallery/pull/985>`__ (`QuLogic <https://github.com/QuLogic>`__)
+
 
 v0.11.0
 -------
@@ -85,34 +146,6 @@ We now display gallery items using CSS grid instead of  ``float`` property `#906
 -  Add PyVista examples! `#888 <https://github.com/sphinx-gallery/sphinx-gallery/pull/888>`__ (`banesullivan <https://github.com/banesullivan>`__)
 -  Fix a few links in project lists `#883 <https://github.com/sphinx-gallery/sphinx-gallery/pull/883>`__ (`ixjlyons <https://github.com/ixjlyons>`__)
 
-**Closed issues:**
-
--  Matplotlib warnings in seaborn example: “Trying to register the cmap which already exists” `#968 <https://github.com/sphinx-gallery/sphinx-gallery/issues/968>`__
--  reference_url failure in sphinx version > 5 `#967 <https://github.com/sphinx-gallery/sphinx-gallery/issues/967>`__
--  Send feedback `#963 <https://github.com/sphinx-gallery/sphinx-gallery/issues/963>`__
--  disable download buttons `#949 <https://github.com/sphinx-gallery/sphinx-gallery/issues/949>`__
--  Specify Target of ``reference_url`` `#947 <https://github.com/sphinx-gallery/sphinx-gallery/issues/947>`__
--  Display bug for examples mentioning a given API reference `#945 <https://github.com/sphinx-gallery/sphinx-gallery/issues/945>`__
--  Subfolder Examples appearing in main TOC `#939 <https://github.com/sphinx-gallery/sphinx-gallery/issues/939>`__
--  Sphinx-gallery generating huge rst files `#929 <https://github.com/sphinx-gallery/sphinx-gallery/issues/929>`__
--  Broken plot links if sphinx uses ``htmldir`` `#921 <https://github.com/sphinx-gallery/sphinx-gallery/issues/921>`__
--  Distorted gallery overview `#918 <https://github.com/sphinx-gallery/sphinx-gallery/issues/918>`__
--  mini-gallery not shown in grid `#911 <https://github.com/sphinx-gallery/sphinx-gallery/issues/911>`__
--  0.10.1: pep517 build warnings `#907 <https://github.com/sphinx-gallery/sphinx-gallery/issues/907>`__
--  Make thumbnails grid- and flexbox-compatible `#905 <https://github.com/sphinx-gallery/sphinx-gallery/issues/905>`__
--  DOC: Example “Identifying function names in a script” `#900 <https://github.com/sphinx-gallery/sphinx-gallery/issues/900>`__
--  Limit adding mini-galleries for API docs to explicitly referred to items only `#898 <https://github.com/sphinx-gallery/sphinx-gallery/issues/898>`__
--  Documentation “Add mini-galleries for API documentation” `#897 <https://github.com/sphinx-gallery/sphinx-gallery/issues/897>`__
--  TestLoggingTee failing pytest v7.0.0rc1 `#893 <https://github.com/sphinx-gallery/sphinx-gallery/issues/893>`__
--  Resetting matplotlib module `#889 <https://github.com/sphinx-gallery/sphinx-gallery/issues/889>`__
--  Thumbnail for non plot examples `#887 <https://github.com/sphinx-gallery/sphinx-gallery/issues/887>`__
--  Looking for backrefrences “..examples” files instead of “.examples” files `#885 <https://github.com/sphinx-gallery/sphinx-gallery/issues/885>`__
--  Build gallery from .ipynb files only `#882 <https://github.com/sphinx-gallery/sphinx-gallery/issues/882>`__
--  Examples showing at the top instead of interlaced in-between every class `#876 <https://github.com/sphinx-gallery/sphinx-gallery/issues/876>`__
--  Creating API mini-gallery using autosummary recursive option `#797 <https://github.com/sphinx-gallery/sphinx-gallery/issues/797>`__
-
-**Merged pull requests:**
-
 
 v0.10.1
 -------
@@ -130,13 +163,6 @@ Support for Python 3.6 dropped in this release. Requirement is Python >=3.7.
 -  ``0.10.0`` breaks ``sphinx_gallery.load_style`` `#878 <https://github.com/sphinx-gallery/sphinx-gallery/issues/878>`__
 -  Add imagesg directive in load style `#880 <https://github.com/sphinx-gallery/sphinx-gallery/pull/880>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
 -  Use bools for ‘plot_gallery’ in sphinx_gallery_conf `#863 <https://github.com/sphinx-gallery/sphinx-gallery/pull/863>`__ (`timhoffm <https://github.com/timhoffm>`__)
-
-**Closed issues:**
-
--  Idea: make galleries out of the “testing” folder to use each unit test as an example. `#875 <https://github.com/sphinx-gallery/sphinx-gallery/issues/875>`__
--  Output text in dark mode is not visible `#869 <https://github.com/sphinx-gallery/sphinx-gallery/issues/869>`__
--  Using a .gif image works in ``.rst`` sphinx build but not inside example generated with sphinx-gallery `#868 <https://github.com/sphinx-gallery/sphinx-gallery/issues/868>`__
--  How to avoid capture of tqdm progress bars `#867 <https://github.com/sphinx-gallery/sphinx-gallery/issues/867>`__
 
 **Merged pull requests:**
 
@@ -167,15 +193,6 @@ For more details see `#845 <https://github.com/sphinx-gallery/sphinx-gallery/pul
 -  Bug Pin markupsafe version in Python nightly `#831 <https://github.com/sphinx-gallery/sphinx-gallery/pull/831>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
 -  BUG Fix test_minigallery_directive failing on Windows `#830 <https://github.com/sphinx-gallery/sphinx-gallery/pull/830>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
 -  BUG Fix LaTeX Error: File \`tgtermes.sty’ not found in CI `#829 <https://github.com/sphinx-gallery/sphinx-gallery/pull/829>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
-
-**Closed issues:**
-
--  Galleries using bokeh `#841 <https://github.com/sphinx-gallery/sphinx-gallery/issues/841>`__
--  TorchIO now uses sphinx-gallery `#823 <https://github.com/sphinx-gallery/sphinx-gallery/issues/823>`__
--  New release `#817 <https://github.com/sphinx-gallery/sphinx-gallery/issues/817>`__
--  Change DPI? `#804 <https://github.com/sphinx-gallery/sphinx-gallery/issues/804>`__
--  Multiple images in horizontal list are not clickable (cannot zoom in) `#429 <https://github.com/sphinx-gallery/sphinx-gallery/issues/429>`__
--  Notebook style issues with indentation `#342 <https://github.com/sphinx-gallery/sphinx-gallery/issues/342>`__
 
 **Merged pull requests:**
 
@@ -233,15 +250,6 @@ Support for Python 3.5 dropped in this release. Requirement is Python >=3.6.
 -  Replace Travis CI badge with Azure Badge in README `#783 <https://github.com/sphinx-gallery/sphinx-gallery/pull/783>`__ (`sdhiscocks <https://github.com/sdhiscocks>`__)
 -  Point to up-to-date re documentation `#778 <https://github.com/sphinx-gallery/sphinx-gallery/pull/778>`__ (`dstansby <https://github.com/dstansby>`__)
 
-**Closed issues:**
-
--  Generating the output notebooks together with data (folders) used for generating… `#809 <https://github.com/sphinx-gallery/sphinx-gallery/issues/809>`__
--  How to link from one example to another? `#805 <https://github.com/sphinx-gallery/sphinx-gallery/issues/805>`__
--  Incompatibility with matplotlib 3.4.0 ? `#802 <https://github.com/sphinx-gallery/sphinx-gallery/issues/802>`__
--  Pandas \_repr_html\_ not captured in PDF output `#799 <https://github.com/sphinx-gallery/sphinx-gallery/issues/799>`__
--  Optuna project Uses Sphinx-Gallery `#795 <https://github.com/sphinx-gallery/sphinx-gallery/issues/795>`__
--  Adding an extended README `#771 <https://github.com/sphinx-gallery/sphinx-gallery/issues/771>`__
-
 **Merged pull requests:**
 
 -  DOC Add section on altering CSS `#820 <https://github.com/sphinx-gallery/sphinx-gallery/pull/820>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
@@ -277,10 +285,6 @@ Enables HTML animations to be rendered on readthedocs.
 -  DOC Amend run_stale_examples command in configuration.rst `#763 <https://github.com/sphinx-gallery/sphinx-gallery/pull/763>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
 -  DOC update link in projects_list `#754 <https://github.com/sphinx-gallery/sphinx-gallery/pull/754>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
 -  Enable animations HTML to be rendered on readthedocs `#748 <https://github.com/sphinx-gallery/sphinx-gallery/pull/748>`__ (`sdhiscocks <https://github.com/sdhiscocks>`__)
-
-**Closed issues:**
-
--  MNT: Stop using ci-helpers in appveyor.yml `#766 <https://github.com/sphinx-gallery/sphinx-gallery/issues/766>`__
 
 **Merged pull requests:**
 
@@ -349,14 +353,6 @@ by CSS) in version 0.9.0.
 -  Enable html to be rendered on readthedocs `#700 <https://github.com/sphinx-gallery/sphinx-gallery/pull/700>`__ (`sdhiscocks <https://github.com/sdhiscocks>`__)
 -  Remove matplotlib agg warning `#696 <https://github.com/sphinx-gallery/sphinx-gallery/pull/696>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
 
-**Closed issues:**
-
--  Reference :ref:``sphx\_glr\_auto\_examples`` goes to SciKit-Learn examples `#734 <https://github.com/sphinx-gallery/sphinx-gallery/issues/734>`__
--  Q: how to have a couple of images with ``bbox\_inches='tight'``. `#726 <https://github.com/sphinx-gallery/sphinx-gallery/issues/726>`__
--  filename_pattern still doesn’t work all that great for working on one tutorial `#721 <https://github.com/sphinx-gallery/sphinx-gallery/issues/721>`__
--  Gallery example using plotly `#715 <https://github.com/sphinx-gallery/sphinx-gallery/issues/715>`__
--  DOC Builder types clarification `#697 <https://github.com/sphinx-gallery/sphinx-gallery/issues/697>`__
-
 **Merged pull requests:**
 
 -  DOC add section on interpreting error/warnings `#740 <https://github.com/sphinx-gallery/sphinx-gallery/pull/740>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
@@ -422,10 +418,6 @@ Developer changes
 -  Inconsistency with applying & removing sphinx gallery configs `#665 <https://github.com/sphinx-gallery/sphinx-gallery/issues/665>`__
 -  ``make html-noplot`` instructions outdated `#606 <https://github.com/sphinx-gallery/sphinx-gallery/issues/606>`__
 
-**Closed issues:**
-
--  intersphinx links need backreferences_dir `#467 <https://github.com/sphinx-gallery/sphinx-gallery/issues/467>`__
-
 **Merged pull requests:**
 
 -  Fix lint in gen_gallery.py `#686 <https://github.com/sphinx-gallery/sphinx-gallery/pull/686>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
@@ -477,10 +469,6 @@ Developer changes
 -  Fix missing space in error message. `#632 <https://github.com/sphinx-gallery/sphinx-gallery/pull/632>`__ (`anntzer <https://github.com/anntzer>`__)
 -  BUG: Spaces in example filenames break image linking `#440 <https://github.com/sphinx-gallery/sphinx-gallery/issues/440>`__
 
-**Closed issues:**
-
--  New release? `#627 <https://github.com/sphinx-gallery/sphinx-gallery/issues/627>`__
-
 **Merged pull requests:**
 
 -  DOC minor update to release guide `#633 <https://github.com/sphinx-gallery/sphinx-gallery/pull/633>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
@@ -524,34 +512,6 @@ Developer changes
 -  URLError `#569 <https://github.com/sphinx-gallery/sphinx-gallery/pull/569>`__ (`EtienneCmb <https://github.com/EtienneCmb>`__)
 -  MRG Remove last/first_notebook_cell redundancy `#626 <https://github.com/sphinx-gallery/sphinx-gallery/pull/626>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
 -  Remove duplicate doc_solver entry in the API reference structure `#589 <https://github.com/sphinx-gallery/sphinx-gallery/pull/589>`__ (`kanderso-nrel <https://github.com/kanderso-nrel>`__)
-
-**Closed issues:**
-
--  Allow removal of “download jupyter notebook” link `#622 <https://github.com/sphinx-gallery/sphinx-gallery/issues/622>`__
--  thumbnails from loaded figures `#607 <https://github.com/sphinx-gallery/sphinx-gallery/issues/607>`__
--  last_notebook_cell `#605 <https://github.com/sphinx-gallery/sphinx-gallery/issues/605>`__
--  Building fails with pickling error `#602 <https://github.com/sphinx-gallery/sphinx-gallery/issues/602>`__
--  BUG: Bugs with backref links `#587 <https://github.com/sphinx-gallery/sphinx-gallery/issues/587>`__
--  BUG backreferences not working for functions if not imported directly `#583 <https://github.com/sphinx-gallery/sphinx-gallery/issues/583>`__
--  AttributeError: ‘URLError’ object has no attribute ‘url’ `#568 <https://github.com/sphinx-gallery/sphinx-gallery/issues/568>`__
--  BUG Check “backreferences_dir” is str or None `#567 <https://github.com/sphinx-gallery/sphinx-gallery/issues/567>`__
--  check_duplicated does not respect the ignore_pattern `#474 <https://github.com/sphinx-gallery/sphinx-gallery/issues/474>`__
--  Sphinx-Gallery Binder links: environment.yml does not get “installed” `#628 <https://github.com/sphinx-gallery/sphinx-gallery/issues/628>`__
--  Another place to replace “######” separators by “# %%” `#620 <https://github.com/sphinx-gallery/sphinx-gallery/issues/620>`__
--  How to prevent output to stderr from being captured. `#618 <https://github.com/sphinx-gallery/sphinx-gallery/issues/618>`__
--  Master failing with sphinx dev `#617 <https://github.com/sphinx-gallery/sphinx-gallery/issues/617>`__
--  Mention the support for \_repr_html\_ on custom scraper doc `#614 <https://github.com/sphinx-gallery/sphinx-gallery/issues/614>`__
--  Mention the multiple possible separators in the notebook-style example `#611 <https://github.com/sphinx-gallery/sphinx-gallery/issues/611>`__
--  Cell marker causes pycodestyle error `#608 <https://github.com/sphinx-gallery/sphinx-gallery/issues/608>`__
--  Reduce the amount of hard dependencies? `#597 <https://github.com/sphinx-gallery/sphinx-gallery/issues/597>`__
--  instances not getting correct CSS classes `#588 <https://github.com/sphinx-gallery/sphinx-gallery/issues/588>`__
--  greedy backreferences `#580 <https://github.com/sphinx-gallery/sphinx-gallery/issues/580>`__
--  Error when using two image scrappers together `#579 <https://github.com/sphinx-gallery/sphinx-gallery/issues/579>`__
--  Improve the junit xml `#576 <https://github.com/sphinx-gallery/sphinx-gallery/issues/576>`__
--  Remove the note linking to the download section at the beginning of the example from latex/pdf output `#572 <https://github.com/sphinx-gallery/sphinx-gallery/issues/572>`__
--  typing.TYPE_CHECKING is True at runtime in executed .py files `#570 <https://github.com/sphinx-gallery/sphinx-gallery/issues/570>`__
--  How best to handle data files? `#565 <https://github.com/sphinx-gallery/sphinx-gallery/issues/565>`__
--  ENH Add CSS for pandas dataframe `#544 <https://github.com/sphinx-gallery/sphinx-gallery/issues/544>`__
 
 **Merged pull requests:**
 
@@ -611,26 +571,6 @@ Incompatible changes
 -  [MRG][FIX] Remove output box from print(__doc__) `#529 <https://github.com/sphinx-gallery/sphinx-gallery/pull/529>`__ (`lucyleeow <https://github.com/lucyleeow>`__)
 -  BUG: Fix kwargs modification in loop `#527 <https://github.com/sphinx-gallery/sphinx-gallery/pull/527>`__ (`larsoner <https://github.com/larsoner>`__)
 -  MAINT: Fix AppVeyor `#524 <https://github.com/sphinx-gallery/sphinx-gallery/pull/524>`__ (`larsoner <https://github.com/larsoner>`__)
-
-**Closed issues:**
-
--  Making sphinx-gallery parallel_write_safe `#560 <https://github.com/sphinx-gallery/sphinx-gallery/issues/560>`__
--  Mayavi example cannot run in binder `#554 <https://github.com/sphinx-gallery/sphinx-gallery/issues/554>`__
--  Support pyqtgraph plots `#553 <https://github.com/sphinx-gallery/sphinx-gallery/issues/553>`__
--  Last word in rst used as code `#546 <https://github.com/sphinx-gallery/sphinx-gallery/issues/546>`__
--  ENH capture ’repr’s of last expression `#540 <https://github.com/sphinx-gallery/sphinx-gallery/issues/540>`__
--  Mention list of projects using sphinx-gallery in a documentation page `#536 <https://github.com/sphinx-gallery/sphinx-gallery/issues/536>`__
--  consider looking also for ‘readme.\*’ instead of only ‘README.\*’ `#534 <https://github.com/sphinx-gallery/sphinx-gallery/issues/534>`__
--  Small regression in 0.4.1: print(__doc__) creates empty output block `#528 <https://github.com/sphinx-gallery/sphinx-gallery/issues/528>`__
--  Show memory usage in build output `#522 <https://github.com/sphinx-gallery/sphinx-gallery/issues/522>`__
--  Linking to external examples `#519 <https://github.com/sphinx-gallery/sphinx-gallery/issues/519>`__
--  Intro text gets truncated on ‘-’ character `#517 <https://github.com/sphinx-gallery/sphinx-gallery/issues/517>`__
--  REL: New release `#507 <https://github.com/sphinx-gallery/sphinx-gallery/issues/507>`__
--  Matplotlib raises warning when ‘pyplot.show()’ is called `#488 <https://github.com/sphinx-gallery/sphinx-gallery/issues/488>`__
--  Only support the latest 2 or 3 Sphinx versions `#407 <https://github.com/sphinx-gallery/sphinx-gallery/issues/407>`__
--  Drop Python 2.X support `#405 <https://github.com/sphinx-gallery/sphinx-gallery/issues/405>`__
--  Inspiration from new gallery package for sphinx: sphinx-exhibit `#402 <https://github.com/sphinx-gallery/sphinx-gallery/issues/402>`__
--  DOC: each example should start by explaining why it’s there `#143 <https://github.com/sphinx-gallery/sphinx-gallery/issues/143>`__
 
 **Merged pull requests:**
 
@@ -708,29 +648,6 @@ Incompatible changes
 -  Remove links to read the docs `#461 <https://github.com/sphinx-gallery/sphinx-gallery/pull/461>`__ (`GaelVaroquaux <https://github.com/GaelVaroquaux>`__)
 -  [MRG+1] Add requirements.txt to manifest `#458 <https://github.com/sphinx-gallery/sphinx-gallery/pull/458>`__ (`ksunden <https://github.com/ksunden>`__)
 
-**Closed issues:**
-
--  Allow .rst extension for README files `#508 <https://github.com/sphinx-gallery/sphinx-gallery/issues/508>`__
--  Generation of unchanged examples `#506 <https://github.com/sphinx-gallery/sphinx-gallery/issues/506>`__
--  Binder integration and Read the docs `#503 <https://github.com/sphinx-gallery/sphinx-gallery/issues/503>`__
--  Extending figure_rst to support html figures? `#498 <https://github.com/sphinx-gallery/sphinx-gallery/issues/498>`__
--  ENH: remove API crossrefs from hover text `#497 <https://github.com/sphinx-gallery/sphinx-gallery/issues/497>`__
--  BUG: warnings/stderr not captured `#491 <https://github.com/sphinx-gallery/sphinx-gallery/issues/491>`__
--  Should ``image\_scrapers`` be renamed (to ``output\_scrapers`` for example)? `#485 <https://github.com/sphinx-gallery/sphinx-gallery/issues/485>`__
--  Strip in-file sphinx_gallery directives from code `#481 <https://github.com/sphinx-gallery/sphinx-gallery/issues/481>`__
--  Generating gallery sometimes freezes `#479 <https://github.com/sphinx-gallery/sphinx-gallery/issues/479>`__
--  Adding a ReST block immediately after the module docstring breaks the generated .rst file `#473 <https://github.com/sphinx-gallery/sphinx-gallery/issues/473>`__
--  how to make custom image scraper `#469 <https://github.com/sphinx-gallery/sphinx-gallery/issues/469>`__
--  pythonhosted.org seems to be still up and running `#465 <https://github.com/sphinx-gallery/sphinx-gallery/issues/465>`__
--  Small regression in 0.3.1 with output figure numbering `#464 <https://github.com/sphinx-gallery/sphinx-gallery/issues/464>`__
--  Change output format of images `#463 <https://github.com/sphinx-gallery/sphinx-gallery/issues/463>`__
--  Version 0.3.0 release is broken on pypi `#459 <https://github.com/sphinx-gallery/sphinx-gallery/issues/459>`__
--  sphinx-gallery doesn’t play nice with sphinx’s ability to detect new files… `#449 <https://github.com/sphinx-gallery/sphinx-gallery/issues/449>`__
--  Remove the readthedocs version of sphinx gallery docs `#444 <https://github.com/sphinx-gallery/sphinx-gallery/issues/444>`__
--  Support for Plotly `#441 <https://github.com/sphinx-gallery/sphinx-gallery/issues/441>`__
--  Release v0.3.0 `#406 <https://github.com/sphinx-gallery/sphinx-gallery/issues/406>`__
--  Unnecessary regeneration of example pages `#395 <https://github.com/sphinx-gallery/sphinx-gallery/issues/395>`__
--  Unnecessary regeneration of API docs `#394 <https://github.com/sphinx-gallery/sphinx-gallery/issues/394>`__
 
 v0.3.1
 ------
@@ -742,6 +659,7 @@ package.
 
 - Version 0.3.0 release is broken on pypi
   `#459 <https://github.com/sphinx-gallery/sphinx-gallery/issues/459>`__
+
 
 v0.3.0
 ------
@@ -786,50 +704,6 @@ Developer changes
 -  First gallery plot uses .matplotlibrc rather than the matplotlib
    defaults
    `#316 <https://github.com/sphinx-gallery/sphinx-gallery/issues/316>`__
-
-**Closed issues:**
-
--  SG not respecting highlight_lang in conf.py
-   `#452 <https://github.com/sphinx-gallery/sphinx-gallery/issues/452>`__
--  sphinx-gallery doesn’t play nice with sphinx’s ability to detect new
-   files…
-   `#449 <https://github.com/sphinx-gallery/sphinx-gallery/issues/449>`__
--  gallery generation broken on cpython master
-   `#442 <https://github.com/sphinx-gallery/sphinx-gallery/issues/442>`__
--  Improve binder button instructions
-   `#438 <https://github.com/sphinx-gallery/sphinx-gallery/issues/438>`__
--  Won’t display stdout
-   `#435 <https://github.com/sphinx-gallery/sphinx-gallery/issues/435>`__
--  relative paths in github.io
-   `#434 <https://github.com/sphinx-gallery/sphinx-gallery/issues/434>`__
--  ‘make html’ does not attempt to run examples
-   `#425 <https://github.com/sphinx-gallery/sphinx-gallery/issues/425>`__
--  Sprint tomorrow @ euroscipy?
-   `#412 <https://github.com/sphinx-gallery/sphinx-gallery/issues/412>`__
--  Release v0.3.0
-   `#409 <https://github.com/sphinx-gallery/sphinx-gallery/issues/409>`__
--  Supported Python and Sphinx versions
-   `#404 <https://github.com/sphinx-gallery/sphinx-gallery/issues/404>`__
--  How to get the ``.css`` files to copy over on building the docs?
-   `#399 <https://github.com/sphinx-gallery/sphinx-gallery/issues/399>`__
--  feature request: only rebuild individual examples
-   `#397 <https://github.com/sphinx-gallery/sphinx-gallery/issues/397>`__
--  Unnecessary regeneration of example pages
-   `#395 <https://github.com/sphinx-gallery/sphinx-gallery/issues/395>`__
--  Unnecessary regeneration of API docs
-   `#394 <https://github.com/sphinx-gallery/sphinx-gallery/issues/394>`__
--  matplotlib inline vs notebook
-   `#388 <https://github.com/sphinx-gallery/sphinx-gallery/issues/388>`__
--  Can this work for files other than .py ?
-   `#378 <https://github.com/sphinx-gallery/sphinx-gallery/issues/378>`__
--  v0.1.14 release plan
-   `#344 <https://github.com/sphinx-gallery/sphinx-gallery/issues/344>`__
--  SG misses classes that aren’t imported
-   `#205 <https://github.com/sphinx-gallery/sphinx-gallery/issues/205>`__
--  Add a page showing the time taken by the examples
-   `#203 <https://github.com/sphinx-gallery/sphinx-gallery/issues/203>`__
--  Lack of ``install\_requires``
-   `#192 <https://github.com/sphinx-gallery/sphinx-gallery/issues/192>`__
 
 **Merged pull requests:**
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -31,3 +31,4 @@ exclude __pycache__
 recursive-exclude */gen_modules *
 exclude gen_modules
 exclude .DS_store
+exclude .github_changelog_generator

--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,8 @@ An incomplete list:
 
 * `Apache TVM <https://tvm.apache.org/docs/tutorial/index.html>`_
 * `Astropy <https://docs.astropy.org/en/stable/generated/examples/index.html>`_
-* `Biotite <https://www.biotite-python.org/examples/gallery/index.html>`_
 * `Auto-sklearn <https://automl.github.io/auto-sklearn/master/examples/index.html>`_
+* `Biotite <https://www.biotite-python.org/examples/gallery/index.html>`_
 * `Cartopy <https://scitools.org.uk/cartopy/docs/latest/gallery/>`_
 * `Fury <https://fury.gl/latest/auto_examples/index.html>`_
 * `GIMLi <https://www.pygimli.org/_examples_auto/index.html>`_
@@ -55,9 +55,9 @@ An incomplete list:
 * `Scikit-learn <http://scikit-learn.org/stable/auto_examples/index.html>`_
 * `SimPEG <https://docs.simpeg.xyz/content/examples/>`_
 * `Sphinx-Gallery <https://sphinx-gallery.github.io/stable/auto_examples/index.html>`_
+* `SunPy <https://docs.sunpy.org/en/stable/generated/gallery/index.html>`_
 * `Tonic <https://tonic.readthedocs.io/en/latest/auto_examples/index.html>`_
 * `TorchIO <https://torchio.readthedocs.io/auto_examples/index.html>`_
-* `SunPy <https://docs.sunpy.org/en/stable/generated/gallery/index.html>`_
 
 .. projects_list_end
 

--- a/doc/maintainers.rst
+++ b/doc/maintainers.rst
@@ -100,30 +100,7 @@ Prepare for release
 Finalize the release
 --------------------
 
-1. Create the new release on PyPI
-
-   * Build a source distribution and an ``any`` wheel::
-
-        git clean -xdf
-        python setup.py sdist bdist_wheel
-
-   * Check the release::
-
-        twine check dist/sphinx-gallery-<version>.*
-
-     ``<version>`` should be the release version, e.g., ``0.7.0``, and it
-     should check both the source distribution and the wheel.
-
-   * Upload to PyPI::
-
-        twine upload dist/*
-
-     Again, ``<version>`` should be the release version, e.g., ``0.7.0``.
-
-   * Confirm that the new version of Sphinx Gallery
-     `is posted to pypi <https://pypi.org/project/sphinx-gallery/>`_.
-
-2. Create a new release on GitHub
+1. Create a new release on GitHub
 
    * Go to the `Draft a new release <https://github.com/sphinx-gallery/sphinx-gallery/releases/new>`_ page.
    * The **tag version** is whatever the version is in ``__init__.py`` prepended with ``v``. E.g., ``v0.7.0``.
@@ -131,9 +108,11 @@ Finalize the release
    * The **description** should contain the markdown changelog
      you generated above (in the ``CHANGELOG.md`` file).
    * Click **Publish release** when you are done.
+   * Confirm that the new version of Sphinx Gallery
+     `is posted to PyPI <https://pypi.org/project/sphinx-gallery/#history>`_.
 
-3. Now that the releases are complete, we need to switch the "master" branch back into a developer
-   mode. Bump the `Sphinx Gallery version number <https://github.com/sphinx-gallery/sphinx-gallery/blob/master/sphinx_gallery/__init__.py>`_
+2. Now that the releases are complete, we need to switch the `master`` branch
+   back into a developer mode. Bump the `Sphinx Gallery version number <https://github.com/sphinx-gallery/sphinx-gallery/blob/master/sphinx_gallery/__init__.py>`_
    to the next minor (or major) release and append ``.dev0`` to the end, and make a PR for this change.
 
-4. Celebrate! You've just released a new version of Sphinx Gallery!
+3. Celebrate! You've just released a new version of Sphinx Gallery!

--- a/doc/maintainers.rst
+++ b/doc/maintainers.rst
@@ -46,21 +46,36 @@ Prepare for release
        command below ``<version>`` is the current (not development) version of
        the package, e.g., ``0.6.0``. We do this because our failing discipline
        of writing in the CHANGES.rst all relevant changes, this helps our
-       memory. It is a good idea to add appropriate labels (e.g., 'BUG') to
+       memory. It is a good idea to add appropriate labels to
        issues and pull requests so they are categorized correctly in the
-       CHANGES.rst generated. ::
+       CHANGES.rst generated. The labels we currently use are:
 
-          github_changelog_generator -u sphinx-gallery -p sphinx-gallery --since-tag=v<version> --token <your-40-digit-token>
+         ``bug``
+           For fixed bugs.
+         ``enhancement``
+           For enhancements
+         ``maintenance``
+           For general project maintenance (e.g., CIs)
+         ``documentation``
+           For documentation improvements.
+
+       The changelog can generated with the following::
+
+          github_changelog_generator --since-tag=v<version> --token <your-40-digit-token>
+
+       To avoid the need to pass ``--token``, you can use ``export CHANGELOG_GITHUB_TOKEN=<your-40-digit-token>`` instead.
 
     2. Edit CHANGELOG.md to look reasonable (it will be used later). It's a
-       good idea to add labels to issues and pull requests so
-       `github_changelog_generator` can correctly categorize them in in the
-       CHANGES.rst file generated.
+       good idea to add labels to issues and pull requests and iteratively
+       re-run `github_changelog_generator` until PRs are correctly categorized
+       in the ``CHANGES.md`` file generated.
 
     3. Propagate the relevant changes to `CHANGES.rst <https://github.com/sphinx-gallery/sphinx-gallery/blob/master/CHANGES.rst>`_.
        You can easily convert it RST with pandoc::
 
           pandoc CHANGELOG.md --wrap=none -o CHANGELOG.rst
+
+       Then copy just the sections to ``CHANGES.rst``.
 
 2. Build the docs cleanly
 
@@ -74,8 +89,8 @@ Prepare for release
 4. Update version
 
      Update the version in ``sphinx_gallery/__init__.py``, which should end in
-     ``.dev0``. You should remove ``.dev0``, and the numbers that remain will
-     become the version for this release.
+     ``.dev0``. You should replace ``.dev0`` with ``0`` to obtain a semantic
+     version (e.g., ``0.12.dev0`` to ``0.12.0``).
 
 5. Open a Pull Request that contains the two changes we've made above
 

--- a/doc/maintainers.rst
+++ b/doc/maintainers.rst
@@ -15,92 +15,62 @@ How to make a release
 
 .. highlight:: console
 
-Check credentials and prerequisites
------------------------------------
+1. Update ``CHANGES.rst`` and version in a PR
+---------------------------------------------
 
-Sphinx Gallery is `hosted on the pypi repository <https://pypi.org/project/sphinx-gallery/>`_.
-To create a new release of Sphinx Gallery, you need to do these things:
-You should double-check a few things to make sure that you can create
-a new release for Sphinx Gallery.
+1. Use `github_changelog_generator
+   <https://github.com/github-changelog-generator/github-changelog-generator#installation>`_ to
+   gather all merged pull requests and closed issues during the development
+   cycle. You will likely need to `generate a Github token <https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token>`_
+   as Github only allows 50 unauthenticated requests per hour. In the
+   command below ``<version>`` is the current (not development) version of
+   the package, e.g., ``0.6.0``. The changelog can generated with the following::
 
-1. Ensure that you **registered an account** on `the PyPI index <https://pypi.org/account/register/>`_.
-2. Ensure you have **push access** to the
-   `Sphinx Gallery pypi repository <https://pypi.org/project/sphinx-gallery/>`_.
-   Ask one of the Sphinx Gallery core developers if you do not.
-3. Install the `GitHub Changelog Generator <https://github.com/github-changelog-generator/github-changelog-generator#installation>`_.
-   This is a small tool written in Ruby to generate a markdown list of recent changes.
-4. Install `the twine package <https://twine.readthedocs.io/en/latest/>`_. This is
-   a package that helps you
-   bundle and push new Python package distributions to pip.
+      github_changelog_generator --since-tag=v<version> --token <your-40-digit-token>
 
+   To avoid the need to pass ``--token``, you can use ``export CHANGELOG_GITHUB_TOKEN=<your-40-digit-token>`` instead.
 
-Prepare for release
--------------------
-1. Update ``CHANGES.rst``
+2. Iteratively update PR labels on GitHub and regenerate ``CHANGELOG.md`` so
+   that PRs are categorized correctly. The labels we currently use are:
 
-    1. Use `github_changelog_generator
-       <https://github.com/github-changelog-generator/github-changelog-generator#installation>`_ to
-       gather all merged pull requests and closed issues during the development
-       cycle. You will likely need to `generate a Github token <https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token>`_
-       as Github only allows 50 unauthenticated requests per hour. In the
-       command below ``<version>`` is the current (not development) version of
-       the package, e.g., ``0.6.0``. We do this because our failing discipline
-       of writing in the CHANGES.rst all relevant changes, this helps our
-       memory. It is a good idea to add appropriate labels to
-       issues and pull requests so they are categorized correctly in the
-       CHANGES.rst generated. The labels we currently use are:
+   ``bug``
+      For fixed bugs.
+   ``enhancement``
+      For enhancements
+   ``maintenance``
+      For general project maintenance (e.g., CIs)
+   ``documentation``
+      For documentation improvements.
+   
+   Once all PRs land in one of these categories, manually edit CHANGELOG.md to
+   look reasonable if necessary.
 
-         ``bug``
-           For fixed bugs.
-         ``enhancement``
-           For enhancements
-         ``maintenance``
-           For general project maintenance (e.g., CIs)
-         ``documentation``
-           For documentation improvements.
+3. Propagate the relevant changes to `CHANGES.rst <https://github.com/sphinx-gallery/sphinx-gallery/blob/master/CHANGES.rst>`_.
+   You can easily convert it RST with pandoc::
 
-       The changelog can generated with the following::
+      pandoc CHANGELOG.md --wrap=none -o CHANGELOG.rst
 
-          github_changelog_generator --since-tag=v<version> --token <your-40-digit-token>
+   Then copy just the sections to ``CHANGES.rst``. **Keep ``CHANGELOG.md`` for
+   later.**
 
-       To avoid the need to pass ``--token``, you can use ``export CHANGELOG_GITHUB_TOKEN=<your-40-digit-token>`` instead.
+4. Update the version in ``sphinx_gallery/__init__.py``, which should end in
+   ``.dev0``. You should replace ``.dev0`` with ``0`` to obtain a semantic
+   version (e.g., ``0.12.dev0`` to ``0.12.0``).
 
-    2. Edit CHANGELOG.md to look reasonable (it will be used later). It's a
-       good idea to add labels to issues and pull requests and iteratively
-       re-run `github_changelog_generator` until PRs are correctly categorized
-       in the ``CHANGES.md`` file generated.
+5. Open a PR with the above **changelog** and **version** changes (along with
+   any updates to this ``maintainers.rst`` document!).
 
-    3. Propagate the relevant changes to `CHANGES.rst <https://github.com/sphinx-gallery/sphinx-gallery/blob/master/CHANGES.rst>`_.
-       You can easily convert it RST with pandoc::
+6. Make sure CIs are green.
 
-          pandoc CHANGELOG.md --wrap=none -o CHANGELOG.rst
+7. Check that the built documentation looks correct.
 
-       Then copy just the sections to ``CHANGES.rst``.
+8. Get somebody else to make sure all looks well, and merge this pull request.
 
-2. Build the docs cleanly
+2.  Finalize the release
+------------------------
 
-     Make sure to clean all and have a clean build. Double-check visually that
-     everything looks right.
-
-3. Double check CIs
-
-     Make sure CIs are green on the master branch.
-
-4. Update version
-
-     Update the version in ``sphinx_gallery/__init__.py``, which should end in
-     ``.dev0``. You should replace ``.dev0`` with ``0`` to obtain a semantic
-     version (e.g., ``0.12.dev0`` to ``0.12.0``).
-
-5. Open a Pull Request that contains the two changes we've made above
-
-     The **version bump** and **the CHANGELOG update** should be in the PR.
-     Get somebody else to make sure all looks well, and merge this pull request.
-
-Finalize the release
---------------------
-
-1. Create a new release on GitHub
+1. Make sure CIs are green following the "Release" PR.
+2. Create a new release on GitHub
 
    * Go to the `Draft a new release <https://github.com/sphinx-gallery/sphinx-gallery/releases/new>`_ page.
    * The **tag version** is whatever the version is in ``__init__.py`` prepended with ``v``. E.g., ``v0.7.0``.
@@ -111,8 +81,8 @@ Finalize the release
    * Confirm that the new version of Sphinx Gallery
      `is posted to PyPI <https://pypi.org/project/sphinx-gallery/#history>`_.
 
-2. Now that the releases are complete, we need to switch the `master`` branch
+3. Now that the releases are complete, we need to switch the `master`` branch
    back into a developer mode. Bump the `Sphinx Gallery version number <https://github.com/sphinx-gallery/sphinx-gallery/blob/master/sphinx_gallery/__init__.py>`_
    to the next minor (or major) release and append ``.dev0`` to the end, and make a PR for this change.
 
-3. Celebrate! You've just released a new version of Sphinx Gallery!
+4. Celebrate! You've just released a new version of Sphinx Gallery!

--- a/sphinx_gallery/__init__.py
+++ b/sphinx_gallery/__init__.py
@@ -6,7 +6,7 @@ Sphinx Gallery
 import os
 # dev versions should have "dev" in them, stable should not.
 # doc/conf.py makes use of this to set the version drop-down.
-__version__ = '0.12.0.dev0'
+__version__ = '0.12.0'
 
 
 def glr_path_static():


### PR DESCRIPTION
1. Add custom `maintenance` and `documentation` label support for github-changelog-generator and use them
2. Simplify github-changelog-generator use by a `.github_changelog_generator` file
3. Remove `Closed Issues` headings in changelog (we should really just track changes-by-PR)
4. Update release docs
5. Bump version number
6. Add automated PyPI release when we cut a GitHub release (shortens release process)

Will look at the rendered docs and merge if it looks good, cut a release, and then check to make sure things propagated to PyPI!