### PR TITLE
DOC Note support for python 3.7 dropped in release notes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+v0.15.0
+-------
+
+Support for Python 3.7 dropped in this release. Requirement is now Python >=3.8.
+
 v0.14.0
 -------
 


### PR DESCRIPTION
I think support was dropped in #1197