### PR TITLE
Make _LoggingTee compatible with TextIO

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -67,6 +67,10 @@ class _LoggingTee:
         self.logger_buffer = ''
         self.set_std_and_reset_position()
 
+        # For TextIO compatibility
+        self.closed = False
+        self.encoding = "utf-8"
+
     def set_std_and_reset_position(self):
         if not isinstance(sys.stdout, _LoggingTee):
             self.origs = (sys.stdout, sys.stderr)
@@ -107,13 +111,35 @@ class _LoggingTee:
             self.logger.verbose('%s', self.logger_buffer)
             self.logger_buffer = ''
 
-    # Needed to work with Abseil
+    # For TextIO compatibility
     def close(self):
         pass
 
-    # When called from a local terminal seaborn needs it in Python3
+    def fileno(self):
+        return self.output.fileno()
+
     def isatty(self):
         return self.output.isatty()
+
+    def readable(self):
+        return False
+
+    def seekable(self):
+        return False
+
+    def tell(self):
+        return self.output.tell()
+
+    def writable(self):
+        return True
+
+    @property
+    def errors(self):
+        return self.output.errors
+
+    @property
+    def newlines(self):
+        return self.output.newlines
 
     # When called in gen_rst, conveniently use context managing
     def __enter__(self):

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -1049,15 +1049,18 @@ def test_textio_compat(log_collector_wrap):
     assert not tee.seekable()
     assert tee.writable()
 
+
 def test_isatty(monkeypatch, log_collector_wrap):
     _, _, tee, _ = log_collector_wrap
     assert not tee.isatty()
     monkeypatch.setattr(tee.output, 'isatty', lambda: True)
     assert tee.isatty()
 
+
 def test_errors(log_collector_wrap):
     _, _, tee, _ = log_collector_wrap
     assert tee.errors == tee.output.errors
+
 
 def test_newlines(log_collector_wrap):
     _, _, tee, _ = log_collector_wrap

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -6,6 +6,7 @@ Testing the rst files generator
 import ast
 import codecs
 import importlib
+import io
 import logging
 import tempfile
 import re
@@ -1050,11 +1051,24 @@ def test_textio_compat(log_collector_wrap):
     assert tee.writable()
 
 
+def test_fileno(monkeypatch, log_collector_wrap):
+    _, _, tee, _ = log_collector_wrap
+    with pytest.raises(io.UnsupportedOperation):
+        tee.fileno()
+
+
 def test_isatty(monkeypatch, log_collector_wrap):
     _, _, tee, _ = log_collector_wrap
     assert not tee.isatty()
     monkeypatch.setattr(tee.output, 'isatty', lambda: True)
     assert tee.isatty()
+
+
+def test_tell(monkeypatch, log_collector_wrap):
+    _, _, tee, _ = log_collector_wrap
+    assert tee.tell() == tee.output.tell()
+    monkeypatch.setattr(tee.output, 'tell', lambda: 42)
+    assert tee.tell() == tee.output.tell()
 
 
 def test_errors(log_collector_wrap):

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -1043,12 +1043,26 @@ def test_multi_line(log_collector_wrap):
     assert tee.logger_buffer == 'third line'
 
 
+def test_textio_compat(log_collector_wrap):
+    _, _, tee, _ = log_collector_wrap
+    assert not tee.readable()
+    assert not tee.seekable()
+    assert tee.writable()
+
+
 def test_isatty(monkeypatch, log_collector_wrap):
     _, _, tee, _ = log_collector_wrap
     assert not tee.isatty()
     monkeypatch.setattr(tee.output, 'isatty', lambda: True)
     assert tee.isatty()
 
+def test_errors(log_collector_wrap):
+    _, _, tee, _ = log_collector_wrap
+    assert tee.errors == tee.output.errors
+
+def test_newlines(log_collector_wrap):
+    _, _, tee, _ = log_collector_wrap
+    assert tee.newlines == tee.output.newlines
 
 # TODO: test that broken thumbnail does appear when needed
 # TODO: test that examples are executed after a no-plot and produce

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -1049,7 +1049,6 @@ def test_textio_compat(log_collector_wrap):
     assert not tee.seekable()
     assert tee.writable()
 
-
 def test_isatty(monkeypatch, log_collector_wrap):
     _, _, tee, _ = log_collector_wrap
     assert not tee.isatty()


### PR DESCRIPTION
Closes #1150.

Following up on the discussion in issue sphinx-gallery/sphinx-gallery#1150, I'd like to propose this PR to improve the compatibility between _LoggingTee and TextIO. It also includes some tests to keep the coverage complete.

Judging from the previous comments, the non-compatibility was already an issue for other packages (e.g. seaborn). In this PR, the classic attributes of [TextIOBase](https://docs.python.org/3/library/io.html#io.TextIOBase) and of [IOBase](https://docs.python.org/3/library/io.html#io.IOBase) (inherited) are all implemented.

This should prevent further issues on the compatibility between the expected stdout and _LoggingTee. I am, of course, open to reverting to adding only the "encoding" attribute if you find it safer/more appropriate. However, this should not be breaking since I am only adding missing attributes and refactoring previous modifications.

(Sorry for the blank lines issue!)