### PR TITLE
Set table.dataframe width in CSS file close #1128

### DIFF
--- a/doc/_static/theme_override.css
+++ b/doc/_static/theme_override.css
@@ -33,3 +33,7 @@ a.sphx-glr-backref-module-sphinx_gallery {
 .anim-state label {
     display: inline-block;
 }
+
+table.dataframe {
+    width: auto
+}


### PR DESCRIPTION
set the table width of dataframe to auto to avoid clipped cell values (e.g. float values).

