### PR TITLE
ENH: Always write sg_execution_times

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -805,8 +805,6 @@ def write_computation_times(gallery_conf, target_dir, costs):
         List of dicts of computation costs and paths, see gen_rst.py for details.
     """
     total_time = sum(cost["t"] for cost in costs)
-    if total_time == 0:
-        return
     if target_dir is None:  # all galleries together
         out_dir = gallery_conf["src_dir"]
         where = "all galleries"


### PR DESCRIPTION
In MNE-Python we only execute examples that have been changed. I'd like to link CircleCI artifacts redirector action to `sg_execution_times.htmtl`, but this only exists if any examples have been executed. It's easy enough to just *always* write this file (the cost is very low), so I figure we might as well do it.