### PR TITLE
ENH: Improve API usage graph

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -914,11 +914,11 @@ def _init_api_usage(gallery_dir):
 # Colors from https://personal.sron.nl/~pault/data/colourschemes.pdf
 # 3 Diverging Colour Schemes, Figure 12, plus alpha=AA
 API_COLORS = dict(
-    edge="#00000088",
-    okay="#6EA6CDAA",  # blue
-    bad_1="#FEDA8BAA",  # yellow
-    bad_2="#F67E4BAA",  # orange
-    bad_3="#A50026AA",  # red
+    edge="#00000080",  # gray (by alpha)
+    okay="#98CAE180",  # blue
+    bad_1="#FEDA8B80",  # yellow
+    bad_2="#F67E4B80",  # orange
+    bad_3="#A5002680",  # red
 )
 
 


### PR DESCRIPTION
After working on https://github.com/mne-tools/mne-python/pull/12013#issuecomment-1736018069 I wanted to port over some changes that I think will be generally helpful. After some simplifications and tweaks to the diagram to make it more readable, esp. with a dense layout with overlaps, this is what I see:

| | before | after |
| -- | -- | -- |
| SG | ![image](https://github.com/sphinx-gallery/sphinx-gallery/assets/2365790/66d0216f-bc47-4fe5-8daf-9db2662daf09) | ![image](https://github.com/sphinx-gallery/sphinx-gallery/assets/2365790/54113b0d-9192-4079-a9a3-822b4de8f5c3) |
| MNE | ![image](https://github.com/sphinx-gallery/sphinx-gallery/assets/2365790/08c32208-08af-4cfb-85ae-ec3df4bdbe88) | ![image](https://github.com/sphinx-gallery/sphinx-gallery/assets/2365790/7c77bb3c-2663-4296-9cf3-e6301b2c8b8d) |

@drammock feel free to test out locally (`PATTERN=no_examples make html-pattern` in MNE or `make html` in `doc` of this repo) and tweak if you want to try changing stuff.