### PR TITLE
Avoid importing new modules in backrefs

### DIFF
--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -12,6 +12,7 @@ from html import escape
 import inspect
 import os
 import re
+import sys
 import warnings
 
 from sphinx.errors import ExtensionError
@@ -178,42 +179,27 @@ class NameFinder(ast.NodeVisitor):
         return options
 
 
-def _from_import(a, b):
-    imp_line = f"from {a} import {b}"
-    scope = dict()
-    with warnings.catch_warnings(record=True):  # swallow warnings
-        warnings.simplefilter("ignore")
-        exec(imp_line, scope, scope)
-    return scope
-
-
 def _get_short_module_name(module_name, obj_name):
     """Get the shortest possible module name."""
     if "." in obj_name:
         obj_name, attr = obj_name.split(".")
     else:
         attr = None
-    scope = {}
+
     try:
-        # Find out what the real object is supposed to be.
-        scope = _from_import(module_name, obj_name)
-    except Exception:  # wrong object
+        real_obj = getattr(sys.modules[module_name], obj_name)
+        if attr is not None:
+            getattr(real_obj, attr)  # wrong class
+    except (AttributeError, KeyError):  # wrong object
         return None
-    else:
-        real_obj = scope[obj_name]
-        if attr is not None and not hasattr(real_obj, attr):  # wrong class
-            return None  # wrong object
 
     parts = module_name.split(".")
     short_name = module_name
     for i in range(len(parts) - 1, 0, -1):
         short_name = ".".join(parts[:i])
-        scope = {}
         try:
-            scope = _from_import(short_name, obj_name)
-            # Ensure shortened object is the same as what we expect.
-            assert real_obj is scope[obj_name]
-        except Exception:  # libraries can throw all sorts of exceptions...
+            assert real_obj is getattr(sys.modules[short_name], obj_name)
+        except (AssertionError, AttributeError, KeyError):  # wrong object
             # get the last working module name
             short_name = ".".join(parts[: (i + 1)])
             break

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -13,7 +13,6 @@ import inspect
 import os
 import re
 import sys
-import warnings
 
 from sphinx.errors import ExtensionError
 import sphinx.util

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -186,10 +186,14 @@ def _get_short_module_name(module_name, obj_name):
         attr = None
 
     try:
+        # look only in sys.modules to avoid importing the module, which may
+        # otherwise have side effects
         real_obj = getattr(sys.modules[module_name], obj_name)
         if attr is not None:
-            getattr(real_obj, attr)  # wrong class
-    except (AttributeError, KeyError):  # wrong object
+            getattr(real_obj, attr)
+    except (AttributeError, KeyError):
+        # AttributeError: wrong class
+        # KeyError: wrong object or module not previously imported
         return None
 
     parts = module_name.split(".")
@@ -198,7 +202,10 @@ def _get_short_module_name(module_name, obj_name):
         short_name = ".".join(parts[:i])
         try:
             assert real_obj is getattr(sys.modules[short_name], obj_name)
-        except (AssertionError, AttributeError, KeyError):  # wrong object
+        except (AssertionError, AttributeError, KeyError):
+            # AssertionError: shortened object is not what we expect
+            # KeyError: short module name not previously imported
+            # AttributeError: wrong class or object
             # get the last working module name
             short_name = ".".join(parts[: (i + 1)])
             break


### PR DESCRIPTION
This fixes #1158 (or, is intended to help at least) based on the proposed solution in that issue and discussion elsewhere.

Hopefully this solution makes sense but I'm happy to rework as I came up with a lot of ways to do effectively the same thing. I am not too intimately familiar with the import system (at least I was not when I started on this) and definitely a little lost in some of this sphinx-gallery code.

Either way I know @lucyleeow had also suggested this should possibly be a config and I am happy to add that if you want it. I will also read though to see if there's a good spot to put some of this info in the docs.

It's also worth noting that now setuptools 68.1.0 has been released, which should fix the specific problem (case-insensitive imports from editable installs) that brought this issue to light for me.