### PR TITLE
MAINT Add to `test_identify_names` so class property tested

### DIFF
--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -71,6 +71,9 @@ br.identify_names
 from sphinx_gallery.back_references import identify_names
 identify_names
 
+from sphinx_gallery.back_references import DummyClass
+DummyClass().prop
+
 import matplotlib.pyplot as plt
 _ = plt.figure()
 

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -125,6 +125,16 @@ def test_identify_names(unicode_sample, gallery_conf):
                 "is_explicit": False,
             }
         ],
+        # Check we get a in a().b in `visit_Attribute`
+        "DummyClass": [
+            {
+                "name": "DummyClass",
+                "module": "sphinx_gallery.back_references",
+                "module_short": "sphinx_gallery.back_references",
+                "is_class": False,
+                "is_explicit": False,
+            }
+        ],
     }
     _, script_blocks = split_code_and_text_blocks(unicode_sample)
     ref_regex = sg._make_ref_regex(gallery_conf["app"].config)


### PR DESCRIPTION
Ensure we get to the `else` in `visit_Attribute`:

https://github.com/sphinx-gallery/sphinx-gallery/blob/451ccba1007cc523f39cbcc960ebc21ca39f7b75/sphinx_gallery/backreferences.py#L89

This is probably tested in `test_full.py` but nice to have in a more 'unit' test.