### PR TITLE
Remove extra spaces in reported running time

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -153,7 +153,7 @@ CODE_OUTPUT = """.. rst-class:: sphx-glr-script-out
 TIMING_CONTENT = """
 .. rst-class:: sphx-glr-timing
 
-   **Total running time of the script:** ({0: .0f} minutes {1: .3f} seconds)
+   **Total running time of the script:** ({0:.0f} minutes {1:.3f} seconds)
 
 """
 


### PR DESCRIPTION
Changes output from:

```
Total running time of the script: ( 0 minutes 0.197 seconds)
```

To:

```
Total running time of the script: (0 minutes 0.197 seconds)
```