### PR TITLE
MNT: Sync minimum sphinx version with README.rst

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-sphinx >= 3, != 5.2.0, < 6
+sphinx >= 4, != 5.2.0, < 6
 pydata-sphinx-theme
 pytest
 pytest-coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # update README.rst when changing something here
-sphinx>=3
+sphinx>=4


### PR DESCRIPTION
Minimum version was changed to >=4 in README.rst in caef783.