### PR TITLE
MAINT: Make outdated check better

### DIFF
--- a/continuous_integration/azure/install.sh
+++ b/continuous_integration/azure/install.sh
@@ -19,8 +19,8 @@ if [ "$DISTRIB" == "conda" ]; then
     if [ "$SPHINX_VERSION" == "" ]; then
         PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx jinja2<=3.0.3"
     elif [ "$SPHINX_VERSION" == "dev" ]; then
-        # It is a mystery to me why we need black, but we get an error with sphinx that it's needed at the end of the build...
-        PIP_DEPENDENCIES="${PIP_DEPENDENCIES} https://api.github.com/repos/sphinx-doc/sphinx/zipball/master black"
+        # Need to pin to a commit until https://github.com/pydata/pydata-sphinx-theme/issues/1404 is fixed and pydata-sphinx-theme releases
+        PIP_DEPENDENCIES="${PIP_DEPENDENCIES} https://api.github.com/repos/sphinx-doc/sphinx/zipball/3e30fa36a241bade5415051ab01af981caa29d62"
     elif [ "$SPHINX_VERSION" == "old" ]; then
         PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx<5 jinja2<=3.0.3"
     else

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -367,13 +367,16 @@ def save_thumbnail(image_path_template, src_file, script_vars, file_conf,
         return
     # update extension, since gallery_conf setting can be different
     # from file_conf
-    thumb_file = f'{os.path.splitext(thumb_file)[0]}.{ext}'
+    # Here we have to do .new.ext so that optipng and PIL behave well
+    thumb_file = f'{os.path.splitext(thumb_file)[0]}.new.{ext}'
     if ext in ('svg', 'gif'):
         copyfile(img, thumb_file)
     else:
         scale_image(img, thumb_file, *gallery_conf["thumbnail_size"])
         if 'thumbnails' in gallery_conf['compress_images']:
             optipng(thumb_file, gallery_conf['compress_images_args'])
+    fname_old = f"{os.path.splitext(thumb_file)[0][:-3]}{ext}"
+    _replace_md5(thumb_file, fname_old=fname_old)
 
 
 def _get_readme(dir_, gallery_conf, raise_error=True):

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -727,11 +727,24 @@ def _rerun(how, src_dir, conf_dir, out_dir, toctrees_dir,
     want = f'.*targets for {N_RST} source files that are out of date$.*'
     assert re.match(want, status, flags) is not None, lines
     # ... but then later detects that only some have actually changed:
-    # Linux: 8 changed when how='run_stale', 9 when how='modify'.
-    # Windows: always 9 for some reason
     lines = [line for line in status.split('\n') if 'changed,' in line]
-    lines = '\n'.join([how] + lines)
-    n_ch = '(7|8|9|10|11|12)'
+    # Ones that can change on stale:
+    # - auto_examples/future/plot_future_imports_broken
+    # - auto_examples/future/sg_execution_times
+    # - auto_examples/plot_scraper_broken
+    # - auto_examples/sg_execution_times
+    # - sg_api_usage
+    # Sometimes it's not all 5, for example when the execution time and
+    # memory usage reported ends up being the same.
+    #
+    # Modifying an example then adds these two:
+    # - auto_examples/index
+    # - auto_examples/plot_numpy_matplotlib
+    if how == 'modify':
+        n_ch = '[3-7]'
+    else:
+        n_ch = '[1-5]'
+    lines = '\n'.join([f"\n{how} != {n_ch}:"] + lines)
     want = f'.*updating environment:.*[0|1] added, {n_ch} changed, 0 removed.*'
     assert re.match(want, status, flags) is not None, lines
     want = ('.*executed 1 out of %s.*after excluding %s files.*based on MD5.*'

--- a/sphinx_gallery/tests/tinybuild/doc/conf.py
+++ b/sphinx_gallery/tests/tinybuild/doc/conf.py
@@ -1,4 +1,5 @@
 import os.path as op
+import sphinx
 from sphinx_gallery.scrapers import matplotlib_scraper
 from sphinx_gallery.sorting import FileNameSortKey
 
@@ -129,3 +130,22 @@ sphinx_gallery_conf = {
 nitpicky = True
 highlight_language = 'python3'
 html_static_path = ['_static_nonstandard']
+
+
+class ReportChanged:
+
+    def __repr__(self):
+        return "ReportChanged"
+
+    def __call__(self, app, env, added, changed, removed):
+        from sphinx.util.console import bold
+        logger = sphinx.util.logging.getLogger('sphinx-gallery')
+        if changed:
+            logger.info(bold(f'\nFiles changed ({len(changed)}):'))
+            for fname in sorted(changed):
+                logger.info(f'     - {fname}')
+        return []
+
+
+def setup(app):
+    app.connect("env-get-outdated", ReportChanged())

--- a/sphinx_gallery/utils.py
+++ b/sphinx_gallery/utils.py
@@ -159,11 +159,16 @@ def _replace_md5(fname_new, fname_old=None, method='move', mode='b'):
     if fname_old is None:
         assert fname_new.endswith('.new')
         fname_old = os.path.splitext(fname_new)[0]
-    if os.path.isfile(fname_old) and (get_md5sum(fname_old, mode) ==
-                                      get_md5sum(fname_new, mode)):
-        if method == 'move':
-            os.remove(fname_new)
-    else:
+    replace = True
+    if os.path.isfile(fname_old):
+        if get_md5sum(fname_old, mode) == get_md5sum(fname_new, mode):
+            replace = False
+            if method == 'move':
+                os.remove(fname_new)
+        else:
+            logger.debug(
+                f"Replacing stale {fname_old} with {fname_new}")
+    if replace:
         if method == 'move':
             move(fname_new, fname_old)
         else:


### PR DESCRIPTION
Improve `tinybuild` by

1. Adding something that prints what's detected as modified when rerunning
2. Only replacing thumbnails when they change (which reduced the number of modified files in the test)
3. Slightly better reporting on failure

It's entirely possible this will fail for older versions of Sphnix... let's see!