### PR TITLE
MAINT: Speed up conda solving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,6 @@ junit-results.xml
 # Sphinx documentation
 doc/_build/
 doc/auto_examples
-doc/auto_mayavi_examples
 doc/auto_plotly_examples
 doc/auto_pyvista_examples
 doc/tutorials/

--- a/continuous_integration/azure/install.sh
+++ b/continuous_integration/azure/install.sh
@@ -27,7 +27,7 @@ if [ "$DISTRIB" == "conda" ]; then
         PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx==${SPHINX_VERSION} jinja2<=3.0.3"
     fi
     source activate base
-    conda install --yes -c conda-forge mamba
+    conda install --yes -c conda-forge mamba conda
     mamba install --yes -c conda-forge $CONDA_TO_INSTALL
     mamba info --envs
     pytest --version

--- a/continuous_integration/azure/install.sh
+++ b/continuous_integration/azure/install.sh
@@ -27,8 +27,9 @@ if [ "$DISTRIB" == "conda" ]; then
         PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx==${SPHINX_VERSION} jinja2<=3.0.3"
     fi
     source activate base
-    conda install --yes -c conda-forge $CONDA_TO_INSTALL
-    conda info --envs
+    conda install --yes -c conda-forge mamba
+    mamba install --yes -c conda-forge $CONDA_TO_INSTALL
+    mamba info --envs
     pytest --version
     python -m pip install $PIP_DEPENDENCIES
     python -m pip install --pre pydata-sphinx-theme


### PR DESCRIPTION
CIs are taking 40+ minutes in https://github.com/sphinx-gallery/sphinx-gallery/pull/1154 which is too long. Let's see if `mamba` goes faster. If not, we should just stop using `conda` since we can just use `pip` instead.

It might be worth moving to GitHub Actions as well at some point...