### PR TITLE
MAINT Lint - fix ast node type in docstrings

### DIFF
--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -248,10 +248,10 @@ def identify_names(script_blocks, ref_regex, global_variables=None, node=""):
         the corresponding content string of block and the leading line number.
     ref_regex : str
         Regex to find references to python objects.
-    example_globals: Optional[Dict[str, Any]]
-        Global variables for examples. Default=None
-    node : ast.Module or str
-        The parsed node. Default=""
+    example_globals: Optional[Dict[str, Any]], default=None
+        Global variables for examples.
+    node : ast.Module or str, default=""
+        The parsed node. Note, when parsed with `mode='exec'` node is ast.Module type.
 
     Returns
     -------

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -248,10 +248,10 @@ def identify_names(script_blocks, ref_regex, global_variables=None, node=""):
         the corresponding content string of block and the leading line number.
     ref_regex : str
         Regex to find references to python objects.
-    example_globals: Optional[Dict[str, Any]], default=None
-        Global variables for examples.
-    node : ast.Module or str, default=""
-        The parsed node. Note, when parsed with `mode='exec'` node is ast.Module type.
+    example_globals: Optional[Dict[str, Any]]
+        Global variables for examples. Default=None
+    node : ast.Module or str
+        The parsed node. Default="".
 
     Returns
     -------

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -430,10 +430,9 @@ def generate_dir_rst(
     seen_backrefs: set,
         Back references encountered when parsing this gallery
         will be stored in this set.
-    include_toctree: bool,
+    include_toctree: bool, default=True
         Whether or not toctree should be included
         in generated rst file.
-        Default = True.
 
     Returns
     -------

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -430,9 +430,10 @@ def generate_dir_rst(
     seen_backrefs: set,
         Back references encountered when parsing this gallery
         will be stored in this set.
-    include_toctree: bool, default=True
+    include_toctree: bool
         Whether or not toctree should be included
         in generated rst file.
+        Default = True.
 
     Returns
     -------

--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -83,7 +83,8 @@ def _get_docstring_and_rest(filename):
     lineno : int
         The line number.
     node : ast.Module
-        The ast node.
+        The ast node. When `filename` parsed with `mode='exec' node should be
+        of type `ast.Module`.
     """
     node, content = parse_source_file(filename)
 

--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -82,8 +82,8 @@ def _get_docstring_and_rest(filename):
         ``filename`` content without the docstring
     lineno : int
         The line number.
-    node : ast Node
-        The node.
+    node : ast.Module
+        The ast node.
     """
     node, content = parse_source_file(filename)
 
@@ -167,8 +167,8 @@ def split_code_and_text_blocks(source_file, return_node=False):
         (label, content, line_number)
         List where each element is a tuple with the label ('text' or 'code'),
         the corresponding content string of block and the leading line number.
-    node : ast Node
-        The parsed node.
+    node : ast.Module
+        The parsed ast node.
     """
     docstring, rest_of_content, lineno, node = _get_docstring_and_rest(source_file)
     blocks = [("text", docstring, 1)]


### PR DESCRIPTION
Also expands `ast.Module` typing as we use 'ast node' everywhere else.