### PR TITLE
FIX: Add blank line at end of table of contents block

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -474,6 +474,8 @@ def _format_toctree(items, includehidden=False):
 
    %s\n""" % "\n   ".join(items)
 
+    st += "\n"
+
     return st
 
 


### PR DESCRIPTION
Without this, it can come up against a next text block, e.g. subsection title, which will cause indentation error.

Example below of issue raising `...\auto_tutorials\index.rst:204:Explicit markup ends without a blank line; unexpected unindent.`

Before:
```rst
.. toctree::
   :hidden:

   /auto_tutorials/01_KalmanFilterTutorial
   /auto_tutorials/02_ExtendedKalmanFilterTutorial
   /auto_tutorials/03_UnscentedKalmanFilterTutorial
   /auto_tutorials/04_ParticleFilter
   /auto_tutorials/05_DataAssociation-Clutter
   /auto_tutorials/06_DataAssociation-MultiTargetTutorial
   /auto_tutorials/07_PDATutorial
   /auto_tutorials/08_JPDATutorial
   /auto_tutorials/09_Initiators_&_Deleters
   /auto_tutorials/10_Simulation_&_Tracking_Components
Filters
-------
Here are some tutorials which cover additional filtering techniques.
```

After (applying this PR):
```rst
.. toctree::
   :hidden:

   /auto_tutorials/01_KalmanFilterTutorial
   /auto_tutorials/02_ExtendedKalmanFilterTutorial
   /auto_tutorials/03_UnscentedKalmanFilterTutorial
   /auto_tutorials/04_ParticleFilter
   /auto_tutorials/05_DataAssociation-Clutter
   /auto_tutorials/06_DataAssociation-MultiTargetTutorial
   /auto_tutorials/07_PDATutorial
   /auto_tutorials/08_JPDATutorial
   /auto_tutorials/09_Initiators_&_Deleters
   /auto_tutorials/10_Simulation_&_Tracking_Components

Filters
-------
Here are some tutorials which cover additional filtering techniques.

```