### PR TITLE
MAINT: Use non-aliased status_iterator

### DIFF
--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -23,7 +23,6 @@ from sphinx.errors import ExtensionError
 from sphinx.search import js_index
 import sphinx.util
 
-
 logger = sphinx.util.logging.getLogger('sphinx-gallery')
 
 
@@ -344,7 +343,7 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
     flat = [[dirpath, filename]
             for dirpath, _, filenames in os.walk(html_gallery_dir)
             for filename in filenames]
-    iterator = sphinx.util.status_iterator(
+    iterator = sphinx.util.display.status_iterator(
         flat, 'embedding documentation hyperlinks for %s... ' % gallery_dir,
         color='fuchsia', length=len(flat),
         stringify_func=lambda x: os.path.basename(x[1]))

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -450,7 +450,7 @@ def generate_dir_rst(
     costs = []
     subsection_toctree_filenames = []
     build_target_dir = os.path.relpath(target_dir, gallery_conf['src_dir'])
-    iterator = sphinx.util.status_iterator(
+    iterator = sphinx.util.display.status_iterator(
         sorted_listdir,
         'generating gallery for %s... ' % build_target_dir,
         length=len(sorted_listdir))

--- a/sphinx_gallery/interactive_example.py
+++ b/sphinx_gallery/interactive_example.py
@@ -205,7 +205,7 @@ def _copy_binder_notebooks(app):
     if not isinstance(gallery_dirs, (list, tuple)):
         gallery_dirs = [gallery_dirs]
 
-    iterator = sphinx.util.status_iterator(
+    iterator = sphinx.util.display.status_iterator(
         gallery_dirs, 'copying binder notebooks...', length=len(gallery_dirs))
 
     for i_folder in iterator:
@@ -323,7 +323,7 @@ def create_jupyterlite_contents(app, exception):
     if not isinstance(gallery_dirs, (list, tuple)):
         gallery_dirs = [gallery_dirs]
 
-    iterator = sphinx.util.status_iterator(
+    iterator = sphinx.util.display.status_iterator(
         gallery_dirs, 'Copying Jupyterlite contents ...',
         length=len(gallery_dirs))
 


### PR DESCRIPTION
Should fix warnings of the form:
```
/home/circleci/python_env/lib/python3.9/site-packages/sphinx_gallery/docs_resolv.py:470: RemovedInSphinx80Warning: The alias 'sphinx.util.status_iterator' is deprecated, use 'sphinx.util.display.status_iterator' instead. Check CHANGES for Sphinx API modifications.
```
Hopefully it exists in our oldest supported Sphinx, otherwise I'll add a `status_iterator` to `sphinx_gallery.utils` where we `try/except` to use the new version