### PR TITLE
MAINT Update backreferences docs and add tests

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -426,12 +426,12 @@ To make this work in your documentation you need to include to the
         # a list of regexes of qualified module names where the full module
         # (e.g., a.b.meth) name should be used for links instead of the short
         # module name (e.g., a.meth)
-        'yourmodule\.submod',
+        'module\.submodule',
         ]
     }
 
 In the above example, all qualified names matching the regex
-``'yourmodule\.submod'`` would use the full module name when creating links. All
+``'module\.submodule'`` would use the full module name when creating links. All
 others will use the (default) way of linking.
 
 .. _references_to_examples:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -410,7 +410,16 @@ point to the directory containing ``searchindex.js``, such as
 If you wish to do the same for ordinary reST documentation,
 see :ref:`plain_rst`.
 
-If you are using inherited classes in your code and are experiencing
+Resolving module paths
+^^^^^^^^^^^^^^^^^^^^^^
+
+When finding links to objects we use, by default, the shortest module path,
+checking that it still directs to the same object. This is because it is common
+for a class that is defined in a deeper module to be documented in a shallower
+one because it is imported in a higher level modules' ``__init__.py`` (thus
+that's the namespace users expect it to be).
+
+However, if you are using inherited classes in your code and are experiencing
 incorrect links in the sense that links point to the base class of an object
 instead of the child, the option ``prefer_full_module`` might solve your issue.
 See `the GitHub
@@ -419,15 +428,13 @@ for more context.
 
 To make this work in your documentation you need to include
 ``prefer_full_module`` in the Sphinx-Gallery configuration dictionary in
-the ``conf.py`` file::
+``conf.py``::
 
     sphinx_gallery_conf = {
         ...
-        'prefer_full_module': {
         # Regexes to match the fully qualified names of objects where the full
         # module name should be used. To use full names for all objects use: '.*'
-        'module\.submodule',
-        }
+        'prefer_full_module': {r'module\.submodule'}
     }
 
 In the above example, all fully qualified names matching the regex
@@ -480,7 +487,7 @@ your Sphinx-Gallery configuration ``conf.py`` file with::
         # Regexes to match objects to exclude from implicit backreferences.
         # The default option is an empty set, i.e. exclude nothing.
         # To exclude everything, use: '.*'
-        'exclude_implicit_doc': {},
+        'exclude_implicit_doc': {r'pyplot\.show'},
     }
 
 The path you specify in ``backreferences_dir`` (here we choose

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -410,29 +410,29 @@ point to the directory containing ``searchindex.js``, such as
 If you wish to do the same for ordinary reST documentation,
 see :ref:`plain_rst`.
 
-If you are using inheritance for your documented code and you are experience
-wrong links in the sense that the links point to the base class of an object
+If you are using inherited classes in your code and are experiencing
+incorrect links in the sense that links point to the base class of an object
 instead of the child, the option ``prefer_full_module`` might solve your issue.
-Have also a look at `the GitHub
+See `the GitHub
 issue <https://github.com/sphinx-gallery/sphinx-gallery/issues/947>`__
-implementing this option for more context.
+for more context.
 
 To make this work in your documentation you need to include to the
-configuration
-dictionary within your Sphinx ``conf.py`` file::
+``prefer_full_module`` configuration within your Sphinx ``conf.py`` file::
 
     sphinx_gallery_conf = {
         ...
         'prefer_full_module':[
-        # a list of regex command of your module where the full module
-        # name should be used for sphinx_gallery instead of the shortend
-        'yourmodule.*+\d{4}',
+        # a list of regexes of qualified module names where the full module
+        # (e.g., a.b.meth) name should be used for links instead of the short
+        # module name (e.g., a.meth)
+        'yourmodule\.submod',
         ]
     }
 
-In the above examples all modules matching the string ``'yourmodule.*+\d{4}'``
-would use the full module name when creating the links. All other use the
-(default) way of linking.
+In the above example, all qualified names matching the regex
+``'yourmodule\.submod'`` would use the full module name when creating links. All
+others will use the (default) way of linking.
 
 .. _references_to_examples:
 
@@ -443,12 +443,13 @@ When documenting a given function/method/attribute/object/class, Sphinx-Gallery
 enables you to link to any examples that either:
 
 1. Use the function/method/attribute/object or instantiate the class in the
-   code.
+   code (generates *implicit backreferences*).
 2. Refer to that function/method/attribute/object/class using sphinx markup
    ``:func:``/``:meth:``/``:attr:``/``:obj:``/``:class:`` in a text
    block. You can omit this role markup if you have set the `default_role
    <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-default_role>`_
-   in your ``conf.py`` to any of these roles.
+   in your ``conf.py`` to any of these roles (generates *explicit
+   backreferences*).
 
 The former is useful for auto-documenting functions that are used and classes
 that are explicitly instantiated. The generated links are called implicit

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -376,8 +376,8 @@ Add intersphinx links to your examples
 ======================================
 
 Sphinx-Gallery enables you to add hyperlinks in your example scripts so that
-you can link the used functions to their matching online documentation. As such
-code snippets within the gallery appear like this
+you can link used functions/methods/attributes/objects/classes to their matching
+online documentation. Such code snippets within the gallery appear like this:
 
 .. raw:: html
 
@@ -417,22 +417,23 @@ See `the GitHub
 issue <https://github.com/sphinx-gallery/sphinx-gallery/issues/947>`__
 for more context.
 
-To make this work in your documentation you need to include to the
-``prefer_full_module`` configuration within your Sphinx ``conf.py`` file::
+To make this work in your documentation you need to include
+``prefer_full_module`` in the Sphinx-Gallery configuration dictionary in
+the ``conf.py`` file::
 
     sphinx_gallery_conf = {
         ...
-        'prefer_full_module':[
-        # a list of regexes of qualified module names where the full module
-        # (e.g., a.b.meth) name should be used for links instead of the short
-        # module name (e.g., a.meth)
+        'prefer_full_module': {
+        # Regexes to match the fully qualified names of objects where the full
+        # module name should be used. To use full names for all objects use: '.*'
         'module\.submodule',
-        ]
+        }
     }
 
-In the above example, all qualified names matching the regex
-``'module\.submodule'`` would use the full module name when creating links. All
-others will use the (default) way of linking.
+In the above example, all fully qualified names matching the regex
+``'module\.submodule'`` would use the full module name
+(e.g., module.submodule.meth) when creating links, instead of the short module
+name (e.g., module.meth). All others will use the (default) way of linking.
 
 .. _references_to_examples:
 
@@ -451,10 +452,10 @@ enables you to link to any examples that either:
    in your ``conf.py`` to any of these roles (generates *explicit
    backreferences*).
 
-The former is useful for auto-documenting functions that are used and classes
-that are explicitly instantiated. The generated links are called implicit
-backreferences. The latter is useful for classes that are typically implicitly
-returned rather than explicitly instantiated (e.g.,
+The former is useful for auto-documenting functions/methods/attributes/objects
+that are used and classes that are explicitly instantiated. The generated links
+are called implicit backreferences. The latter is useful for classes that are
+typically implicitly returned rather than explicitly instantiated (e.g.,
 :class:`matplotlib.axes.Axes` which is most often instantiated only indirectly
 within function calls). Such links are called explicit backreferences.
 
@@ -476,8 +477,9 @@ your Sphinx-Gallery configuration ``conf.py`` file with::
         # this case sphinx_gallery and numpy in a tuple of strings.
         'doc_module'          : ('sphinx_gallery', 'numpy'),
 
-        # objects to exclude from implicit backreferences. The default option
-        # is an empty set, i.e. exclude nothing.
+        # Regexes to match objects to exclude from implicit backreferences.
+        # The default option is an empty set, i.e. exclude nothing.
+        # To exclude everything, use: '.*'
         'exclude_implicit_doc': {},
     }
 

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -264,7 +264,7 @@ class SphinxDocLinkResolver:
                 - cobj['module_short'] : shortened module name (str)
                 - cobj['is_class'] : whether object is class (bool)
                 - cobj['is_explicit'] : whether object is an explicit
-                  backreference (referred to in sphinx markup) (bool)
+                  backreference (referred to by sphinx markup) (bool)
 
         this_url: str
             URL of the current page. Needed to construct relative URLs
@@ -284,7 +284,7 @@ class SphinxDocLinkResolver:
             # we don't have it cached
             use_full_module = False
             for pattern in self.config['prefer_full_module']:
-                if re.search(pattern, full_name):
+                if re.search(pattern, cobj['module'] + '.' + cobj['name']):
                     use_full_module = True
                     break
             self._link_cache[full_name] = self._get_link_type(

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -258,9 +258,14 @@ class SphinxDocLinkResolver:
         cobj : dict
             Dict with information about the "code object" for which we are
             resolving a link.
-            cobj['name'] : function or class name (str)
-            cobj['module_short'] : shortened module name (str)
-            cobj['module'] : module name (str)
+
+                - cobj['name'] : function or class name (str)
+                - cobj['module'] : module name (str)
+                - cobj['module_short'] : shortened module name (str)
+                - cobj['is_class'] : whether object is class (bool)
+                - cobj['is_explicit'] : whether object is an explicit
+                  backreference (referred to in sphinx markup) (bool)
+
         this_url: str
             URL of the current page. Needed to construct relative URLs
             (only used if relative=True in constructor).

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -104,7 +104,7 @@ DEFAULT_GALLERY_CONF = {
     'default_thumb_file': None,
     'line_numbers': False,
     'nested_sections': True,
-    'prefer_full_module': [],
+    'prefer_full_module': {},
     'api_usage_ignore': '.*__.*__',
     'show_api_usage': False,  # if this changes, change write_api_entries, too
     'copyfile_regex': '',

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -61,7 +61,7 @@ DEFAULT_GALLERY_CONF = {
     'gallery_dirs': 'auto_examples',
     'backreferences_dir': None,
     'doc_module': (),
-    'exclude_implicit_doc': {},
+    'exclude_implicit_doc': set(),
     'reference_url': {},
     'capture_repr': ('_repr_html_', '__repr__'),
     'ignore_repr_types': r'',
@@ -104,7 +104,7 @@ DEFAULT_GALLERY_CONF = {
     'default_thumb_file': None,
     'line_numbers': False,
     'nested_sections': True,
-    'prefer_full_module': {},
+    'prefer_full_module': set(),
     'api_usage_ignore': '.*__.*__',
     'show_api_usage': False,  # if this changes, change write_api_entries, too
     'copyfile_regex': '',

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -75,6 +75,9 @@ br.identify_names
 from sphinx_gallery.back_references import identify_names
 identify_names
 
+import matplotlib.pyplot as plt
+_ = plt.figure()
+
 """
 
     fname = tmpdir.join("unicode_sample.py")

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -14,7 +14,6 @@ import sys
 import time
 import glob
 import json
-from pathlib import Path
 
 from packaging.version import Version
 

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -206,7 +206,7 @@ def test_junit(sphinx_app, tmpdir):
 
 def test_run_sphinx(sphinx_app):
     """Test basic outputs."""
-    out_dir = str(sphinx_app.outdir)
+    out_dir = sphinx_app.outdir
     out_files = os.listdir(out_dir)
     assert 'index.html' in out_files
     assert 'auto_examples' in out_files

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -14,6 +14,7 @@ import sys
 import time
 import glob
 import json
+from pathlib import Path
 
 from packaging.version import Version
 
@@ -205,7 +206,7 @@ def test_junit(sphinx_app, tmpdir):
 
 def test_run_sphinx(sphinx_app):
     """Test basic outputs."""
-    out_dir = sphinx_app.outdir
+    out_dir = str(sphinx_app.outdir)
     out_files = os.listdir(out_dir)
     assert 'index.html' in out_files
     assert 'auto_examples' in out_files


### PR DESCRIPTION
Fixes some nitpicks in backreferences docs.

Edit:

This PR now does the following:

* Minor wording updates in backreferences/linking docs
* Update docstring `SphinxDocLinkResolver.resolve`
* Change `prefer_full_module` to set instead of list, like other similar configs (e.g., exclude_implicit_doc)
* Use the full module (instead of short module) name when matching `prefer_full_module` - gives you finer control and brings it in line with what `exclude_implicit_doc` does.
* Update and add a test to better test `_get_short_module_name`
