### PR TITLE
MAINT: Bump version to dev

### DIFF
--- a/sphinx_gallery/__init__.py
+++ b/sphinx_gallery/__init__.py
@@ -6,7 +6,7 @@ Sphinx Gallery
 import os
 # dev versions should have "dev" in them, stable should not.
 # doc/conf.py makes use of this to set the version drop-down.
-__version__ = '0.12.0'
+__version__ = '0.13.dev0'
 
 
 def glr_path_static():


### PR DESCRIPTION
Release appears to have worked, let's move to 0.13.dev0

https://pypi.org/project/sphinx-gallery/#history