### PR TITLE
Fix thumbnail text formatting

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -221,6 +221,9 @@ def _sanitize_rst(string):
     # :anchor:`the term` --> the term
     string = re.sub(r':[a-z]+:`([^`<>]+)( <[^`<>]+>)?`', r'\1', string)
 
+    # r'\\dfrac' --> r'\dfrac'
+    string = string.replace('\\\\', '\\')
+
     return string
 
 


### PR DESCRIPTION
Add one more sanitizing case (needed for https://matplotlib.org/stable/gallery/text_labels_and_annotations/dfrac_demo.html#sphx-glr-gallery-text-labels-and-annotations-dfrac-demo-py)

Closes #1002.
