### PR TITLE
ENH raise error in check_jupyterlite_conf with unknown key

### DIFF
--- a/sphinx_gallery/interactive_example.py
+++ b/sphinx_gallery/interactive_example.py
@@ -428,12 +428,24 @@ def check_jupyterlite_conf(jupyterlite_conf, app):
         raise ConfigError(
             '`jupyterlite_conf` must be a dictionary')
 
+    conf_defaults = {
+        'jupyterlite_contents': 'jupyterlite_contents',
+        'notebook_modification_function': None,
+        'use_jupyter_lab': True,
+    }
+
     result = jupyterlite_conf.copy()
-    result.setdefault('use_jupyter_lab', True)
-    result.setdefault('jupyterlite_contents', 'jupyterlite_contents')
+    unknown_keys = set(result) - set(conf_defaults)
+    if unknown_keys:
+        raise ConfigError(
+            f"Found some unknown keys in sphinx_gallery_conf['jupyterlite']: "
+            f"{list(unknown_keys)}. "
+            f"Allowed keys are: {list(conf_defaults)}")
+
+    for key, default_value in conf_defaults.items():
+        result.setdefault(key, default_value)
     result['jupyterlite_contents'] = os.path.join(
         app.srcdir,
         result['jupyterlite_contents'])
-    result.setdefault('notebook_modification_function', None)
 
     return result

--- a/sphinx_gallery/interactive_example.py
+++ b/sphinx_gallery/interactive_example.py
@@ -439,7 +439,7 @@ def check_jupyterlite_conf(jupyterlite_conf, app):
     if unknown_keys:
         raise ConfigError(
             f"Found some unknown keys in sphinx_gallery_conf['jupyterlite']: "
-            f"{list(unknown_keys)}. "
+            f"{sorted(unknown_keys)}. "
             f"Allowed keys are: {list(conf_defaults)}")
 
     for key, default_value in conf_defaults.items():

--- a/sphinx_gallery/tests/test_interactive_example.py
+++ b/sphinx_gallery/tests/test_interactive_example.py
@@ -248,8 +248,15 @@ def test_check_jupyterlite_conf():
     assert check_jupyterlite_conf(conf, app) == expected
 
     match = (
-        'Found.+unknown keys.+unknown_key.+Allowed keys are.+'
-        'jupyterlite_contents.+notebook_modification_function.+use_jupyter_lab'
+        'Found.+unknown keys.+another_unknown_key.+unknown_key.+'
+        'Allowed keys are.+jupyterlite_contents.+'
+        'notebook_modification_function.+use_jupyter_lab'
     )
     with pytest.raises(ConfigError, match=match):
-        check_jupyterlite_conf({'unknown_key': 'value'}, app)
+        check_jupyterlite_conf(
+            {
+                'unknown_key': 'value',
+                'another_unknown_key': 'another_value'
+            },
+            app
+        )

--- a/sphinx_gallery/tests/test_interactive_example.py
+++ b/sphinx_gallery/tests/test_interactive_example.py
@@ -246,3 +246,10 @@ def test_check_jupyterlite_conf():
     }
 
     assert check_jupyterlite_conf(conf, app) == expected
+
+    match = (
+        'Found.+unknown keys.+unknown_key.+Allowed keys are.+'
+        'jupyterlite_contents.+notebook_modification_function.+use_jupyter_lab'
+    )
+    with pytest.raises(ConfigError, match=match):
+        check_jupyterlite_conf({'unknown_key': 'value'}, app)


### PR DESCRIPTION
This raises an informative error when `sphinx_gallery_conf['jupyterlite']` contains keys that are not expected.

This is useful to detect typos in the key.