### PR TITLE
ENH: Add support for WebP

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -154,8 +154,8 @@ Image scrapers are functions (or callable class instances) that do the following
 things:
 
 1. Collect a list of images created in the latest execution of code.
-2. Write these images to disk in PNG, JPEG, SVG, or GIF format (with .png,
-   .jpg, .svg, or .gif extensions, respectively)
+2. Write these images to disk in PNG, JPEG, SVG, GIF, or WebP format (with .png,
+   .jpg, .svg, .gif, or .webp extensions, respectively)
 3. Return reST that embeds these figures in the built documentation.
 
 The function should take the following inputs (in this order):
@@ -197,8 +197,8 @@ reST (see below).
 
 This function will be called once for each code block of your examples.
 Sphinx-Gallery will take care of scaling images for the gallery
-index page thumbnails. PNG images are scaled using Pillow, and
-SVG images are copied.
+index page thumbnails. PNG, JPEG and WebP images are scaled using Pillow, and
+SVG and GIF images are copied.
 
 .. warning:: SVG images do not work with ``latex`` build modes, thus will not
              work while building a PDF version of your documentation.
@@ -305,8 +305,8 @@ Example 3: matplotlib with SVG format
 -------------------------------------
 The :func:`sphinx_gallery.scrapers.matplotlib_scraper` supports ``**kwargs``
 to pass to :meth:`matplotlib.figure.Figure.savefig`, one of which is the
-``format`` argument. Currently Sphinx-Gallery supports PNG (default) and SVG
-output formats. To use SVG, you can do::
+``format`` argument. See :ref:`custom_scraper` for supported formats.
+To use SVG, you can do::
 
     from sphinx_gallery.scrapers import matplotlib_scraper
 

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -100,8 +100,8 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
         Additional keyword arguments to pass to
         :meth:`~matplotlib.figure.Figure.savefig`, e.g. ``format='svg'``.
         The ``format`` kwarg in particular is used to set the file extension
-        of the output file (currently only 'png', 'jpg', and 'svg' are
-        supported).
+        of the output file (currently only 'png', 'jpg', 'svg', 'gif', and
+        'webp' are supported).
 
     Returns
     -------
@@ -300,7 +300,8 @@ class ImagePathIterator:
 
 
 # For now, these are what we support
-_KNOWN_IMG_EXTS = ('png', 'svg', 'jpg', 'gif')
+# Update advanced.rst if this list is changed
+_KNOWN_IMG_EXTS = ('png', 'svg', 'jpg', 'gif', 'webp')
 
 
 def _find_image_ext(path):

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -30,7 +30,7 @@ import pytest
 
 # total number of plot_*.py files in tinybuild/examples + examples_rst_index
 # + examples_with_rst
-N_EXAMPLES = 14 + 3 + 2
+N_EXAMPLES = 15 + 3 + 2
 N_FAILING = 2
 N_GOOD = N_EXAMPLES - N_FAILING  # galleries that run w/o error
 # passthroughs examples_rst_index, examples_with_rst
@@ -289,6 +289,7 @@ def test_image_formats(sphinx_app):
     thumb_fnames = ['../_images/sphx_glr_plot_svg_thumb.svg',
                     '../_images/sphx_glr_plot_numpy_matplotlib_thumb.png',
                     '../_images/sphx_glr_plot_animation_thumb.gif',
+                    '../_images/sphx_glr_plot_webp_thumb.webp',
                     ]
     for thumb_fname in thumb_fnames:
         file_fname = op.join(generated_examples_dir, thumb_fname)
@@ -300,7 +301,8 @@ def test_image_formats(sphinx_app):
     for ex, ext, nums, extra in (
             ('plot_svg', 'svg', [1], None),
             ('plot_numpy_matplotlib', 'png', [1], None),
-            ('plot_animation', 'png', [1, 3], 'function Animation')):
+            ('plot_animation', 'png', [1, 3], 'function Animation'),
+            ('plot_webp', 'webp', [1], None)):
         html_fname = op.join(generated_examples_dir, '%s.html' % ex)
         with codecs.open(html_fname, 'r', 'utf-8') as fid:
             html = fid.read()
@@ -314,7 +316,8 @@ def test_image_formats(sphinx_app):
                           (ex, num, ext))
             file_fname2 = op.join(generated_examples_dir, img_fname2)
             want_html = f'srcset="{img_fname0}, {img_fname2} 2.00x"'
-            if ext in ('png', 'jpg', 'svg'):  # check 2.00x (tests directive)
+            if ext in ('png', 'jpg', 'svg', 'webp'):
+                # check 2.00x (tests directive)
                 assert op.isfile(file_fname2), file_fname2
                 assert want_html in html
 

--- a/sphinx_gallery/tests/tinybuild/doc/conf.py
+++ b/sphinx_gallery/tests/tinybuild/doc/conf.py
@@ -13,6 +13,9 @@ class matplotlib_format_scraper:
         if op.basename(block_vars['target_file']) == 'plot_svg.py' and \
                 gallery_conf['builder_name'] != 'latex':
             kwargs['format'] = 'svg'
+        elif op.basename(block_vars['target_file']) == 'plot_webp.py' and \
+                gallery_conf['builder_name'] != 'latex':
+            kwargs['format'] = 'webp'
         return matplotlib_scraper(block, block_vars, gallery_conf, **kwargs)
 
 

--- a/sphinx_gallery/tests/tinybuild/examples/plot_webp.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_webp.py
@@ -1,0 +1,9 @@
+"""
+============
+Save as WebP
+============
+"""
+
+import matplotlib.pyplot as plt
+
+plt.plot([1, 2])


### PR DESCRIPTION
and update docs on supported formats.

[WebP](https://en.wikipedia.org/wiki/WebP) yields much smaller file sizes than optimized png in only very little more time. For the Matplotlib docs with 2637 `sphx-glr...` files I got the following results:

|                                          | Total size in MB | Percentage of orginal size | Extra time|
|---------------------------- |:-----------------:|:---------------------------:|------------|
plain png                           | 162.4 | 100 % | -  |
optipng -o7                       | 115.9 | 71 %  | 4:35 hrs |
webp lossless quality=100 | 65.5  | 40 % | 9 mins  |



<br>  
<hr>  

My first thought was to integrate the `_KNOWN_IMG_EXTS` list into the docstring of [`matplotlib_scraper`](https://github.com/sphinx-gallery/sphinx-gallery/blob/b17bf5500a6b3340725cbf01207a2c3d1da14c3b/sphinx_gallery/scrapers.py#L103-L105) but the only solution I found for it is https://stackoverflow.com/a/10308363/3944322 and I think it's a bit of overkill, isn't it?


Do we need tests for it? [`test_custom_scraper_thumbnail_alpha`](https://github.com/sphinx-gallery/sphinx-gallery/blob/b17bf5500a6b3340725cbf01207a2c3d1da14c3b/sphinx_gallery/tests/test_gen_rst.py#L445) could be parameterized with `_KNOWN_IMG_EXTS` but I'm not sure if this really gives more/better test coverage.

Closes #1055