### PR TITLE
MAINT Fix failure in `write_api_entry_usage` source-read 

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -910,7 +910,7 @@ def write_api_entry_usage(app, docname, source):
     that they are used in.
     """
     gallery_conf = app.config.sphinx_gallery_conf
-    if gallery_conf["show_api_usage"] is False:
+    if gallery_conf["show_api_usage"] is False or docname is None:
         return
     # since this is done at the gallery directory level (as opposed
     # to in a gallery directory, e.g. auto_examples), it runs last


### PR DESCRIPTION
Doc build and test_full.py tests on windows failing.

Windows tells us:
```
sphinx_gallery\gen_gallery.py:919: in write_api_entry_usage
    "sg_api_usage" not in docname
E   TypeError: argument of type 'NoneType' is not iterable
```

AFAICT `docname` should: "Returns the docname of the document currently being parsed."
https://www.sphinx-doc.org/en/master/extdev/envapi.html#sphinx.environment.BuildEnvironment.docname

'source-read' gives `env.docname` which  does not seem to have changed recently: https://github.com/sphinx-doc/sphinx/blob/da9f8a5c33ad5eeef05dd780f2988f3ff7351ef3/sphinx/environment/__init__.py#L545