### PR TITLE
MAINT Fix check for mismatched "ignore" blocks

### DIFF
--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -212,7 +212,7 @@ def remove_ignore_blocks(code_block):
     """
     Return the content of *code_block* with ignored areas removed.
 
-    An ignore block starts with # sphinx_gallery_begin_ignore, and ends with
+    An ignore block starts with # sphinx_gallery_start_ignore, and ends with
     # sphinx_gallery_end_ignore. These lines and anything in between them will
     be removed, but surrounding empty lines are preserved.
 
@@ -221,8 +221,8 @@ def remove_ignore_blocks(code_block):
     code_block : str
         A code segment.
     """
-    num_start_flags = len(re.findall(START_IGNORE_FLAG, code_block))
-    num_end_flags = len(re.findall(END_IGNORE_FLAG, code_block))
+    num_start_flags = len(re.findall(START_IGNORE_FLAG, code_block, re.MULTILINE))
+    num_end_flags = len(re.findall(END_IGNORE_FLAG, code_block, re.MULTILINE))
 
     if num_start_flags != num_end_flags:
         raise ExtensionError(

--- a/sphinx_gallery/tests/test_py_source_parser.py
+++ b/sphinx_gallery/tests/test_py_source_parser.py
@@ -76,7 +76,7 @@ def test_remove_ignore_comments():
     normal_code = "# Regular code\n# should\n# be untouched!"
     assert sg.remove_ignore_blocks(normal_code) == normal_code
 
-    mismatched_code = "# sphinx_gallery_start_ignore"
+    mismatched_code = "x=5\n# sphinx_gallery_start_ignore\ny=4"
     with pytest.raises(ExtensionError) as error:
         sg.remove_ignore_blocks(mismatched_code)
     assert "must have a matching" in str(error)


### PR DESCRIPTION
The checks for mismatched "ignore" blocks were not detecting either "start" or "end" flags, and just comparing `0 == 0`. This PR:
- fixes these regex evaluations
- corrects the name of "start" flag in the `remove_ignore_blocks` docstring
- updates the test to simulate more realistic use case with a multi-line code block