### PR TITLE
MAINT: Replace build_sphinx with sphinx-build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           command: |
             pip install --progress-bar off --user --upgrade --only-binary ":all:" pip setuptools
             pip install --progress-bar off --user --upgrade --only-binary ":all:" numpy matplotlib "pyqt5!=5.15.2,!=5.15.3,!=5.15.8" vtk
-            pip install --progress-bar off --user --upgrade seaborn statsmodels pillow joblib sphinx pytest traits pyvista memory_profiler "ipython!=8.7.0" plotly graphviz "docutils>=0.18"
+            pip install --progress-bar off --user --upgrade seaborn statsmodels pillow joblib sphinx pytest traits pyvista memory_profiler "ipython!=8.7.0" plotly graphviz "docutils>=0.18" imageio
             pip install --progress-bar off "jupyterlite-sphinx>=0.8.0,<0.9.0" "jupyterlite-pyodide-kernel<0.1.0" libarchive-c
             pip install --progress-bar off --user --upgrade --pre pydata-sphinx-theme
       - save_cache:
@@ -59,7 +59,7 @@ jobs:
           command: |
             python setup.py develop --user
 
-      - run: python setup.py build_sphinx -nW --keep-going
+      - run: sphinx-build doc doc/_build/html -nW --keep-going -b html
       - store_artifacts:
           path: doc/_build/html/
           destination: rtd_html

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ stages:
         set -eo pipefail
         python --version
         python -m pip install --user --upgrade pip setuptools wheel
-        pip install --user --upgrade --progress-bar off "ipython!=8.7.0" numpy seaborn statsmodels matplotlib sphinx pillow pytest pytest-cov joblib "plotly>=4.0"
+        pip install --user --upgrade --progress-bar off "ipython!=8.7.0" numpy seaborn statsmodels matplotlib sphinx pillow pytest pytest-cov joblib "plotly>=4.0" imageio
         pip install --user --upgrade --progress-bar off --pre pydata-sphinx-theme
         echo "Qt, plotly, VTK"
         pip install --user --upgrade --progress-bar off pyvista "pyqt5!=5.15.8" plotly vtk

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,3 @@ filterwarnings =
 markers =
     conf_file:Configuration file.
 junit_family = xunit2
-
-[build_sphinx]
-source-dir = doc/
-build-dir  = doc/_build
-all_files  = 1

--- a/sphinx_gallery/tests/test_load_style.py
+++ b/sphinx_gallery/tests/test_load_style.py
@@ -15,4 +15,4 @@ def test_load_style(sphinx_app_wrapper):
     assert os.path.isfile(index_html)
     with open(index_html) as fid:
         content = fid.read()
-    assert 'link rel="stylesheet" type="text/css" href="_static/sg_gallery.css"' in content  # noqa: E501
+    assert 'link rel="stylesheet" type="text/css" href="_static/sg_gallery.css' in content  # noqa: E501


### PR DESCRIPTION
In Sphinx 7.0.1 support for build_sphinx was removed. I think this is the way to go.

Also installs `imageio` as I think that is not an expected failure...

Edit: ~install `absl-py` for Sphinx-dev test~. Also, sphinx-dev adds `?hash(?)` to href-link so removed the closing " from the test.