### PR TITLE
ENH: Create backreferences for default roles

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -446,7 +446,9 @@ enables you to link to any examples that either:
    code.
 2. Refer to that function/method/attribute/object/class using sphinx markup
    ``:func:``/``:meth:``/``:attr:``/``:obj:``/``:class:`` in a text
-   block.
+   block. You can omit this role markup if you have set the `default_role
+   <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-default_role>`_
+   in your ``conf.py`` to any of these roles.
 
 The former is useful for auto-documenting functions that are used and classes
 that are explicitly instantiated. The generated links are called implicit

--- a/examples/plot_6_function_identifier.py
+++ b/examples/plot_6_function_identifier.py
@@ -29,7 +29,7 @@ This functionality is used to add documentation hyperlinks to your code
 import os.path as op  # noqa, analysis:ignore
 import matplotlib.pyplot as plt
 import sphinx_gallery
-from sphinx_gallery.backreferences import identify_names
+from sphinx_gallery.backreferences import identify_names, _make_ref_regex
 from sphinx_gallery.py_source_parser import split_code_and_text_blocks
 
 filename = 'plot_6_function_identifier.py'
@@ -39,7 +39,7 @@ if not op.exists(filename):
 
 _, script_blocks = split_code_and_text_blocks(filename)
 
-names = identify_names(script_blocks)
+names = identify_names(script_blocks, _make_ref_regex())
 
 # %%
 # In the code block above, we use the internal function ``identify_names`` to

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -40,8 +40,8 @@ from .utils import (replace_py_ipynb, scale_image, get_md5sum, _replace_md5,
                     optipng)
 from . import glr_path_static
 from .backreferences import (_write_backreferences, _thumbnail_div,
-                             identify_names, THUMBNAIL_PARENT_DIV,
-                             THUMBNAIL_PARENT_DIV_CLOSE)
+                             identify_names, _make_ref_regex,
+                             THUMBNAIL_PARENT_DIV, THUMBNAIL_PARENT_DIV_CLOSE)
 from .downloads import CODE_DOWNLOAD
 from .py_source_parser import (split_code_and_text_blocks,
                                remove_config_comments,
@@ -1134,7 +1134,9 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf,
         global_variables = script_vars['example_globals']
     else:
         global_variables = None
-    example_code_obj = identify_names(script_blocks, global_variables, node)
+    ref_regex = _make_ref_regex(gallery_conf['app'].config)
+    example_code_obj = identify_names(script_blocks, ref_regex,
+                                      global_variables, node)
     if example_code_obj:
         codeobj_fname = target_file[:-3] + '_codeobj.pickle.new'
         with open(codeobj_fname, 'wb') as fid:

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -27,8 +27,11 @@ def pytest_report_header(config, startdir):
 @pytest.fixture
 def gallery_conf(tmpdir):
     """Set up a test sphinx-gallery configuration."""
-    app = Mock(spec=Sphinx, config=dict(source_suffix={'.rst': None}),
-               extensions=[])
+    app = Mock(
+        spec=Sphinx,
+        config=dict(source_suffix={".rst": None}, default_role=None),
+        extensions=[],
+    )
     gallery_conf = gen_gallery._fill_gallery_conf_defaults(
         {},  app=app)
     gen_gallery._update_gallery_conf_builder_inited(

--- a/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
@@ -39,7 +39,9 @@ x = Figure()  # plt.Figure should be decorated (class), x shouldn't (inst)
 # nested resolution resolves to numpy.random.mtrand.RandomState:
 rng = np.random.RandomState(0)
 # test Issue 583
-sphinx_gallery.backreferences.identify_names([('text', 'Text block', 1)])
+sphinx_gallery.backreferences.identify_names(
+    [('text', 'Text block', 1)],
+    sphinx_gallery.backreferences._make_ref_regex({'default_role': None}))
 # 583: methods don't link properly
 dc = sphinx_gallery.backreferences.DummyClass()
 dc.run()


### PR DESCRIPTION
When adding mini-galleries for API documentation, only the 5 roles `func`, `math`, `attr`, `obj` and `class` were taken into consideration. It is, however, common practice to define a default role (e.g. `:py:obj:`) using the `default_role` entry in `conf.py`. This PR enables the creation of backreferences for references without an explicit role if the default role in `conf.py` is one of the five roles listed above. Note that only the default role definition in `conf.py` is taken into consideration, i.e. setting the default role using the [`.. default-role::`](https://docutils.sourceforge.io/docs/ref/rst/directives.html#default-role) directive is not taken into account.

Further, separate titles (`Title <link>`) and suppressed link creations (`!no.link`) are handled correctly now.

The project listed in [README.rst](https://github.com/sphinx-gallery/sphinx-gallery/blob/master/README.rst) use the following default roles:


site | default role
-----|-------------
Sphinx-Gallery, Nilearn, PyStruct, GIMLi, pyRiemann, Astropy, <br/> PySurfer, PyTorch, PyVista, SimPEG, Fury, Optuna, <br/> Auto-sklearn, OpenML-Python, TorchIO, Biotite, Apache TVM, Tonic | - (none)
Scikit-learn | literal
scikit-image | autolink
MNE-python, Cartopy, PlasmaPy, Radis | py:obj
Nestle, SunPy, Matplotlib, NetworkX | obj

Projects in the last two rows benefit from this PR as more backreferences/mini-galleries are created, see https://github.com/matplotlib/matplotlib/issues/25595.  
<br/>
#### This PR comprises two commits:  

[TST: Refactor test_identify_names2](https://github.com/sphinx-gallery/sphinx-gallery/commit/3607ddf80aba0f6926da34487a4b657b9a5618d6)

- split into two tests for implicit and explicit names
- avoid repeated testing of first code_str (code_str and expected were
  extended and the complete code_str tested once more)
- turn into parameterized test for better extensibility

[ENH: Allow for default roles when creating backreferences](https://github.com/sphinx-gallery/sphinx-gallery/commit/ec15af892cbd81b14073945c9063234ec074ac82)

When adding mini-galleries for API documentation, only the 5 roles
func, math, attr, obj and class were taken into consideration. It is,
however, common practice to define a default role (e.g. :py:obj:) using
the default_role entry in conf.py. This commit enables the creation of
backreferences for references without an explicite role if the default
role in conf.py is one of the five roles listed above.
Please note the only the default role definition in conf.py is taken
into consideration, i.e. setting the default role using the
.. default-role:: directive is not taken into account.

Further, separate titles (`Title <link>`) and suppressed link creations
(`!no.link`) are handled correctly now.
