### PR TITLE
Maint: Fix `app.builder.outdir` as Sphinx now using pathlib

### DIFF
--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -323,7 +323,7 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
             if url is None:
                 doc_resolvers[this_module] = SphinxDocLinkResolver(
                     app.config.sphinx_gallery_conf,
-                    app.builder.outdir, src_gallery_dir, relative=True)
+                    str(app.builder.outdir), src_gallery_dir, relative=True)
             else:
                 doc_resolvers[this_module] = SphinxDocLinkResolver(
                     app.config.sphinx_gallery_conf,

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -205,7 +205,7 @@ def test_junit(sphinx_app, tmpdir):
 
 def test_run_sphinx(sphinx_app):
     """Test basic outputs."""
-    out_dir = sphinx_app.outdir
+    out_dir = str(sphinx_app.outdir)
     out_files = os.listdir(out_dir)
     assert 'index.html' in out_files
     assert 'auto_examples' in out_files


### PR DESCRIPTION
CI is failing with sphinx dev with error:
(see: https://dev.azure.com/sphinx-gallery/sphinx-gallery/_build/results?buildId=1368&view=logs&j=18f51a03-7fab-57d7-f724-30d2d83bc222&t=7c53da0f-8616-5987-83c8-9378d265c3e8&l=1124)
```
ERROR at setup of test_timings ________________________
/usr/share/miniconda/lib/python3.10/site-packages/sphinx/events.py:96: in emit
    results.append(listener.handler(self.app, *args))
sphinx_gallery/docs_resolv.py:471: in embed_code_links
    _embed_code_links(app, gallery_conf, gallery_dir)
sphinx_gallery/docs_resolv.py:324: in _embed_code_links
    doc_resolvers[this_module] = SphinxDocLinkResolver(
sphinx_gallery/docs_resolv.py:146: in __init__
    if doc_url.startswith(('http://',/ 'https://'))/:
E   AttributeError: 'PosixPath' object has no attribute 'startswith'

The above exception was the direct cause of the following exception:
sphinx_gallery/tests/test_full.py:51: in sphinx_app
    return _sphinx_app(tmpdir_factory, 'html')
sphinx_gallery/tests/test_full.py:83: in _sphinx_app
    app.build(False, [])
/usr/share/miniconda/lib/python3.10/site-packages/sphinx/application.py:355: in build
    self.events.emit('build-finished', None)
/usr/share/miniconda/lib/python3.10/site-packages/sphinx/events.py:107: in emit
    raise ExtensionError(__("Handler %r for event %r threw an exception") %
E   sphinx.errors.ExtensionError: Handler <function embed_code_links at 0x7f163d981990> for event 'build-finished' threw an exception (exception: 'PosixPath' object has no attribute 'startswith')
```
I think sphinx started using pathlib in: https://github.com/sphinx-doc/sphinx/pull/11526

Potentially in future we may want to check if `outdir` is a `Path` object (instead of checking if str starts with http..) but have just used `str` for now.