### PR TITLE
updated mpl gui warning catcher to new error message

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -102,7 +102,8 @@ For example, to remove the specific Matplotlib agg warning, you can add::
 
     warnings.filterwarnings("ignore", category=UserWarning,
                             message='Matplotlib is currently using agg, which is a'
-                                    ' non-GUI backend, so cannot show the figure.')
+                                    ' non-GUI backend, so cannot show the figure.'
+                                    '|(\n|.)*is non-interactive, and thus cannot be shown')
 
 to your ``conf.py`` file.
 

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -42,7 +42,7 @@ def _import_matplotlib():
     filterwarnings("ignore", category=UserWarning,
                    message='Matplotlib is currently using agg, which is a'
                            ' non-GUI backend, so cannot show the figure.'
-                           '|(\n|.)*is non-interactive, and thus cannot be' 
+                           '|(\n|.)*is non-interactive, and thus cannot be'
                            ' shown')
 
     if matplotlib_backend != 'agg':

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -41,7 +41,9 @@ def _import_matplotlib():
 
     filterwarnings("ignore", category=UserWarning,
                    message='Matplotlib is currently using agg, which is a'
-                           ' non-GUI backend, so cannot show the figure.')
+                           ' non-GUI backend, so cannot show the figure.'
+                           '|(\n|.)*is non-interactive, and thus cannot be' 
+                           ' shown')
 
     if matplotlib_backend != 'agg':
         raise ExtensionError(

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -989,6 +989,8 @@ def test_matplotlib_warning_filter(sphinx_app):
     warning = ('Matplotlib is currently using agg, which is a'
                ' non-GUI backend, so cannot show the figure.')
     assert warning not in html
+    warning = 'is non-interactive, and thus cannot be shown'
+    assert warning not in html
 
 
 def test_jupyter_notebook_pandoc(sphinx_app):


### PR DESCRIPTION
Hi folks, https://github.com/matplotlib/matplotlib/pull/26472 changed the wording of the gui error message, so this PR updates the filters and docs to the new warning message wording.  This is gonna be in the 3.8 release. 
I wonder if there's a better way to do this though. 