### PR TITLE
CLN Clean up naming of early config validation

### DIFF
--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -29,9 +29,9 @@ def gallery_conf(tmpdir):
     """Set up a test sphinx-gallery configuration."""
     app = Mock(spec=Sphinx, config=dict(source_suffix={'.rst': None}),
                extensions=[])
-    gallery_conf = gen_gallery._complete_gallery_conf_config_inited(
+    gallery_conf = gen_gallery._fill_gallery_conf_defaults(
         {},  app=app)
-    gen_gallery._complete_gallery_conf_builder_inited(
+    gen_gallery._update_gallery_conf_builder_inited(
         gallery_conf, str(tmpdir))
     gallery_conf.update(examples_dir=str(tmpdir), gallery_dir=str(tmpdir))
     return gallery_conf

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -15,9 +15,9 @@ from sphinx.errors import ConfigError, ExtensionError, SphinxWarning
 from sphinx_gallery.gen_gallery import (
     check_duplicate_filenames, check_spaces_in_filenames,
     collect_gallery_files, write_computation_times,
-    _complete_gallery_conf_config_inited,
+    _fill_gallery_conf_defaults,
     write_api_entry_usage,
-    normalize_gallery_conf_config_inited
+    fill_gallery_conf_defaults
 )
 from sphinx_gallery.interactive_example import create_jupyterlite_contents
 
@@ -26,10 +26,10 @@ def test_bad_config():
     """Test that bad config values are caught."""
     sphinx_gallery_conf = dict(example_dir='')
     with pytest.raises(ConfigError, match="example_dir.*did you mean 'examples_dirs'?.*"):  # noqa: E501
-        _complete_gallery_conf_config_inited(sphinx_gallery_conf)
+        _fill_gallery_conf_defaults(sphinx_gallery_conf)
     sphinx_gallery_conf = dict(n_subsection_order='')
     with pytest.raises(ConfigError, match=r"did you mean one of \['subsection_order', 'within_.*"):  # noqa: E501
-        _complete_gallery_conf_config_inited(sphinx_gallery_conf)
+        _fill_gallery_conf_defaults(sphinx_gallery_conf)
 
 
 def test_default_config(sphinx_app_wrapper):
@@ -114,11 +114,11 @@ def test_bad_api():
     """Test that we raise an error for bad API usage arguments."""
     sphinx_gallery_conf = dict(api_usage_ignore=('foo',))
     with pytest.raises(ConfigError, match='.*must be str.*'):
-        _complete_gallery_conf_config_inited(sphinx_gallery_conf)
+        _fill_gallery_conf_defaults(sphinx_gallery_conf)
     sphinx_gallery_conf = dict(show_api_usage='foo')
     with pytest.raises(ConfigError,
                        match='.*must be True, False or "unused".*'):
-        _complete_gallery_conf_config_inited(sphinx_gallery_conf)
+        _fill_gallery_conf_defaults(sphinx_gallery_conf)
 
 
 @pytest.mark.conf_file(content="""
@@ -428,7 +428,7 @@ def test_first_notebook_cell_config(sphinx_app_wrapper):
     # First cell must be str
     with pytest.raises(ConfigError):
         app = sphinx_app_wrapper.create_sphinx_app()
-        normalize_gallery_conf_config_inited(app, app.config, check_keys=False)
+        fill_gallery_conf_defaults(app, app.config, check_keys=False)
 
 
 @pytest.mark.conf_file(content="""
@@ -439,7 +439,7 @@ def test_last_notebook_cell_config(sphinx_app_wrapper):
     # Last cell must be str
     with pytest.raises(ConfigError):
         app = sphinx_app_wrapper.create_sphinx_app()
-        normalize_gallery_conf_config_inited(app, app.config, check_keys=False)
+        fill_gallery_conf_defaults(app, app.config, check_keys=False)
 
 
 @pytest.mark.conf_file(content="""
@@ -451,7 +451,7 @@ def test_backreferences_dir_config(sphinx_app_wrapper):
     with pytest.raises(ConfigError,
                        match="The 'backreferences_dir' parameter must be of"):
         app = sphinx_app_wrapper.create_sphinx_app()
-        normalize_gallery_conf_config_inited(app, app.config, check_keys=False)
+        fill_gallery_conf_defaults(app, app.config, check_keys=False)
 
 
 @pytest.mark.conf_file(content="""
@@ -463,7 +463,7 @@ sphinx_gallery_conf = {
 def test_backreferences_dir_pathlib_config(sphinx_app_wrapper):
     """Tests pathlib.Path does not raise exception."""
     app = sphinx_app_wrapper.create_sphinx_app()
-    normalize_gallery_conf_config_inited(app, app.config, check_keys=False)
+    fill_gallery_conf_defaults(app, app.config, check_keys=False)
 
 
 def test_write_computation_times_noop():
@@ -485,7 +485,7 @@ def test_pypandoc_config_list(sphinx_app_wrapper):
                        match="'pypandoc' parameter must be of type bool or "
                              "dict"):
         app = sphinx_app_wrapper.create_sphinx_app()
-        normalize_gallery_conf_config_inited(app, app.config, check_keys=False)
+        fill_gallery_conf_defaults(app, app.config, check_keys=False)
 
 
 @pytest.mark.conf_file(content="""
@@ -498,7 +498,7 @@ def test_pypandoc_config_keys(sphinx_app_wrapper):
                        match="'pypandoc' only accepts the following key "
                              "values:"):
         app = sphinx_app_wrapper.create_sphinx_app()
-        normalize_gallery_conf_config_inited(app, app.config, check_keys=False)
+        fill_gallery_conf_defaults(app, app.config, check_keys=False)
 
 
 @pytest.mark.conf_file(content="""

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -21,7 +21,8 @@ import pytest
 from sphinx.errors import ExtensionError
 import sphinx_gallery.gen_rst as sg
 from sphinx_gallery import downloads
-from sphinx_gallery.gen_gallery import generate_dir_rst, _update_gallery_conf
+from sphinx_gallery.gen_gallery import (
+    generate_dir_rst, _update_gallery_conf_exclude_implicit_doc)
 from sphinx_gallery.scrapers import ImagePathIterator, figure_rst
 from sphinx_gallery.interactive_example import check_binder_conf
 
@@ -540,7 +541,7 @@ def test_exclude_implicit(gallery_conf,
     gallery_conf['doc_module'] = ('numpy',)
     if exclusion:
         gallery_conf['exclude_implicit_doc'] = exclusion
-        _update_gallery_conf(gallery_conf)
+        _update_gallery_conf_exclude_implicit_doc(gallery_conf)
     _generate_rst(gallery_conf, 'test_exclude_implicit.py', EXCLUDE_CONTENT)
     if sys.version_info >= (3, 8, 0):
         assert mock_write_backreferences.call_args.args[0] == expected

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -4,7 +4,7 @@ import pytest
 
 from sphinx.errors import ConfigError, ExtensionError
 import sphinx_gallery
-from sphinx_gallery.gen_gallery import _complete_gallery_conf_config_inited
+from sphinx_gallery.gen_gallery import _fill_gallery_conf_defaults
 from sphinx_gallery.scrapers import (figure_rst, SG_IMAGE,
                                      matplotlib_scraper, ImagePathIterator,
                                      save_figures, _KNOWN_IMG_EXTS,
@@ -17,7 +17,7 @@ def gallery_conf(tmpdir):
     # Skip if numpy not installed
     pytest.importorskip("numpy")
 
-    gallery_conf = _complete_gallery_conf_config_inited({})
+    gallery_conf = _fill_gallery_conf_defaults({})
     gallery_conf.update(src_dir=str(tmpdir), examples_dir=str(tmpdir),
                         gallery_dir=str(tmpdir))
 
@@ -123,7 +123,7 @@ def test_custom_scraper(gallery_conf, monkeypatch):
         for cust in (_custom_func, 'sphinx_gallery'):
             gallery_conf.update(image_scrapers=[cust])
             # smoke test that it works
-            _complete_gallery_conf_config_inited(
+            _fill_gallery_conf_defaults(
                 gallery_conf, check_keys=False)
     # degenerate
     # without the monkey patch to add sphinx_gallery._get_sg_image_scraper,
@@ -131,12 +131,12 @@ def test_custom_scraper(gallery_conf, monkeypatch):
     gallery_conf.update(image_scrapers=['sphinx_gallery'])
     with pytest.raises(ConfigError,
                        match="has no attribute '_get_sg_image_scraper'"):
-        _complete_gallery_conf_config_inited(gallery_conf, check_keys=False)
+        _fill_gallery_conf_defaults(gallery_conf, check_keys=False)
 
     # other degenerate conditions
     gallery_conf.update(image_scrapers=['foo'])
     with pytest.raises(ConfigError, match='Unknown image scraper'):
-        _complete_gallery_conf_config_inited(gallery_conf, check_keys=False)
+        _fill_gallery_conf_defaults(gallery_conf, check_keys=False)
     gallery_conf.update(image_scrapers=[_custom_func])
     fname_template = os.path.join(gallery_conf['gallery_dir'],
                                   'image{0}.png')
@@ -154,13 +154,13 @@ def test_custom_scraper(gallery_conf, monkeypatch):
         m.setattr(sphinx_gallery, '_get_sg_image_scraper', 'foo',
                   raising=False)
         with pytest.raises(ConfigError, match='^Unknown image.*\n.*callable'):
-            _complete_gallery_conf_config_inited(
+            _fill_gallery_conf_defaults(
                 gallery_conf, check_keys=False)
     with monkeypatch.context() as m:
         m.setattr(sphinx_gallery, '_get_sg_image_scraper', lambda: 'foo',
                   raising=False)
         with pytest.raises(ConfigError, match='^Scraper.*was not callable'):
-            _complete_gallery_conf_config_inited(
+            _fill_gallery_conf_defaults(
                 gallery_conf, check_keys=False)
 
 


### PR DESCRIPTION
Follow-up of #1120. I tried to clean-up the namings and add a few docstrings.