### PR TITLE
Add test for setting a non-agg Matplotlib backend

### DIFF
--- a/sphinx_gallery/tests/tinybuild/examples/plot_matplotlib_backend.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_matplotlib_backend.py
@@ -1,0 +1,24 @@
+"""
+Setting the Matplotlib backend
+==============================
+"""
+
+# %%
+# The Matplotlib backend should start as `agg`
+
+import matplotlib
+print(f"Matplotlib backend is {matplotlib.get_backend()}")
+assert matplotlib.get_backend() == "agg"
+
+# %%
+# Changing the Matplotlib backend to `svg` should be possible
+
+matplotlib.use("svg")
+print(f"Matplotlib backend is {matplotlib.get_backend()}")
+assert matplotlib.get_backend() == "svg"
+
+# %%
+# In a new code block, the Matplotlib backend should continue to be `svg`
+
+print(f"Matplotlib backend is {matplotlib.get_backend()}")
+assert matplotlib.get_backend() == "svg"


### PR DESCRIPTION
This PR adds a regression test for #1102.  If the Matplotlib backend is reset to `agg` between code blocks, the example will raise an `AssertionError` during the build of `tinybuild` in the test suite.