### PR TITLE
FIX JupyterLite button links

### DIFF
--- a/sphinx_gallery/interactive_example.py
+++ b/sphinx_gallery/interactive_example.py
@@ -339,7 +339,7 @@ def gen_jupyterlite_rst(fpath, gallery_conf):
     Parameters
     ----------
     fpath: str
-        The path to the `.ipynb` file for which a JupyterLite badge will be
+        The path to the `.py` file for which a JupyterLite badge will be
         generated.
 
     gallery_conf : dict
@@ -355,10 +355,17 @@ def gen_jupyterlite_rst(fpath, gallery_conf):
     # Make sure we have the right slashes (in case we're on Windows)
     notebook_location = notebook_location.replace(os.path.sep, '/')
 
+    lite_root_url = os.path.relpath(
+        os.path.join(gallery_conf['src_dir'], 'lite'),
+        os.path.dirname(fpath)
+    )
+    # Make sure we have the right slashes (in case we're on Windows)
+    lite_root_url = lite_root_url.replace(os.path.sep, '/')
+
     if gallery_conf["jupyterlite"].get("use_jupyter_lab", True):
-        lite_root_url = "/lite/lab"
+        lite_root_url += "/lab"
     else:
-        lite_root_url = "/lite/retro/notebooks"
+        lite_root_url += "/retro/notebooks"
 
     lite_url = f"{lite_root_url}/?path={notebook_location}"
 

--- a/sphinx_gallery/tests/test_interactive_example.py
+++ b/sphinx_gallery/tests/test_interactive_example.py
@@ -176,7 +176,9 @@ def test_gen_jupyterlite_rst(use_jupyter_lab, example_file, tmpdir):
         os.chdir(orig_dir)
     image_rst = ' .. image:: images/jupyterlite_badge_logo.svg'
 
-    target_rst_template = ':target: {root_url}/lite/{jupyter_part}.+path={notebook_path}'
+    target_rst_template = (
+        ':target: {root_url}/lite/{jupyter_part}.+path={notebook_path}'
+    )
     if 'subdir' not in file_path:
         root_url = r'\.\.'
         notebook_path = r'example_dir/myfile\.ipynb'


### PR DESCRIPTION
Turns out #1105 was not the right fix, we need to use a relative URL. For example if I copy `_build/html` to a repo like https://github.com/lesteve/sphinx-gallery-jupyterlite, an example html page is 
https://lesteve.github.io/sphinx-gallery-jupyterlite/auto_examples/no_output/plot_raise.html
and I want the link to go to
`https://lesteve.github.io/sphinx-gallery-jupyterlite/lite` so `../../lite`. `/lite` as done in #1105 goes to `https://lesteve.github.io/lite` which is incorrect. If the example is one folder above you want `../lite` instead. This is why I use `os.path.relpath` to get the root URL.

I have added more tests as well with a nested gallery folder (aka sub-gallery I think).