### PR TITLE
Avoid potentially changing the matplotlib backend when scraping

### DIFF
--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -110,7 +110,10 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
         The ReSTructuredText that will be rendered to HTML containing
         the images. This is often produced by :func:`figure_rst`.
     """
-    matplotlib, plt = _import_matplotlib()
+    # Do not use _import_matplotlib() to avoid potentially changing the backend
+    import matplotlib
+    import matplotlib.pyplot as plt
+
     from matplotlib.animation import Animation
     image_path_iterator = block_vars['image_path_iterator']
     image_rsts = []


### PR DESCRIPTION
The matplotlib backend is set to `agg` in the function `_import_matplotlib()`, which is called both (1) when resetting matplotlib for each example and (2) when scraping each code block for matplotlib plots (`matplotlib_scraper()`).  The forcing of the backend to `agg` in the latter case means that an example is unable to make use of non-`agg` backends.

My particular use case is that I want to use `mplcairo` in an example to show how to use its blending operators, e.g., the example begins:
```python
import matplotlib
matplotlib.use("module://mplcairo.base")
...
```
With the current code, the matplotlib backend is immediately set back to `agg` after scraping the first code block, and so the subsequent code blocks (and the eventual plot) do not work properly.

This PR replaces the call of `_import_matplotlib()` in `matplotlib_scraper()` with direct imports of `matplotlib` and `matplotlib.pyplot`, so the backend will not be set to `agg` when scraping for matplotlib plots.  Recall that the backend will still continue to be set to `agg` when resetting matplotlib between examples.  So, the result of this PR is that an explicit call to change the backend within an example will now persist through the rest of that example, but otherwise the backend will be `agg`.