### PR TITLE
Correctly hide download buttons

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -486,8 +486,7 @@ Hide the download buttons in the example headers
 .. code-block:: css
 
     div.sphx-glr-download-link-note {
-        height: 0px;
-        visibility: hidden;
+        display: none;
     }
 
 Disable thumbnail text on hover


### PR DESCRIPTION
`visibility:hidden; height: 0px` still keeps margins, creating a large  amount of whitespace. `display: none` is the correct way to remove an HTML element completely.