### PR TITLE
ENH: Write all computation times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run: sphinx-build doc doc/_build/html -nW --keep-going -b html
       - store_artifacts:
           path: doc/_build/html/
-          destination: rtd_html
+          destination: html
       - store_test_results:
           path: doc/_build/html/
 
@@ -85,27 +85,27 @@ jobs:
 
   deploy_dev:
     docker:
-      - image: circleci/python:3.7-stretch
+      - image: circleci/python:3.8-stretch
     steps:
       - checkout
       - add_ssh_keys:
           fingerprints:
             - "87:18:18:25:10:8c:29:0f:25:bd:28:b1:4f:cd:af:96"
       - attach_workspace:
-          at: rtd_html
-      - run: ./.circleci/docs_deploy.sh rtd_html dev
+          at: html
+      - run: ./.circleci/docs_deploy.sh html dev
 
   deploy_stable:
     docker:
-      - image: circleci/python:3.7-stretch
+      - image: circleci/python:3.8-stretch
     steps:
       - checkout
       - add_ssh_keys:
           fingerprints:
             - "87:18:18:25:10:8c:29:0f:25:bd:28:b1:4f:cd:af:96"
       - attach_workspace:
-          at: rtd_html
-      - run: ./.circleci/docs_deploy.sh rtd_html stable
+          at: html
+      - run: ./.circleci/docs_deploy.sh html stable
 
 
 workflows:

--- a/.github/workflows/circle_artifacts.yml
+++ b/.github/workflows/circle_artifacts.yml
@@ -9,5 +9,5 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           api-token: ${{ secrets.CIRCLECI_TOKEN }}
-          artifact-path: 0/rtd_html/index.html
+          artifact-path: 0/html/index.html
           circleci-jobs: build_docs

--- a/.gitignore
+++ b/.gitignore
@@ -64,9 +64,10 @@ doc/tutorials/
 doc/gen_modules/
 
 # Test builds
-sphinx_gallery/tests/tinybuild/gen_modules/
-sphinx_gallery/tests/tinybuild/auto_examples/
-sphinx_gallery/tests/tinybuild/_build/
+sphinx_gallery/tests/tinybuild/doc/gen_modules/
+sphinx_gallery/tests/tinybuild/doc/auto_*/
+sphinx_gallery/tests/tinybuild/doc/_build/
+sphinx_gallery/tests/tinybuild/doc/sg_execution_times.rst
 sphinx_gallery/tests/tinybuild/tiny_html/
 junit-results.xml
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,11 @@ recursive-include pyvista_examples *.py
 recursive-include pyvista_examples *.rst
 recursive-include sphinx_gallery *.py
 recursive-include sphinx_gallery/tests/testconfs *
+recursive-exclude sphinx_gallery/tests/tinybuild/doc/_build *
+recursive-exclude sphinx_gallery/tests/tinybuild/doc/jupyterlite_contents *
+recursive-exclude sphinx_gallery/tests/tinybuild/doc/gen_modules *
+recursive-exclude sphinx_gallery/tests/tinybuild/doc/auto_* *
+exclude sphinx_gallery/tests/tinybuild/doc/sg_execution_times.rst
 recursive-include sphinx_gallery/tests/tinybuild *
 include sphinx_gallery/tests/reference_parse.txt
 exclude sphinx_gallery/_static/broken_stamp.svg

--- a/continuous_integration/azure/install.sh
+++ b/continuous_integration/azure/install.sh
@@ -19,8 +19,7 @@ if [ "$DISTRIB" == "conda" ]; then
     if [ "$SPHINX_VERSION" == "" ]; then
         PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx jinja2<=3.0.3"
     elif [ "$SPHINX_VERSION" == "dev" ]; then
-        # Need to pin to a commit until https://github.com/pydata/pydata-sphinx-theme/issues/1404 is fixed and pydata-sphinx-theme releases
-        PIP_DEPENDENCIES="${PIP_DEPENDENCIES} https://api.github.com/repos/sphinx-doc/sphinx/zipball/3e30fa36a241bade5415051ab01af981caa29d62"
+        PIP_DEPENDENCIES="${PIP_DEPENDENCIES} https://api.github.com/repos/sphinx-doc/sphinx/zipball/dev"
     elif [ "$SPHINX_VERSION" == "old" ]; then
         PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx<5 jinja2<=3.0.3"
     else

--- a/continuous_integration/azure/install.sh
+++ b/continuous_integration/azure/install.sh
@@ -14,7 +14,7 @@ if [ "$DISTRIB" == "conda" ]; then
     # source ~/miniconda/etc/profile.d/conda.sh
     echo "##vso[task.prependpath]$CONDA/bin"
     export PATH=${CONDA}/bin:${PATH}
-    CONDA_TO_INSTALL="python=$PYTHON_VERSION pip numpy setuptools matplotlib pillow pytest pytest-cov coverage seaborn statsmodels 'plotly>=4.0' joblib wheel libiconv graphviz memory_profiler \"ipython!=8.7.0\" pypandoc"
+    CONDA_TO_INSTALL="python=$PYTHON_VERSION pip numpy setuptools matplotlib pillow pytest pytest-cov coverage seaborn statsmodels 'plotly>=4.0' joblib wheel libiconv pygraphviz memory_profiler \"ipython!=8.7.0\" pypandoc"
     PIP_DEPENDENCIES="jupyterlite-sphinx>=0.8.0,<0.9.0 jupyterlite-pyodide-kernel<0.1.0 libarchive-c"
     if [ "$SPHINX_VERSION" == "" ]; then
         PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx jinja2<=3.0.3"

--- a/continuous_integration/azure/install.sh
+++ b/continuous_integration/azure/install.sh
@@ -19,7 +19,7 @@ if [ "$DISTRIB" == "conda" ]; then
     if [ "$SPHINX_VERSION" == "" ]; then
         PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx jinja2<=3.0.3"
     elif [ "$SPHINX_VERSION" == "dev" ]; then
-        PIP_DEPENDENCIES="${PIP_DEPENDENCIES} https://api.github.com/repos/sphinx-doc/sphinx/zipball/dev"
+        PIP_DEPENDENCIES="${PIP_DEPENDENCIES} https://api.github.com/repos/sphinx-doc/sphinx/zipball/master"
     elif [ "$SPHINX_VERSION" == "old" ]; then
         PIP_DEPENDENCIES="${PIP_DEPENDENCIES} sphinx<5 jinja2<=3.0.3"
     else

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -21,15 +21,9 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
 .PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
 
-# Theme variable default
-theme = rtd
-
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"
-	@echo "             can include the sphinx theme to rendered with variable"
-	@echo "     theme=[default,rtd,alabaster,sphinxdoc,scrolls,agogo,"
-	@echo "            traditional,nature,haiku,pyramid,bizstyle]"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
 	@echo "  pickle     to make pickle files"
@@ -60,19 +54,16 @@ clean:
 	rm -rf tutorials/
 	rm -rf gen_modules/
 
-html-noplot: export SPHX_GLR_THEME = $(theme)
 html-noplot:
 	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-html_abort_on_example_error: export SPHX_GLR_THEME = $(theme)
 html_abort_on_example_error:
 	$(SPHINXBUILD) -D abort_on_example_error=1 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-html: export SPHX_GLR_THEME = $(theme)
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -177,7 +177,8 @@ generated:
   :ref:`sphx_glr_auto_examples_plot_6_function_identifier.py`)
 
 Additionally, two compressed ``.zip`` files containing all the ``.ipynb`` and
-``.py`` files are generated.
+``.py`` files are generated, as well as a root-level ``sg_execution_times.rst`` file
+containing all of the execution times.
 
 For more advanced configuration, see the :ref:`configuration` page.
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     author="Óscar Nájera",
     author_email="najera.oscar@gmail.com",
     install_requires=install_requires,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     license="3-clause BSD",
     classifiers=[
         "Intended Audience :: Developers",

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -742,7 +742,7 @@ def _sec_to_readable(t):
 
 
 def _cost_key(cost):
-    """Cost (time_elapsed, memory_used) sorting function."""
+    """Cost sorting function."""
     # sort by descending computation time, descending memory, alphabetical name
     return (-cost["t"], -cost["mem"], cost["src_file"])
 
@@ -752,14 +752,13 @@ def _format_for_writing(costs, *, src_dir, kind="rst"):
 
     Parameters
     ----------
-    costs: List[Tuple[Tuple[float], str]]
-        List of tuples of computation costs and absolute paths to example, of format:
-        ((time_elapsed, memory_used), example_path).
+    costs: List[Dict]
+        List of dicts of computation costs and paths, see gen_rst.py for details.
     src_dir : pathlib.Path
         The Sphinx source directory.
     kind: 'rst', 'rst-full' or 'console', default='rst'
         Format for printing to 'console' or for writing `sg_execution_times.rst' ('rst'
-        and 'rst-full').
+        for single galleries and 'rst-full' for all galleries).
 
     Returns
     -------
@@ -802,19 +801,18 @@ def write_computation_times(gallery_conf, target_dir, costs):
         Sphinx-Gallery configuration dictionary.
     target_dir : str | None
         Path to directory where example python source file are.
-    costs: List[Tuple[Tuple[float], str, str]]
-        List of tuples of computation costs and absolute paths to example, of format:
-        ((time_elapsed, memory_used), example_path).
+    costs: List[Dict]
+        List of dicts of computation costs and paths, see gen_rst.py for details.
     """
     total_time = sum(cost["t"] for cost in costs)
     if total_time == 0:
         return
-    if target_dir is None:  # global
+    if target_dir is None:  # all galleries together
         out_dir = gallery_conf["src_dir"]
         where = "all galleries"
         kind = "rst-full"
         ref_extra = ""
-    else:  # local
+    else:  # a single gallery
         out_dir = target_dir
         where = os.path.relpath(target_dir, gallery_conf["src_dir"])
         kind = "rst"
@@ -1155,8 +1153,7 @@ def write_junit_xml(gallery_conf, target_dir, costs):
     target_dir : Union[str, pathlib.Path]
         Build directory.
     costs: List[Tuple[Tuple[float], str]]
-        List of tuples of computation costs and absolute paths to example, of format:
-        ((time_elapsed, memory_used), example_path).
+        List of dicts of computation costs and paths, see gen_rst.py for details.
     """
     if not gallery_conf["junit"] or not gallery_conf["plot_gallery"]:
         return

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -442,9 +442,8 @@ def generate_dir_rst(
     index_content: str,
         Content which will be written to the index rst file
         presenting the current example gallery
-    costs: list,
-        List of costs (time_elapsed, memory_used) for building each element of the
-        gallery and absolute path to the example file
+    costs: dict
+        Dict of costs for building each element of the gallery.
     toctree_items: list,
         List of files included in toctree
         (independent of include_toctree's value)
@@ -497,11 +496,11 @@ def generate_dir_rst(
         length=len(sorted_listdir),
     )
     for fname in iterator:
-        intro, title, cost = generate_file_rst(
+        intro, title, (t, mem) = generate_file_rst(
             fname, target_dir, src_dir, gallery_conf, seen_backrefs
         )
         src_file = os.path.normpath(os.path.join(src_dir, fname))
-        costs.append((cost, src_file))
+        costs.append(dict(t=t, mem=mem, src_file=src_file, target_dir=target_dir))
         gallery_item_filename = os.path.join(build_target_dir, fname[:-3]).replace(
             os.sep, "/"
         )

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -442,8 +442,8 @@ def generate_dir_rst(
     index_content: str,
         Content which will be written to the index rst file
         presenting the current example gallery
-    costs: dict
-        Dict of costs for building each element of the gallery
+    costs: List[Dict]
+        List of dicts of costs for building each element of the gallery
          with keys "t", "mem", "src_file", and "target_dir".
     toctree_items: list,
         List of files included in toctree

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -443,7 +443,8 @@ def generate_dir_rst(
         Content which will be written to the index rst file
         presenting the current example gallery
     costs: dict
-        Dict of costs for building each element of the gallery.
+        Dict of costs for building each element of the gallery
+         with keys "t", "mem", "src_file", and "target_dir".
     toctree_items: list,
         List of files included in toctree
         (independent of include_toctree's value)

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -855,21 +855,26 @@ def _rerun(
     # ... but then later detects that only some have actually changed:
     lines = [line for line in status.split("\n") if "changed," in line]
     # Ones that can change on stale:
+    #
     # - auto_examples/future/plot_future_imports_broken
     # - auto_examples/future/sg_execution_times
     # - auto_examples/plot_scraper_broken
     # - auto_examples/sg_execution_times
+    # - auto_examples_rst_index/sg_execution_times
+    # - auto_examples_with_rst/sg_execution_times
     # - sg_api_usage
-    # Sometimes it's not all 5, for example when the execution time and
+    # - sg_execution_times
+    #
+    # Sometimes it's not all 8, for example when the execution time and
     # memory usage reported ends up being the same.
     #
     # Modifying an example then adds these two:
     # - auto_examples/index
     # - auto_examples/plot_numpy_matplotlib
     if how == "modify":
-        n_ch = "[3-9]"
+        n_ch = "[3-10]"
     else:
-        n_ch = "[1-6]"
+        n_ch = "[1-8]"
     lines = "\n".join([f"\n{how} != {n_ch}:"] + lines)
     want = f".*updating environment:.*[0|1] added, {n_ch} changed, 0 removed.*"
     assert re.match(want, status, flags) is not None, lines

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -872,7 +872,7 @@ def _rerun(
     # - auto_examples/index
     # - auto_examples/plot_numpy_matplotlib
     if how == "modify":
-        n_ch = "[3-10]"
+        n_ch = "([3-9]|10)"
     else:
         n_ch = "[1-8]"
     lines = "\n".join([f"\n{how} != {n_ch}:"] + lines)

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -618,7 +618,7 @@ def test_rebuild(tmpdir_factory, sphinx_app):
     lines = [line for line in status.split("\n") if "removed" in line]
     want = f".*{N_RST} added, 0 changed, 0 removed.*"
     assert re.match(want, status, re.MULTILINE | re.DOTALL) is not None, lines
-    want = ".*targets for 3 source files that are out of date$.*"
+    want = ".*targets for [2-3] source files that are out of date$.*"
     lines = [line for line in status.split("\n") if "out of date" in line]
     assert re.match(want, status, re.MULTILINE | re.DOTALL) is not None, lines
     lines = [line for line in status.split("\n") if "on MD5" in line]

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -546,7 +546,7 @@ def test_backreferences_dir_pathlib_config(sphinx_app_wrapper):
 
 
 def test_write_computation_times_noop():
-    write_computation_times(None, None, [[[0]]])
+    write_computation_times(None, None, [dict(t=0)])
 
 
 def test_write_api_usage_noop(sphinx_app_wrapper):

--- a/sphinx_gallery/tests/tinybuild/doc/Makefile
+++ b/sphinx_gallery/tests/tinybuild/doc/Makefile
@@ -1,4 +1,4 @@
-SPHINXOPTS=
+SPHINXOPTS=-v
 
 all: clean html show
 


### PR DESCRIPTION
For a while I've wanted a full listing of example computation times. This PR writes them to the `src_dir` root as `sg_execution_times.html`, which I think is hopefully safe enough.

Snuck in some cleanups of `pytest.mark.parametrize` so our test names can be a bit shorter in the terminal, too.