### PR TITLE
MAINT: Improve CircleCI time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,10 @@ jobs:
           at: ~/
       - bash_env
       - run:
+          name: Get LaTeX tools
+          command: |
+            sudo apt install texlive texlive-latex-extra latexmk tex-gyre
+      - run:
           name: latexpdf
           command: |
             make -C sphinx_gallery/tests/tinybuild/doc clean latexpdf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,24 @@
-version: 2
+version: 2.1
+
+# Aliases to reuse
+_imageconfig: &imageconfig
+  docker:
+    - image: cimg/base:2022.10-22.04
+
+commands:
+  bash_env:
+    steps:
+      - run:
+          name: Set BASH_ENV
+          command: |
+            ./.circleci/setup_bash.sh
+
 jobs:
-  build_docs:
-    docker:
-      - image: cimg/python:3.10.10
+  setup_env:
+    <<: *imageconfig
     steps:
       # Get our data and merge with upstream
       - checkout
-      - run:
-          name: Update libraries
-          command: |
-            sudo apt update
-            sudo apt --no-install-recommends install -yq \
-              libosmesa6 libglx-mesa0 libopengl0 libglx0 libdbus-1-3 \
-              libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 xvfb \
-              texlive texlive-latex-extra latexmk optipng tex-gyre graphviz
       - run:
           name: Merge with upstream
           command: |
@@ -23,15 +28,7 @@ jobs:
               echo "Merging $(cat merge.txt)";
               git pull --ff-only origin "refs/pull/$(cat merge.txt)/merge";
             fi
-      # Python env
-      - run:
-          name: Set up Xvfb
-          command: |
-            echo 'export PATH=~/.local/bin:$PATH' >> $BASH_ENV
-            echo 'export XDG_RUNTIME_DIR=/tmp/runtime-circleci' >> $BASH_ENV
-            echo 'export DISPLAY=:99' >> $BASH_ENV
-            /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
-
+      - bash_env
       - restore_cache:
           keys:
             - cache-pip
@@ -47,9 +44,6 @@ jobs:
           key: cache-pip
           paths:
             - ~/.cache/pip
-
-      # Fix libgcc_s.so.1 pthread_cancel bug:
-      # https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
       - run:
           name: Test libs
           command: |
@@ -58,30 +52,52 @@ jobs:
           name: Install
           command: |
             python setup.py develop --user
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - project
+            - python_env
 
+  build_docs:
+    <<: *imageconfig
+    steps:
+      - attach_workspace:
+          at: ~/
+      - bash_env
       - run: sphinx-build doc doc/_build/html -nW --keep-going -b html
       - store_artifacts:
           path: doc/_build/html/
           destination: html
       - store_test_results:
           path: doc/_build/html/
-
-      - run: sphinx-build sphinx_gallery/tests/tinybuild/doc tiny_html
-      - store_artifacts:
-          path: tiny_html
-          destination: tiny_html
-
-      - run:
-          name: latexpdf
-          command: |
-            cd sphinx_gallery/tests/tinybuild/doc && make clean && make latexpdf
-      - store_artifacts:
-          path: sphinx_gallery/tests/tinybuild/doc/_build/latex/
-          destination: latex
-
       - persist_to_workspace:
           root: doc/_build/html
           paths: .
+
+  build_tinyhtml:
+    <<: *imageconfig
+    steps:
+      - attach_workspace:
+          at: ~/
+      - bash_env
+      - run: make -C sphinx_gallery/tests/tinybuild/doc clean html
+      - store_artifacts:
+          path: sphinx_gallery/tests/tinybuild/doc/_build/html
+          destination: tiny_html
+
+  build_latexpdf:
+    <<: *imageconfig
+    steps:
+      - attach_workspace:
+          at: ~/
+      - bash_env
+      - run:
+          name: latexpdf
+          command: |
+            make -C sphinx_gallery/tests/tinybuild/doc clean latexpdf
+      - store_artifacts:
+          path: sphinx_gallery/tests/tinybuild/doc/_build/latex/
+          destination: latex
 
   deploy_dev:
     docker:
@@ -114,10 +130,22 @@ workflows:
     jobs:
       # https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
       # Run for all branches and tags
-      - build_docs:
+      - setup_env: &filter_tags
           filters:
             tags:
               only: /.*/
+      - build_docs:
+          requires:
+            - setup_env
+          <<: *filter_tags
+      - build_tinyhtml:
+          requires:
+            - setup_env
+          <<: *filter_tags
+      - build_latexpdf:
+          requires:
+            - setup_env
+          <<: *filter_tags
       # Run for master branch
       - deploy_dev:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,12 +36,12 @@ jobs:
           name: Pip
           # for VTK: https://gitlab.kitware.com/vtk/vtk/-/packages/102
           command: |
-            pip install --progress-bar off --upgrade --only-binary ":all:" pip setuptools
-            pip install --progress-bar off --upgrade --only-binary ":all:" \
+            pip install --upgrade --only-binary ":all:" pip setuptools
+            pip install --upgrade --only-binary ":all:" \
                 numpy matplotlib seaborn statsmodels pillow joblib sphinx pytest traits pyvista memory_profiler "ipython!=8.7.0" plotly graphviz "docutils>=0.18" imageio pydata-sphinx-theme \
                 "jupyterlite-sphinx>=0.8.0,<0.9.0" "jupyterlite-pyodide-kernel<0.1.0" libarchive-c
             pip uninstall -yq vtk  # pyvista installs vtk above
-            pip install --only-binary ":all" --extra-index-url https://wheels.vtk.org vtk-osmesa
+            pip install --upgrade --only-binary ":all" --extra-index-url https://wheels.vtk.org vtk-osmesa
       - save_cache:
           key: cache-pip-1
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,9 @@ jobs:
           name: Pip
           command: |
             pip install --progress-bar off --upgrade --only-binary ":all:" pip setuptools
-            pip install --progress-bar off --upgrade --only-binary ":all:" numpy matplotlib "pyqt5!=5.15.2,!=5.15.3,!=5.15.8" vtk
-            pip install --progress-bar off --upgrade seaborn statsmodels pillow joblib sphinx pytest traits pyvista memory_profiler "ipython!=8.7.0" plotly graphviz "docutils>=0.18" imageio
-            pip install --progress-bar off "jupyterlite-sphinx>=0.8.0,<0.9.0" "jupyterlite-pyodide-kernel<0.1.0" libarchive-c
-            pip install --progress-bar off --upgrade --pre pydata-sphinx-theme
+            pip install --progress-bar off --upgrade --only-binary ":all:" --extra-index-url https://gitlab.kitware.com/api/v4/projects/13/packages/pypi/simple \
+                vtk-osmesa numpy matplotlib seaborn statsmodels pillow joblib sphinx pytest traits pyvista memory_profiler "ipython!=8.7.0" plotly graphviz "docutils>=0.18" imageio pydata-sphinx-theme \
+                "jupyterlite-sphinx>=0.8.0,<0.9.0" "jupyterlite-pyodide-kernel<0.1.0" libarchive-c
       - save_cache:
           key: cache-pip-1
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,11 @@ jobs:
           # for VTK: https://gitlab.kitware.com/vtk/vtk/-/packages/102
           command: |
             pip install --progress-bar off --upgrade --only-binary ":all:" pip setuptools
-            pip install --progress-bar off --upgrade --only-binary ":all:" --extra-index-url https://wheels.vtk.org \
-                numpy matplotlib vtk-osmesa seaborn statsmodels pillow joblib sphinx pytest traits pyvista memory_profiler "ipython!=8.7.0" plotly graphviz "docutils>=0.18" imageio pydata-sphinx-theme \
+            pip install --progress-bar off --upgrade --only-binary ":all:" \
+                numpy matplotlib seaborn statsmodels pillow joblib sphinx pytest traits pyvista memory_profiler "ipython!=8.7.0" plotly graphviz "docutils>=0.18" imageio pydata-sphinx-theme \
                 "jupyterlite-sphinx>=0.8.0,<0.9.0" "jupyterlite-pyodide-kernel<0.1.0" libarchive-c
+            pip uninstall -yq vtk  # pyvista installs vtk above
+            pip install --only-binary ":all" --extra-index-url https://wheels.vtk.org vtk-osmesa
       - save_cache:
           key: cache-pip-1
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,11 @@ jobs:
             - cache-pip-1
       - run:
           name: Pip
+          # for VTK: https://gitlab.kitware.com/vtk/vtk/-/packages/102
           command: |
             pip install --progress-bar off --upgrade --only-binary ":all:" pip setuptools
-            pip install --progress-bar off --upgrade --only-binary ":all:" --extra-index-url https://gitlab.kitware.com/api/v4/projects/13/packages/pypi/simple \
-                vtk-osmesa numpy matplotlib seaborn statsmodels pillow joblib sphinx pytest traits pyvista memory_profiler "ipython!=8.7.0" plotly graphviz "docutils>=0.18" imageio pydata-sphinx-theme \
+            pip install --progress-bar off --upgrade --only-binary ":all:" --extra-index-url https://wheels.vtk.org \
+                numpy matplotlib vtk-osmesa seaborn statsmodels pillow joblib sphinx pytest traits pyvista memory_profiler "ipython!=8.7.0" plotly graphviz "docutils>=0.18" imageio pydata-sphinx-theme \
                 "jupyterlite-sphinx>=0.8.0,<0.9.0" "jupyterlite-pyodide-kernel<0.1.0" libarchive-c
       - save_cache:
           key: cache-pip-1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,17 +31,17 @@ jobs:
       - bash_env
       - restore_cache:
           keys:
-            - cache-pip
+            - cache-pip-1
       - run:
           name: Pip
           command: |
-            pip install --progress-bar off --user --upgrade --only-binary ":all:" pip setuptools
-            pip install --progress-bar off --user --upgrade --only-binary ":all:" numpy matplotlib "pyqt5!=5.15.2,!=5.15.3,!=5.15.8" vtk
-            pip install --progress-bar off --user --upgrade seaborn statsmodels pillow joblib sphinx pytest traits pyvista memory_profiler "ipython!=8.7.0" plotly graphviz "docutils>=0.18" imageio
+            pip install --progress-bar off --upgrade --only-binary ":all:" pip setuptools
+            pip install --progress-bar off --upgrade --only-binary ":all:" numpy matplotlib "pyqt5!=5.15.2,!=5.15.3,!=5.15.8" vtk
+            pip install --progress-bar off --upgrade seaborn statsmodels pillow joblib sphinx pytest traits pyvista memory_profiler "ipython!=8.7.0" plotly graphviz "docutils>=0.18" imageio
             pip install --progress-bar off "jupyterlite-sphinx>=0.8.0,<0.9.0" "jupyterlite-pyodide-kernel<0.1.0" libarchive-c
-            pip install --progress-bar off --user --upgrade --pre pydata-sphinx-theme
+            pip install --progress-bar off --upgrade --pre pydata-sphinx-theme
       - save_cache:
-          key: cache-pip
+          key: cache-pip-1
           paths:
             - ~/.cache/pip
       - run:
@@ -51,7 +51,7 @@ jobs:
       - run:
           name: Install
           command: |
-            python setup.py develop --user
+            pip install -e .
       - persist_to_workspace:
           root: ~/
           paths:

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 set -eo pipefail
+echo "set -eo pipefail" >> "$BASH_ENV"
 sudo apt update
 sudo apt --no-install-recommends install -yq \
     libgl1 libosmesa6 mesa-utils \
     optipng graphviz python3-venv
 python3 -m venv ~/python_env
-echo "set -e" >> "$BASH_ENV"
-echo "source ~/python_env/bin/activate" >> "$BASH_ENV"
 source ~/python_env/bin/activate
+echo "source ~/python_env/bin/activate" >> "$BASH_ENV"
 echo "Python: $(which python)"
 echo "pip:    $(which pip)"

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 sudo apt update
 sudo apt --no-install-recommends install -yq \
-    libopengl0 libegl1 libosmesa6 mesa-utils \  # 3D
+    libgl1 libosmesa6 mesa-utils \  # 3D
     optipng graphviz python3-venv  # sphinx-gallery
 python3 -m venv ~/python_env
 echo "set -e" >> "$BASH_ENV"

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -2,12 +2,10 @@
 
 set -eo pipefail
 sudo apt --no-install-recommends install -yq \
-    libosmesa6 libglx-mesa0 libopengl0 libglx0 libdbus-1-3 libxkbcommon-x11-0 \
-    libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
-    libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 \
-    xvfb texlive texlive-latex-extra latexmk optipng tex-gyre graphviz \
-    python3.10-venv python3-venv
-python3.10 -m venv ~/python_env
+    libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6 mesa-utils libxcb-shape0 libxcb-cursor0 xvfb \
+    texlive texlive-latex-extra latexmk optipng tex-gyre graphviz \
+    python3-venv
+python3 -m venv ~/python_env
 echo "set -e" >> "$BASH_ENV"
 echo 'export DISPLAY=:99' >> "$BASH_ENV"
 echo 'export XDG_RUNTIME_DIR=/tmp/runtime-circleci' >> "$BASH_ENV"

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -3,9 +3,7 @@
 set -eo pipefail
 echo "set -eo pipefail" >> "$BASH_ENV"
 sudo apt update
-sudo apt --no-install-recommends install -yq \
-    libgl1 libosmesa6 mesa-utils \
-    optipng graphviz python3-venv
+sudo apt --no-install-recommends install -yq optipng graphviz python3-venv
 python3 -m venv ~/python_env
 source ~/python_env/bin/activate
 echo "source ~/python_env/bin/activate" >> "$BASH_ENV"

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -eo pipefail
+sudo apt update
 sudo apt --no-install-recommends install -yq \
     libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6 mesa-utils libxcb-shape0 libxcb-cursor0 xvfb \
     texlive texlive-latex-extra latexmk optipng tex-gyre graphviz \

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -12,3 +12,6 @@ echo 'export DISPLAY=:99' >> "$BASH_ENV"
 echo 'export XDG_RUNTIME_DIR=/tmp/runtime-circleci' >> "$BASH_ENV"
 echo "source ~/python_env/bin/activate" >> "$BASH_ENV"
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset
+source ~/python_env/bin/activate
+echo "Python: $(which python)"
+echo "pip:    $(which pip)"

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eo pipefail
+sudo apt --no-install-recommends install -yq \
+    libosmesa6 libglx-mesa0 libopengl0 libglx0 libdbus-1-3 libxkbcommon-x11-0 \
+    libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
+    libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 \
+    xvfb texlive texlive-latex-extra latexmk optipng tex-gyre graphviz \
+    python3.10-venv python3-venv
+python3.10 -m venv ~/python_env
+echo "set -e" >> "$BASH_ENV"
+echo 'export DISPLAY=:99' >> "$BASH_ENV"
+echo 'export XDG_RUNTIME_DIR=/tmp/runtime-circleci' >> "$BASH_ENV"
+echo "source ~/python_env/bin/activate" >> "$BASH_ENV"
+/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -2,7 +2,9 @@
 
 set -eo pipefail
 sudo apt update
-sudo apt --no-install-recommends install -yq optipng graphviz python3-venv
+sudo apt --no-install-recommends install -yq \
+    libopengl0 libegl1 libosmesa6 mesa-utils \  # 3D
+    optipng graphviz python3-venv  # sphinx-gallery
 python3 -m venv ~/python_env
 echo "set -e" >> "$BASH_ENV"
 echo "source ~/python_env/bin/activate" >> "$BASH_ENV"

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -8,7 +8,6 @@ sudo apt --no-install-recommends install -yq \
 python3 -m venv ~/python_env
 echo "set -e" >> "$BASH_ENV"
 echo "source ~/python_env/bin/activate" >> "$BASH_ENV"
-/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset
 source ~/python_env/bin/activate
 echo "Python: $(which python)"
 echo "pip:    $(which pip)"

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -3,8 +3,8 @@
 set -eo pipefail
 sudo apt update
 sudo apt --no-install-recommends install -yq \
-    libgl1 libosmesa6 mesa-utils \  # 3D
-    optipng graphviz python3-venv  # sphinx-gallery
+    libgl1 libosmesa6 mesa-utils \
+    optipng graphviz python3-venv
 python3 -m venv ~/python_env
 echo "set -e" >> "$BASH_ENV"
 echo "source ~/python_env/bin/activate" >> "$BASH_ENV"

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -3,13 +3,10 @@
 set -eo pipefail
 sudo apt update
 sudo apt --no-install-recommends install -yq \
-    libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6 mesa-utils libxcb-shape0 libxcb-cursor0 xvfb \
     texlive texlive-latex-extra latexmk optipng tex-gyre graphviz \
     python3-venv
 python3 -m venv ~/python_env
 echo "set -e" >> "$BASH_ENV"
-echo 'export DISPLAY=:99' >> "$BASH_ENV"
-echo 'export XDG_RUNTIME_DIR=/tmp/runtime-circleci' >> "$BASH_ENV"
 echo "source ~/python_env/bin/activate" >> "$BASH_ENV"
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset
 source ~/python_env/bin/activate

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -2,9 +2,7 @@
 
 set -eo pipefail
 sudo apt update
-sudo apt --no-install-recommends install -yq \
-    texlive texlive-latex-extra latexmk optipng tex-gyre graphviz \
-    python3-venv
+sudo apt --no-install-recommends install -yq optipng graphviz python3-venv
 python3 -m venv ~/python_env
 echo "set -e" >> "$BASH_ENV"
 echo "source ~/python_env/bin/activate" >> "$BASH_ENV"

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ doc/auto_plotly_examples
 doc/auto_pyvista_examples
 doc/tutorials/
 doc/gen_modules/
+doc/sg_execution_times.rst
 
 # Test builds
 sphinx_gallery/tests/tinybuild/doc/gen_modules/


### PR DESCRIPTION
CircleCI is sometimes a bottleneck, this attempts to refactor it to use a single `setup_env` step whose workspace then gets reused by the `html`, `tinybuild`, and `latexpdf` jobs.