### PR TITLE
ENH Add functionality to modify Jupyterlite notebooks based on their content

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -371,7 +371,7 @@ min_reported_time = 0
 if 'SOURCE_DATE_EPOCH' in os.environ:
     min_reported_time = sys.maxint if sys.version_info[0] == 2 else sys.maxsize
 
-def notebook_modification_function(notebook_content):
+def notebook_modification_function(notebook_content, notebook_filename):
     markdown = "\n".join(
         ["<div class='alert alert-danger'>",
          "<h1>JupyterLite warnings</h1>",
@@ -419,7 +419,9 @@ sphinx_gallery_conf = {
                'notebooks_dir': 'notebooks',
                'use_jupyter_lab': True,
                },
-    'jupyterlite': {'notebook_modification_function': notebook_modification_function},
+    'jupyterlite': {
+        'notebook_modification_function': notebook_modification_function
+    },
     'show_memory': True,
     'promote_jupyter_magic': False,
     'junit': os.path.join('sphinx-gallery', 'junit-results.xml'),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,6 +19,7 @@ import warnings
 
 import sphinx_gallery
 from sphinx_gallery.sorting import FileNameSortKey
+from sphinx_gallery.notebook import add_markdown_cell, add_code_cell
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -370,6 +371,26 @@ min_reported_time = 0
 if 'SOURCE_DATE_EPOCH' in os.environ:
     min_reported_time = sys.maxint if sys.version_info[0] == 2 else sys.maxsize
 
+def notebook_modification_function(notebook_content):
+    markdown = "\n".join(
+        ["<div class='alert alert-danger'>",
+         "<h1>JupyterLite warnings</h1>",
+         "",
+         "JupyterLite integration in sphinx-gallery is beta "
+         "and it may break in weird ways",
+         "</div>"
+        ]
+    )
+    dummy_notebook_content = {'cells': []}
+    add_markdown_cell(dummy_notebook_content, markdown)
+
+    if "seaborn" in str(notebook_content):
+        code = "%pip install seaborn"
+        add_code_cell(dummy_notebook_content, code)
+
+    notebook_content["cells"] = dummy_notebook_content["cells"] + notebook_content["cells"]
+
+
 sphinx_gallery_conf = {
     'backreferences_dir': 'gen_modules/backreferences',
     'doc_module': ('sphinx_gallery', 'numpy'),
@@ -393,6 +414,7 @@ sphinx_gallery_conf = {
                'notebooks_dir': 'notebooks',
                'use_jupyter_lab': True,
                },
+    'jupyterlite': {'notebook_modification_function': notebook_modification_function},
     'show_memory': True,
     'promote_jupyter_magic': False,
     'junit': os.path.join('sphinx-gallery', 'junit-results.xml'),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -384,8 +384,13 @@ def notebook_modification_function(notebook_content):
     dummy_notebook_content = {'cells': []}
     add_markdown_cell(dummy_notebook_content, markdown)
 
-    if "seaborn" in str(notebook_content):
-        code = "%pip install seaborn"
+    code_lines = []
+    notebook_content_str = str(notebook_content)
+    if "seaborn" in notebook_content:
+        code_lines.append("%pip install seaborn")
+
+    if code_lines:
+        code = "\n".join(code_lines)
         add_code_cell(dummy_notebook_content, code)
 
     notebook_content["cells"] = dummy_notebook_content["cells"] + notebook_content["cells"]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -371,46 +371,45 @@ min_reported_time = 0
 if 'SOURCE_DATE_EPOCH' in os.environ:
     min_reported_time = sys.maxint if sys.version_info[0] == 2 else sys.maxsize
 
+
 def notebook_modification_function(notebook_content, notebook_filename):
     notebook_content_str = str(notebook_content)
+    warning_template = "\n".join(
+        [
+            "<div class='alert alert-{message_class}'>",
+            "",
+            "# JupyterLite warning",
+            "",
+            "{message}",
+            "</div>"
+        ]
+    )
 
     if "pyvista_examples" in notebook_filename:
-        markdown = "\n".join(
-            [
-                "<div class='alert alert-danger'>",
-                "<h1>JupyterLite warning</h1>",
-                "",
-                "PyVista is not packaged in Pyodide, this notebook is not "
-                "expected to work inside JupyterLite"
-                "</div>"
-
-            ]
+        message_class = "danger"
+        message = (
+            "PyVista is not packaged in Pyodide, this notebook is not "
+            "expected to work inside JupyterLite"
         )
     elif "import plotly" in notebook_content_str:
-        markdown = "\n".join(
-            [
-                "<div class='alert alert-danger'>",
-                "<h1>JupyterLite warning</h1>",
-                "",
-                "This notebook is not expected to work inside JupyterLite for now. "
-                "There seems to be some issues with Plotly, see "
-                "<a href='https://github.com/jupyterlite/jupyterlite/pull/950'>this</a> "
-                "for more details."
-                "</div>"
-
-            ]
+        message_class = "danger"
+        message = (
+            "This notebook is not expected to work inside JupyterLite for now."
+            " There seems to be some issues with Plotly, see "
+            "[this]('https://github.com/jupyterlite/jupyterlite/pull/950') "
+            "for more details."
         )
     else:
-        markdown = "\n".join(
-            [
-                "<div class='alert alert-warning'>",
-                "<h1>JupyterLite warning</h1>",
-                "",
-                "JupyterLite integration in sphinx-gallery is beta "
-                "and it may break in weird ways",
-                "</div>"
-            ]
+        message_class = "warning"
+        message = (
+            "JupyterLite integration in sphinx-gallery is beta "
+            "and it may break in unexpected ways"
         )
+
+    markdown = warning_template.format(
+        message_class=message_class,
+        message=message
+    )
 
     dummy_notebook_content = {'cells': []}
     add_markdown_cell(dummy_notebook_content, markdown)
@@ -425,7 +424,9 @@ def notebook_modification_function(notebook_content, notebook_filename):
         code = "\n".join(code_lines)
         add_code_cell(dummy_notebook_content, code)
 
-    notebook_content["cells"] = dummy_notebook_content["cells"] + notebook_content["cells"]
+    notebook_content["cells"] = (
+        dummy_notebook_content["cells"] + notebook_content["cells"]
+    )
 
 
 sphinx_gallery_conf = {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -372,24 +372,56 @@ if 'SOURCE_DATE_EPOCH' in os.environ:
     min_reported_time = sys.maxint if sys.version_info[0] == 2 else sys.maxsize
 
 def notebook_modification_function(notebook_content, notebook_filename):
-    markdown = "\n".join(
-        ["<div class='alert alert-danger'>",
-         "<h1>JupyterLite warnings</h1>",
-         "",
-         "JupyterLite integration in sphinx-gallery is beta "
-         "and it may break in weird ways",
-         "</div>"
-        ]
-    )
+    notebook_content_str = str(notebook_content)
+
+    if "pyvista_examples" in notebook_filename:
+        markdown = "\n".join(
+            [
+                "<div class='alert alert-danger'>",
+                "<h1>JupyterLite warning</h1>",
+                "",
+                "PyVista is not packaged in Pyodide, this notebook is not "
+                "expected to work inside JupyterLite"
+                "</div>"
+
+            ]
+        )
+    elif "import plotly" in notebook_content_str:
+        markdown = "\n".join(
+            [
+                "<div class='alert alert-danger'>",
+                "<h1>JupyterLite warning</h1>",
+                "",
+                "This notebook is not expected to work inside JupyterLite for now. "
+                "There seems to be some issues with Plotly, see "
+                "<a href='https://github.com/jupyterlite/jupyterlite/pull/950'>this</a> "
+                "for more details."
+                "</div>"
+
+            ]
+        )
+    else:
+        markdown = "\n".join(
+            [
+                "<div class='alert alert-warning'>",
+                "<h1>JupyterLite warning</h1>",
+                "",
+                "JupyterLite integration in sphinx-gallery is beta "
+                "and it may break in weird ways",
+                "</div>"
+            ]
+        )
+
     dummy_notebook_content = {'cells': []}
     add_markdown_cell(dummy_notebook_content, markdown)
 
     code_lines = []
-    notebook_content_str = str(notebook_content)
-    if "seaborn" in notebook_content:
+
+    if "seaborn" in notebook_content_str:
         code_lines.append("%pip install seaborn")
 
     if code_lines:
+        code_lines = ["# JupyterLite-specific code"] + code_lines
         code = "\n".join(code_lines)
         add_code_cell(dummy_notebook_content, code)
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1157,8 +1157,6 @@ You then need to add `jupyterlite_sphinx` to your Sphinx extensions in
 
     extensions = [
         ...,
-        ...,
-        ...,
         'jupyterlite_sphinx',
     ]
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1168,8 +1168,9 @@ You can configure JupyterLite integration by setting
     sphinx_gallery_conf = {
       ...
       'jupyterlite': {
-         'jupyterlite_contents': <str> # JupyterLite contents where to copy the example notebooks (relative to Sphinx source directory)
-         'use_jupyter_lab': <bool> # Whether JupyterLite links should start Jupyter Lab instead of the Retrolab Notebook interface.
+         'use_jupyter_lab': <bool>, # Whether JupyterLite links should start Jupyter Lab instead of the Retrolab Notebook interface.
+         'notebook_modification_function': <function>, # function that implements JupyterLite-specific modifications of notebooks
+         'jupyterlite_contents': <str>, # JupyterLite contents where to copy the example notebooks (relative to Sphinx source directory)
          }
     }
 
@@ -1179,12 +1180,28 @@ use_jupyter_lab (type: bool, default: ``True``)
   Whether the default interface activated by the JupyterLite link will be for
   Jupyter Lab or the RetroLab Notebook interface.
 
-jupyterlite_contents (type: string, default: ``jupyterlite_contents``) The name
-  of a folder where the built Jupyter notebooks will be copied, relative to the
-  Sphinx source directory. This is used as Jupyterlite contents.
+notebook_modification_function (type: function, default: ``None``)
+  Function that implements JupyterLite-specific modifications of notebooks. By
+  default, it is ``None`` which means that notebooks are not going to be
+  modified. Its signature should be ``notebook_modification_function(json_dict:
+  dict, notebook_filename: str) -> None`` where ``json_dict`` is what you get
+  when you do ``json.load(open(notebook_filename))``. The function is expected
+  to modify ``json_dict`` in place by adding notebook cells. It is not expected
+  to write to the file, since ``sphinx-gallery`` is in charge of this.
+  ``notebook_filename`` is provided for convenience becauses it is useful to
+  modify the notebook based on its filename. Potential usages of this function
+  are installing additional packages with a ``%pip install seaborn`` code cell,
+  or adding a markdown cell to indicate that a notebook is not expected to work
+  inside JupyterLite, for example because it is using packages that are not
+  packaged inside Pyodide.
+
+jupyterlite_contents (type: string, default: ``jupyterlite_contents``)
+  The name of a folder where the built Jupyter notebooks will be copied,
+  relative to the Sphinx source directory. This is used as Jupyterlite
+  contents.
 
 You can set variables in ``conf.py`` to configure ``jupyterlite-sphinx``, see
-its `jupyterlite-sphinx doc
+the `jupyterlite-sphinx doc
 <https://jupyterlite-sphinx.readthedocs.io/en/latest/configuration.html>`__ for
 more details.
 
@@ -1196,9 +1213,11 @@ extra things will happen:
 2. The built Jupyter Notebooks from the documentation will be copied to a
    folder called ``<jupyterlite_contents>/`` (relative to Sphinx source
    directory)
-3. The rST output of each Sphinx-Gallery example will now have a
+3. If ``notebook_modification_function`` is not None, this function is going to
+   add JupyterLite-specific modifications to notebooks
+4. The rST output of each Sphinx-Gallery example will now have a
    ``launch JupyterLite`` button in it.
-4. That button will point to a JupyterLite link which will start a Jupyter
+5. That button will point to a JupyterLite link which will start a Jupyter
    server in your browser with the current example as notebook
 
 If, for some reason, you want to enable the ``jupyterlite-sphinx`` extension

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1131,7 +1131,7 @@ are:
 - with JupyterLite the first imports take time. At the time of writing
   (February 2023) ``import scipy`` can take ~15-30s. Some innocuously looking
   Python code may just not work and break in an unexpected fashion. The Jupyter
-  kernel is based on Pyodide, see some `here
+  kernel is based on Pyodide, see `here
   <https://pyodide.org/en/latest/usage/wasm-constraints.html>`__ for some
   Pyodide limitations.
 - with JupyterLite environments are not as flexible as Binder, for example you
@@ -1188,7 +1188,7 @@ notebook_modification_function (type: function, default: ``None``)
   when you do ``json.load(open(notebook_filename))``. The function is expected
   to modify ``json_dict`` in place by adding notebook cells. It is not expected
   to write to the file, since ``sphinx-gallery`` is in charge of this.
-  ``notebook_filename`` is provided for convenience becauses it is useful to
+  ``notebook_filename`` is provided for convenience because it is useful to
   modify the notebook based on its filename. Potential usages of this function
   are installing additional packages with a ``%pip install seaborn`` code cell,
   or adding a markdown cell to indicate that a notebook is not expected to work
@@ -1213,8 +1213,8 @@ extra things will happen:
 2. The built Jupyter Notebooks from the documentation will be copied to a
    folder called ``<jupyterlite_contents>/`` (relative to Sphinx source
    directory)
-3. If ``notebook_modification_function`` is not None, this function is going to
-   add JupyterLite-specific modifications to notebooks
+3. If ``notebook_modification_function`` is not ``None``, this function is
+   going to add JupyterLite-specific modifications to notebooks
 4. The rST output of each Sphinx-Gallery example will now have a
    ``launch JupyterLite`` button in it.
 5. That button will point to a JupyterLite link which will start a Jupyter

--- a/sphinx_gallery/interactive_example.py
+++ b/sphinx_gallery/interactive_example.py
@@ -341,7 +341,8 @@ def create_jupyterlite_contents(app, exception):
         return
 
     notebook_pattern = os.path.join(contents_dir, "**", "*.ipynb")
-    notebook_filename_list = glob.glob(notebook_pattern, recursive=True)
+    notebook_filename_list = sorted(
+        glob.glob(notebook_pattern, recursive=True))
 
     logger.info('Modifying Jupyterlite notebooks ...', color='white')
     for notebook_filename in notebook_filename_list:

--- a/sphinx_gallery/interactive_example.py
+++ b/sphinx_gallery/interactive_example.py
@@ -354,13 +354,7 @@ def create_jupyterlite_contents(app, exception):
         with open(notebook_filename) as f:
             notebook_content = json.load(f)
 
-        # TODO decide whether I should pass the filename as well? This can be
-        # useful to modify notebooks based on folder or filename (all the
-        # mayavi stuff should have a big warning saying this is not going to
-        # work, easier by filename than by content). An alternative would be to
-        # have input=filename argument but you have more boilerplate code in
-        # conf.py ...
-        notebook_modification_function(notebook_content)
+        notebook_modification_function(notebook_content, notebook_filename)
 
         with open(notebook_filename, "w") as f:
             json.dump(notebook_content, f)

--- a/sphinx_gallery/interactive_example.py
+++ b/sphinx_gallery/interactive_example.py
@@ -351,7 +351,7 @@ def create_jupyterlite_contents(app, exception):
         notebook_modification_function(notebook_content, notebook_filename)
 
         with open(notebook_filename, "w") as f:
-            json.dump(notebook_content, f)
+            json.dump(notebook_content, f, indent=2)
 
 
 def gen_jupyterlite_rst(fpath, gallery_conf):

--- a/sphinx_gallery/interactive_example.py
+++ b/sphinx_gallery/interactive_example.py
@@ -433,7 +433,7 @@ def check_jupyterlite_conf(jupyterlite_conf, app):
             '`jupyterlite_conf` must be a dictionary')
 
     result = jupyterlite_conf.copy()
-    jupyterlite_conf.setdefault('use_jupyter_lab', True)
+    result.setdefault('use_jupyter_lab', True)
     result.setdefault('jupyterlite_contents', 'jupyterlite_contents')
     result['jupyterlite_contents'] = os.path.join(
         app.srcdir,

--- a/sphinx_gallery/interactive_example.py
+++ b/sphinx_gallery/interactive_example.py
@@ -334,12 +334,6 @@ def create_jupyterlite_contents(app, exception):
                         os.path.join(contents_dir, i_folder),
                         ignore=_remove_ipynb_files)
 
-    # What's the interface should be like?
-    # - input=filename, and function is expected to write to filename
-    # - input=Python object (json.load(filename)), function modifies object in
-    #   place
-    #
-    # For now doing input=Python object
     notebook_modification_function = gallery_conf['jupyterlite'][
         'notebook_modification_function']
 

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -14,6 +14,8 @@ import re
 import shutil
 import sys
 import time
+import glob
+import json
 
 from packaging.version import Version
 
@@ -1062,3 +1064,20 @@ def test_no_dummy_image(sphinx_app):
                    'sphx_glr_plot_repr_002.png')
     assert not op.isfile(img1)
     assert not op.isfile(img2)
+
+
+def test_jupyterlite_modifications(sphinx_app):
+    src_dir = sphinx_app.srcdir
+    jupyterlite_notebook_pattern = op.join(src_dir, 'jupyterlite_contents', '**', '*.ipynb')
+    jupyterlite_notebook_filenames = glob.glob(jupyterlite_notebook_pattern, recursive=True)
+
+    for notebook_filename in jupyterlite_notebook_filenames:
+        with open(notebook_filename) as f:
+            notebook_content = json.load(f)
+
+        first_cell = notebook_content['cells'][0]
+        assert first_cell['cell_type'] == 'markdown'
+        assert (
+            f"JupyterLite-specific change for {notebook_filename}"
+            in first_cell['source']
+    )

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -1068,8 +1068,10 @@ def test_no_dummy_image(sphinx_app):
 
 def test_jupyterlite_modifications(sphinx_app):
     src_dir = sphinx_app.srcdir
-    jupyterlite_notebook_pattern = op.join(src_dir, 'jupyterlite_contents', '**', '*.ipynb')
-    jupyterlite_notebook_filenames = glob.glob(jupyterlite_notebook_pattern, recursive=True)
+    jupyterlite_notebook_pattern = op.join(
+        src_dir, 'jupyterlite_contents', '**', '*.ipynb')
+    jupyterlite_notebook_filenames = glob.glob(
+        jupyterlite_notebook_pattern, recursive=True)
 
     for notebook_filename in jupyterlite_notebook_filenames:
         with open(notebook_filename) as f:
@@ -1080,4 +1082,4 @@ def test_jupyterlite_modifications(sphinx_app):
         assert (
             f"JupyterLite-specific change for {notebook_filename}"
             in first_cell['source']
-    )
+        )

--- a/sphinx_gallery/tests/test_interactive_example.py
+++ b/sphinx_gallery/tests/test_interactive_example.py
@@ -206,5 +206,19 @@ def test_check_jupyterlite_conf():
         'use_jupyter_lab': False,
         'notebook_modification_function': None,
     }
+    assert check_jupyterlite_conf(conf, app) == expected
+
+    def notebook_modification_function(notebook_content, notebook_filename):
+        pass
+
+    conf = {
+        'notebook_modification_function': notebook_modification_function
+    }
+
+    expected = {
+        'jupyterlite_contents': os.path.join('srcdir', 'jupyterlite_contents'),
+        'use_jupyter_lab': True,
+        'notebook_modification_function': notebook_modification_function,
+    }
 
     assert check_jupyterlite_conf(conf, app) == expected

--- a/sphinx_gallery/tests/test_interactive_example.py
+++ b/sphinx_gallery/tests/test_interactive_example.py
@@ -192,7 +192,8 @@ def test_check_jupyterlite_conf():
     assert check_jupyterlite_conf(None, app) is None
     assert check_jupyterlite_conf({}, app) == {
         'jupyterlite_contents': os.path.join('srcdir', 'jupyterlite_contents'),
-        'use_jupyter_lab': True
+        'use_jupyter_lab': True,
+        'notebook_modification_function': None,
     }
 
     conf = {
@@ -202,7 +203,8 @@ def test_check_jupyterlite_conf():
     expected = {
         'jupyterlite_contents': os.path.join(
             'srcdir', 'this_is_the_contents_dir'),
-        'use_jupyter_lab': False
+        'use_jupyter_lab': False,
+        'notebook_modification_function': None,
     }
 
     assert check_jupyterlite_conf(conf, app) == expected

--- a/sphinx_gallery/tests/tinybuild/doc/conf.py
+++ b/sphinx_gallery/tests/tinybuild/doc/conf.py
@@ -71,6 +71,18 @@ intersphinx_mapping = {
     'matplotlib': ('https://matplotlib.org/stable/', None),
     'joblib': ('https://joblib.readthedocs.io/en/latest', None),
 }
+
+
+def notebook_modification_function(notebook_content, notebook_filename):
+    source = f'JupyterLite-specific change for {notebook_filename}'
+    markdown_cell = {
+        'cell_type': 'markdown',
+        'metadata': {},
+        'source': source
+    }
+    notebook_content['cells'] = [markdown_cell] + notebook_content['cells']
+
+
 sphinx_gallery_conf = {
     'doc_module': ('sphinx_gallery',),
     'reference_url': {
@@ -85,6 +97,9 @@ sphinx_gallery_conf = {
                'notebooks_dir': 'notebooks',
                'use_jupyter_lab': True,
                },
+    'jupyterlite': {
+        'notebook_modification_function': notebook_modification_function
+    },
     'examples_dirs': ['../examples/', '../examples_with_rst/',
                       '../examples_rst_index'],
     'reset_argv': ResetArgv(),


### PR DESCRIPTION
To be able to run in JupyterLite, notebooks may need additional code, e.g. `%pip install seaborn` since `seaborn` (or any pure-Python code) is not part of Pyodide.

Also this allows to put a warning in a markdown cell to manage user expectations at the beginning of the notebook. We could add a better warning for notebooks that we don't expect to run any time soon, e.g. the ones using pyvista.

No tests or doc for now, but this still may be enough to get some feed-back on the code.

xref https://github.com/sphinx-gallery/sphinx-gallery/issues/1100