### PR TITLE
Fix JupyterLite URL with nested gallery folders

### DIFF
--- a/sphinx_gallery/interactive_example.py
+++ b/sphinx_gallery/interactive_example.py
@@ -356,9 +356,9 @@ def gen_jupyterlite_rst(fpath, gallery_conf):
     notebook_location = notebook_location.replace(os.path.sep, '/')
 
     if gallery_conf["jupyterlite"].get("use_jupyter_lab", True):
-        lite_root_url = "../lite/lab"
+        lite_root_url = "/lite/lab"
     else:
-        lite_root_url = "../lite/retro/notebooks"
+        lite_root_url = "/lite/retro/notebooks"
 
     lite_url = f"{lite_root_url}/?path={notebook_location}"
 

--- a/sphinx_gallery/tests/test_interactive_example.py
+++ b/sphinx_gallery/tests/test_interactive_example.py
@@ -169,9 +169,9 @@ def test_gen_jupyterlite_rst(use_jupyter_lab, tmpdir):
         os.chdir(orig_dir)
     image_rst = ' .. image:: images/jupyterlite_badge_logo.svg'
     if use_jupyter_lab:
-        target_rst = ':target: .+lite/lab.+path=mydir/myfile.ipynb'
+        target_rst = ':target: /lite/lab.+path=mydir/myfile.ipynb'
     else:
-        target_rst = ':target: .+lite/retro/notebooks.+path=mydir/myfile.ipynb'
+        target_rst = ':target: /lite/retro/notebooks.+path=mydir/myfile.ipynb'
     alt_rst = ':alt: Launch JupyterLite'
     assert image_rst in rst
     assert re.search(target_rst, rst), rst


### PR DESCRIPTION
I realised this when trying to use the feature on scikit-learn where there are nested folders 

You can also see it in sphinx-gallery, go to https://sphinx-gallery.github.io/stable/auto_examples/no_output/just_code.html, click on JupyterLite button, you will get a HTTP 404.

~Let me know if you want me to add a test for this!~ This was easy to modify an existing test so I did it!