### PR TITLE
[ENH] Minigallery can take arbitrary files/glob patterns as input

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           environment-name: test
           init-shell: bash
-          create-args: 'python=${{ env.PYTHON_VERSION }} pip numpy setuptools matplotlib pillow pytest pytest-cov coverage seaborn statsmodels plotly joblib wheel libiconv pygraphviz memory_profiler ipython pypandoc conda-libmamba-solver mamba'
+          create-args: 'python=${{ env.PYTHON_VERSION }} pip numpy setuptools matplotlib pillow pytest pytest-cov coverage seaborn statsmodels plotly joblib wheel libiconv pygraphviz memory_profiler ipython pypandoc lxml conda-libmamba-solver mamba'
         if: matrix.distrib == 'mamba'
       # Make sure that things work even if the locale is set to C (which
       # effectively means ASCII). Some of the input rst files have unicode

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -34,7 +34,7 @@ elif [ "$SPHINX_VERSION" != "default" ]; then
 fi
 
 set -x
-pip install $EXTRA_ARGS $PIP_DEPENDENCIES pytest pytest-cov coverage pydata-sphinx-theme -e .
+pip install $EXTRA_ARGS $PIP_DEPENDENCIES pytest pytest-cov coverage pydata-sphinx-theme lxml -e .
 set +x
 
 # "pip install pygraphviz" does not guarantee graphviz binaries exist

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,3 +12,4 @@ absl-py
 graphviz
 packaging
 jupyterlite-sphinx
+lxml

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,7 +18,7 @@ from datetime import date
 import warnings
 
 import sphinx_gallery
-from sphinx_gallery.sorting import FileNameSortKey, FunctionSortKey
+from sphinx_gallery.sorting import FileNameSortKey
 from sphinx_gallery.notebook import add_markdown_cell, add_code_cell
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -451,10 +451,6 @@ sphinx_gallery_conf = {
     "compress_images": ("images", "thumbnails"),
     # specify the order of examples to be according to filename
     "within_subsection_order": FileNameSortKey,
-    # put duplicate figure at end
-    "minigallery_sort_order": FunctionSortKey(
-        lambda x: (not x.startswith("plot_4b"), x)
-    ),
     "expected_failing_examples": [
         "../examples/no_output/plot_raise.py",
         "../examples/no_output/plot_syntaxerror.py",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,7 +18,7 @@ from datetime import date
 import warnings
 
 import sphinx_gallery
-from sphinx_gallery.sorting import FileNameSortKey
+from sphinx_gallery.sorting import FileNameSortKey, FunctionSortKey
 from sphinx_gallery.notebook import add_markdown_cell, add_code_cell
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -451,6 +451,10 @@ sphinx_gallery_conf = {
     "compress_images": ("images", "thumbnails"),
     # specify the order of examples to be according to filename
     "within_subsection_order": FileNameSortKey,
+    # put duplicate figure at end
+    "minigallery_sort_order": FunctionSortKey(
+        lambda x: (not x.startswith("plot_4b"), x)
+    ),
     "expected_failing_examples": [
         "../examples/no_output/plot_raise.py",
         "../examples/no_output/plot_syntaxerror.py",

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -687,11 +687,11 @@ list of arguments:
 Sort mini-gallery thumbnails from files
 """""""""""""""""""""""""""""""""""""""
 
-The minigallery directive generates a gallery of thumbnails corresponding to
-the input file strings or object names.
+The :ref:`minigallery <minigalleries_to_examples>` directive generates a gallery of
+thumbnails corresponding to the input file strings or object names.
 You can specify minigallery thumbnails order via the ``minigallery_sort_order``
-configuration, which gets passed to :py:func:`sorted` ``key`` parameter when sorting
-all minigalleries.
+configuration, which gets passed to the :py:func:`sorted` ``key`` parameter when
+sorting all minigalleries.
 Sorting uses the gallery example filenames (e.g., ``plot_example.py``) and
 backreference filenames (e.g., ``numpy.exp.examples``)
 corresponding to all inputs.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -709,7 +709,7 @@ corresponding to all inputs.
 See :ref:`own_sort_keys` for details on writing a custom sort key. Below is an
 example of using :class:`sphinx_gallery.sorting.FunctionSortKey` to put
 backreference thumbnails at the end. Note that
-backreference filenames do not start with 'plot_' and ``False`` gets sorted ahead
+backreference filenames do not start with "plot\_" and ``False`` gets sorted ahead
 of ``True`` (as 0 is less than 1).
 
 .. code-block:: python

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -420,17 +420,18 @@ information, see :ref:`own_sort_keys`.
 Custom sort keys
 ================
 
-You can create a custom sort key class for the following configurations:
+You can create a custom sort key callable for the following configurations:
 
 * :ref:`subsection_order <sub_gallery_order>`
 * :ref:`within_subsection_order <within_gallery_order>`
 * :ref:`minigallery_sort_order <minigallery_order>`
 
 We recommend that you use the :class:`sphinx_gallery.sorting.FunctionSortKey`
-because it will ensure that the ``__repr__`` of your class is stable across runs
-(see below). Simply pass your sort key function when creating a new instance of
-:class:`sphinx_gallery.sorting.FunctionSortKey`.
+because it will ensure that the ``__repr__`` of your callable is stable across runs
+(see below).
 
+Create your callable by passing your sort key function to
+:class:`~sphinx_gallery.sorting.FunctionSortKey` when initializing an instance.
 For example, the following ``within_subsection_order`` configuration will sort
 using the first 10 letters of each filename:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -48,7 +48,6 @@ file, inside a ``sphinx_gallery_conf`` dictionary.
 **Cross-referencing**
 
 - ``reference_url``, ``prefer_full_module`` (:ref:`link_to_documentation`)
-- ``minigallery_sort_order`` (:ref:`minigallery_order`)
 - ``backreferences_dir``, ``doc_module``, ``exclude_implicit_doc``,
   and ``inspect_global_variables`` (:ref:`references_to_examples`)
 - ``minigallery_sort_order`` (:ref:`minigalleries_to_examples`)
@@ -383,10 +382,8 @@ sortkey per gallery. You can use Linux paths, and if your documentation is
 built in a Windows system, paths will be transformed to work accordingly,
 the converse does not hold.
 
-If you so desire you can implement your own sorting key. It will be
-provided the relative paths to `conf.py` of each sub gallery folder.
-Note that it will be passed the subfolder path relative to the ``conf.py`` file.
-See :ref:`own_sort_keys` for more.
+If you implement your own sorting key, it will be passed the subfolder path
+relative to the ``conf.py`` file. See :ref:`own_sort_keys` for more information.
 
 .. _within_gallery_order:
 
@@ -414,27 +411,28 @@ In addition, multiple convenience classes are provided for use with
 - :class:`sphinx_gallery.sorting.FileNameSortKey` to sort by file name.
 - :class:`sphinx_gallery.sorting.ExampleTitleSortKey` to sort by example title.
 
-You can also create your own using :class:`sphinx_gallery.sorting.FunctionSortKey`.
-Note that it will be passed the example file name.
-See :ref:`own_sort_keys` for more.
+You can create a custom sorting function using :class:`sphinx_gallery.sorting.FunctionSortKey`.
+Note that this sorting key will be passed the example file name. For more
+information, see :ref:`own_sort_keys`.
 
 .. _own_sort_keys:
 
-You own sort keys
-=================
+Custom sort keys
+================
 
-You can create your own sort key class for the following configurations:
+You can create a custom sort key class for the following configurations:
 
 * :ref:`subsection_order <sub_gallery_order>`
 * :ref:`within_subsection_order <within_gallery_order>`
 * :ref:`minigallery_sort_order <minigallery_order>`
 
-We recommend that you use :class:`sphinx_gallery.sorting.FunctionSortKey` class,
-which will ensure ``__repr__`` of your class is stable across runs (see below).
-Simply pass your sort key function when creating a new instance of
-:class:`sphinx_gallery.sorting.FunctionSortKey`. For example, the following
-``within_subsection_order`` configuration will sort using the first 10 letters
-of each filename:
+We recommend that you use the :class:`sphinx_gallery.sorting.FunctionSortKey`
+because it will ensure that the ``__repr__`` of your class is stable across runs
+(see below). Simply pass your sort key function when creating a new instance of
+:class:`sphinx_gallery.sorting.FunctionSortKey`.
+
+For example, the following ``within_subsection_order`` configuration will sort
+using the first 10 letters of each filename:
 
 .. code-block:: python
 
@@ -445,21 +443,21 @@ of each filename:
     #...
     }
 
-When creating your own sort key classes, you must ensure
-that the ``__repr__`` of your class is stable across runs.
-Sphinx determines if the build environment has changed
-(and thus if *all* documents should be rewritten)
-by examining the config values using
-``md5(str(obj).encode()).hexdigest()`` in
-``sphinx/builders/html.py``. Default class instances
-in Python have their memory address in their ``__repr__`` which
-will in general change for each build. For example, in
-:class:`sphinx_gallery.sorting.ExplicitOrder` this is fixed via::
+When creating a custom sort key class, you must ensure that the ``__repr__`` of
+the class is stable across runs. Sphinx determines if the build environment has
+changed, and thus if *all* documents should be rewritten, by examining the
+config values using ``md5(str(obj).encode()).hexdigest()`` in
+``sphinx/builders/html.py``. Default class instances in Python have their
+memory address in their ``__repr__`` which is why generally the ``__repr__``
+changes in each build.
+
+For example, in :class:`sphinx_gallery.sorting.ExplicitOrder` stability is
+ensured via the custom ``__repr__``::
 
     def __repr__(self):
         return '<%s: %s>' % (self.__class__.__name__, self.ordered_list)
 
-Thus the files are only all rebuilt if the specified ordered list
+Therefore, the files are only all rebuilt when the specified ordered list
 is changed.
 
 .. _link_to_documentation:
@@ -562,9 +560,9 @@ examples that use the specific function ``numpy.exp``, the example
         ../examples/plot_0_sin.py
         ../examples/plot_4*
 
-Listing multiple items merges all the examples into a
-single mini-gallery. The mini-gallery will only be shown if the files exist or
-the items are actually used or referred to in an example.
+Listing multiple items merges all the examples into a single mini-gallery. The
+mini-gallery will only be shown if the files exist or the items are actually
+used or referred to in an example.
 
 .. minigallery::
     :add-heading:
@@ -573,7 +571,7 @@ the items are actually used or referred to in an example.
     ../examples/plot_0_sin.py
     ../examples/plot_4*
 
-You can also provide the list of items in the body of the directive like so:
+You can also provide the list of items in the body of the directive:
 
 .. code-block:: rst
 
@@ -584,12 +582,15 @@ You can also provide the list of items in the body of the directive like so:
         ../examples/plot_0_sin.py
         ../examples/plot_4*
 
-The ``add-heading`` option adds a heading for the mini-gallery. If no string argument
-is provided the default heading will be:
-"Examples using *{full qualified object name}*" (when only a single item is listed).
-Specifying a custom heading message is
-recommended for a gallery with multiple items because otherwise the default message is
-"Examples of one of multiple objects".
+The ``add-heading`` option adds a heading for the mini-gallery. If no string
+argument is provided, when only a single item is listed the default heading is:
+
+    "Examples using *{full qualified object name}*"
+
+Specifying a custom heading message is recommended for a gallery with multiple
+items because otherwise the default message is:
+
+    "Examples of one of multiple objects".
 
 The example mini-gallery shown above uses the default heading level ``^``. This
 can be changed using the ``heading-level`` option, which accepts a single
@@ -701,16 +702,15 @@ Sort mini-gallery thumbnails from files
 
 The minigallery directive generates a gallery of thumbnails corresponding to
 the input file strings or object names. The ordering of these thumbnails can be
-set using the ``minigallery_sort_order`` configuration, which takes a sort key
-function. It will be passed the path to the gallery examples (e.g.,
-``plot_example.py``) as a string
-and backreference file paths (e.g., ``numpy.exp.examples``),
-from all the input items.
-See :ref:`own_sort_keys` for details on writing your own sort key.
+set using the ``minigallery_sort_order`` configuration, which takes a
+:mod:`sphinx_gallery.sorting` function. The sort key is given the paths to
+the gallery examples (e.g., ``plot_example.py``) and backreference files
+(e.g., ``numpy.exp.examples``) corresponding to the path and qualified name
+inputs respectively.
 
-We recommend using the :class:`sphinx_gallery.sorting.FunctionSortKey` class. Below
-is an example that puts the backreference thumbnails at the end of the
-list.
+See :ref:`own_sort_keys` for details on writing a custom sort key. Here is an
+example of using :class:`sphinx_gallery.sorting.FunctionSortKey` to wrap a
+custom sort key that puts the backreference thumbnails at the end of the list:
 
 .. code-block:: python
 
@@ -724,9 +724,10 @@ list.
 Sorting the set of thumbnails generated from
 :ref:`API backreferences <references_to_examples>` (i.e. the thumbnails linked
 to a qualified object name input) is not supported, but the sorting function can
-be used to position the entire set of backreference thumbnails since it get passed
-the ``{input}.example`` file naming pattern. Thumbnails may be duplicated if
-they correspond to multiple object names or an object name and file/glob input.
+be used to position the entire set of backreference thumbnails since it gets
+passed the ``{input}.example`` file naming pattern. Thumbnails may be duplicated
+if they correspond to multiple object names or an object name and file/glob
+input.
 
 Auto-documenting your API with links to examples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1671,7 +1672,7 @@ The following scrapers are supported:
     how to integrate with Sphinx-Gallery.
 - qtgallery
     This library provides a scraper for Qt windows. See `their repository <https://github.com/ixjlyons/qtgallery>`_
-    for instructions on integrating with Sphinx-Gallery. 
+    for instructions on integrating with Sphinx-Gallery.
 
 It is possible to write custom scrapers for images generated by packages
 outside of those listed above. This is accomplished

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -50,7 +50,7 @@ file, inside a ``sphinx_gallery_conf`` dictionary.
 - ``reference_url``, ``prefer_full_module`` (:ref:`link_to_documentation`)
 - ``backreferences_dir``, ``doc_module``, ``exclude_implicit_doc``,
   and ``inspect_global_variables`` (:ref:`references_to_examples`)
-- ``minigallery_sort_order`` (:ref:`minigalleries_to_examples`)
+- ``minigallery_sort_order`` (:ref:`minigallery_order`)
 
 **Images and thumbnails**
 
@@ -537,68 +537,9 @@ directive so that you can easily add a reduced version of the Gallery to
 your Sphinx documentation ``.rst`` files. The mini-gallery directive therefore
 supports passing a list (space separated) of any of the following:
 
-* full qualified name of object
-* pathlike strings to example Python files (relative to ``conf.py``)
-* glob-style pathlike strings to example Python files (relative to ``conf.py``)
-
-For example, the rst below adds the reduced version of the Gallery for all
-examples that use the specific function ``numpy.exp``, the example
-``examples/plot_sin_.py``, and all files matching the string
-``/examples/plot_4*``:
-
-.. code-block:: rst
-
-    .. minigallery::
-        :add-heading:
-
-        numpy.exp
-        ../examples/plot_0_sin.py
-        ../examples/plot_4*
-
-Listing multiple items merges all the examples into a single mini-gallery. The
-mini-gallery will only be shown if the files exist or the items are actually
-used or referred to in an example. Thumbnails may also be duplicated
-if they correspond to multiple object names or an object name and file/glob
-input.
-
-.. minigallery::
-    :add-heading:
-
-    numpy.exp
-    ../examples/plot_0_sin.py
-    ../examples/plot_4*
-
-You can also provide the list of items in the body of the directive:
-
-.. code-block:: rst
-
-    .. minigallery::
-        :add-heading:
-
-        numpy.exp
-        ../examples/plot_0_sin.py
-        ../examples/plot_4*
-
-The ``add-heading`` option adds a heading for the mini-gallery. If no string
-argument is provided, when only a single item is listed the default heading is:
-
-    "Examples using *{full qualified object name}*"
-
-Specifying a custom heading message is recommended for a gallery with multiple
-items because otherwise the default message is:
-
-    "Examples of one of multiple objects".
-
-The example mini-gallery shown above uses the default heading level ``^``. This
-can be changed using the ``heading-level`` option, which accepts a single
-character (e.g., ``-``).
-
-You can also pass inputs to the minigallery directive as a space separated
-list of arguments:
-
-.. code-block:: rst
-
-    .. minigallery:: numpy.exp ../examples/plot_0_sin.py ../examples/plot_4*
+* full qualified name of object (see :ref:`references_to_examples`)
+* pathlike strings to example Python files, including glob-style
+  (see :ref:`file_based_minigalleries`)
 
 .. _references_to_examples:
 
@@ -682,15 +623,64 @@ mini-gallery directive therefore also supports passing in:
 * pathlike strings to sphinx gallery example files (relative to ``conf.py``)
 * glob-style pathlike strings to sphinx-gallery example files (relative to ``conf.py``)
 
+For example, the rst below adds the reduced version of the Gallery for all
+examples that use the specific function ``numpy.exp``, the example
+``examples/plot_sin_.py``, and all files matching the string
+``/examples/plot_4*``:
+
+.. code-block:: rst
+
+    .. minigallery::
+        :add-heading:
+
+        numpy.exp
+        ../examples/plot_0_sin.py
+        ../examples/plot_4*
+
+Listing multiple items merges all the examples into a single mini-gallery. The
+mini-gallery will only be shown if the files exist or the items are actually
+used or referred to in an example. Thumbnails may also be duplicated
+if they correspond to multiple object names or an object name and file/glob
+input.
+
+.. minigallery::
+    :add-heading:
+
+    numpy.exp
+    ../examples/plot_0_sin.py
+    ../examples/plot_4*
+
+You can also provide the list of items in the body of the directive:
+
+.. code-block:: rst
+
+    .. minigallery::
+        :add-heading:
+
+        numpy.exp
+        ../examples/plot_0_sin.py
+        ../examples/plot_4*
+
+The ``add-heading`` option adds a heading for the mini-gallery. If no string
+argument is provided, when only a single item is listed the default heading is:
+
+    "Examples using *{full qualified object name}*"
+
+Specifying a custom heading message is recommended for a gallery with multiple
+items because otherwise the default message is:
+
+    "Examples of one of multiple objects".
+
+The example mini-gallery shown above uses the default heading level ``^``. This
+can be changed using the ``heading-level`` option, which accepts a single
+character (e.g., ``-``).
+
+You can also pass inputs to the minigallery directive as a space separated
+list of arguments:
+
 .. code-block:: rst
 
     .. minigallery:: numpy.exp ../examples/plot_0_sin.py ../examples/plot_4*
-
-.. minigallery:: numpy.exp ../examples/plot_0_sin.py ../examples/plot_4*
-    :add-heading: Mini-gallery using paths
-    :heading-level: ^
-
-See :ref:`Add mini-galleries <minigalleries_to_examples>` for more details.
 
 .. _minigallery_order:
 

--- a/doc/utils.rst
+++ b/doc/utils.rst
@@ -35,4 +35,4 @@ Minigalllery directive
 
 Sphinx-Gallery provides the ``minigallery`` directive so you can easily add a reduced
 version of the gallery to your documentation.
-See :ref:`minigalleries_to_examples`
+See :ref:`minigalleries_to_examples` for details.

--- a/doc/utils.rst
+++ b/doc/utils.rst
@@ -29,3 +29,10 @@ This will download directly from PyPI our latest released code and
 save it to the current folder. This is a stripped version of the
 Sphinx-Gallery module to incorporate in your project. You should also
 add it to your version control system.
+
+Minigalllery directive
+======================
+
+Sphinx-Gallery provides the ``minigallery`` directive so you can easily add a reduced
+version of the gallery to your documentation.
+See :ref:`minigalleries_to_examples`

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -27,9 +27,12 @@ THUMBNAIL_PARENT_DIV = """
 
     <div class="sphx-glr-thumbnails">
 
+.. thumbnail-parent-div-open
 """
 
 THUMBNAIL_PARENT_DIV_CLOSE = """
+.. thumbnail-parent-div-close
+
 .. raw:: html
 
     </div>

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -115,7 +115,7 @@ class MiniGallery(Directive):
         sortkey = config.sphinx_gallery_conf["minigallery_sort_order"]
         for obj, path in sorted(
             set(file_paths),
-            key=((lambda x: sortkey(str(x[-1].name)) if sortkey else None)),
+            key=((lambda x: sortkey(str(x[-1].name))) if sortkey else None),
         ):
             if path.suffix == ".examples":
                 # Insert the backreferences file(s) using the `include` directive.

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -104,9 +104,7 @@ class MiniGallery(Directive):
             if path := has_backrefs(obj):
                 file_paths.append((obj, path))
             elif paths := Path(src_dir).glob(obj):
-                file_paths.extend(
-                    [(obj, p) for p in paths if (obj, p) not in file_paths]
-                )
+                file_paths.extend([(obj, p) for p in paths])
 
         if len(file_paths) == 0:
             return []
@@ -115,7 +113,7 @@ class MiniGallery(Directive):
 
         # sort on the str(file path but keep (obj, path) pair
         for obj, path in sorted(
-            file_paths,
+            set(file_paths),
             key=lambda x: config.sphinx_gallery_conf["minigallery_sort_order"](
                 str(x[-1])
             ),

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -115,8 +115,7 @@ class MiniGallery(Directive):
         sortkey = config.sphinx_gallery_conf["minigallery_sort_order"]
         for obj, path in sorted(
             set(file_paths),
-            key=((lambda x: sortkey(str(x[-1].name)) if sortkey else None)
-            ),
+            key=((lambda x: sortkey(str(x[-1].name)) if sortkey else None)),
         ):
             if path.suffix == ".examples":
                 # Insert the backreferences file(s) using the `include` directive.

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -111,11 +111,11 @@ class MiniGallery(Directive):
 
         lines.append(THUMBNAIL_PARENT_DIV)
 
-        # sort on the str(file path but keep (obj, path) pair
+        # sort on the str(file_path) but keep (obj, path) pair
+        sortkey = config.sphinx_gallery_conf["minigallery_sort_order"]
         for obj, path in sorted(
             set(file_paths),
-            key=lambda x: config.sphinx_gallery_conf["minigallery_sort_order"](
-                str(x[-1])
+            key=((lambda x: sortkey(str(x[-1].name)) if sortkey else None)
             ),
         ):
             if path.suffix == ".examples":

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -71,6 +71,7 @@ DEFAULT_GALLERY_CONF = {
     "reset_argv": DefaultResetArgv(),
     "subsection_order": None,
     "within_subsection_order": NumberOfCodeLinesSortKey,
+    "minigallery_sort_order": None,
     "gallery_dirs": "auto_examples",
     "backreferences_dir": None,
     "doc_module": (),

--- a/sphinx_gallery/sorting.py
+++ b/sphinx_gallery/sorting.py
@@ -134,3 +134,27 @@ class ExampleTitleSortKey(_SortKey):
         _, script_blocks = split_code_and_text_blocks(src_file)
         _, title = extract_intro_and_title(src_file, script_blocks[0][1])
         return title
+
+
+class FunctionSortKey:
+    """Sort examples using a function passed through to :py:func:`sorted`.
+
+    Parameters
+    ----------
+    func : :external+python:term:`callable`
+           sorting key function,
+           can only take one argument, i.e. lambda func = arg: arg[0] * arg[1]
+    r : str, None
+        printable representation of object
+    """
+
+    def __init__(self, func, r=None):
+        self.f = func
+        self.r = r
+
+    def __repr__(self):
+        return self.r if self.r else "FunctionSortKey"
+
+    def __call__(self, arg):
+        """Return func(arg)."""
+        return self.f(arg)

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -14,6 +14,7 @@ import time
 import glob
 import json
 
+import lxml.html
 from packaging.version import Version
 
 from sphinx import __version__ as sphinx_version
@@ -1069,69 +1070,113 @@ def test_backreference_labels(sphinx_app):
     assert link in html
 
 
-@pytest.mark.parametrize(
-    "test, nlines, filenamesortkey",
-    [
-        # first example, no heading
-        ("Test 1-N", 5, False),
-        # first example, default heading, default level
-        ("Test 1-D-D", 7, False),
-        # first example, default heading, custom level
-        ("Test 1-D-C", 7, False),
-        # first example, custom heading, default level
-        ("Test 1-C-D", 8, False),
-        # both examples, no heading
-        ("Test 2-N", 10, True),
-        # both examples, default heading, default level
-        ("Test 2-D-D", 13, True),
-        # both examples, custom heading, custom level
-        ("Test 2-C-C", 14, True),
-    ],
-)
-def test_minigallery_directive(sphinx_app, test, nlines, filenamesortkey):
-    """Tests the functionality of the minigallery directive."""
+@pytest.fixture(scope="module")
+def minigallery_tree(sphinx_app):
     out_dir = sphinx_app.outdir
     minigallery_html = op.join(out_dir, "minigallery.html")
     with codecs.open(minigallery_html, "r", "utf-8") as fid:
-        lines = fid.readlines()
+        tree = lxml.html.fromstring(fid.read())
 
-    # Regular expressions for matching
-    any_heading = re.compile(r"<h([1-6])>.+<\/h\1>")
-    explicitorder_example = re.compile(
-        r"(?s)<img .+" r"(plot_second_future_imports).+" r"auto_examples\/\1\.html"
+    names = tree.xpath('//p[starts-with(text(), "Test")]')
+    divs = tree.find_class("sphx-glr-thumbnails")
+    assert len(names) == len(divs)
+    return {name.text_content(): div for name, div in zip(names, divs)}
+
+
+@pytest.mark.parametrize(
+    "test, heading, sortkey",
+    [
+        # first example, no heading
+        ("Test 1-N", None, {"explicit"}),
+        # first example, default heading, default level
+        (
+            "Test 1-D-D",
+            ("h2", "Examples using sphinx_gallery.sorting.ExplicitOrder"),
+            {"explicit"},
+        ),
+        # first example, default heading, custom level
+        (
+            "Test 1-D-C",
+            ("h3", "Examples using sphinx_gallery.sorting.ExplicitOrder"),
+            {"explicit"},
+        ),
+        # first example, custom heading, default level
+        ("Test 1-C-D", ("h2", "This is a custom heading"), {"explicit"}),
+        # both examples, no heading
+        ("Test 2-N", None, {"explicit", "filename"}),
+        # both examples, default heading, default level
+        (
+            "Test 2-D-D",
+            ("h2", "Examples using one of multiple objects"),
+            {"explicit", "filename"},
+        ),
+        # both examples, custom heading, custom level
+        (
+            "Test 2-C-C",
+            ("h1", "This is a different custom heading"),
+            {"explicit", "filename"},
+        ),
+        # filepath, no heading
+        ("Test 1-F", None, {"path"}),
+        # glob, no heading
+        ("Test 2-F-G", None, {"glob"}),
+        # all files
+        (
+            "Test 3-F-G-B",
+            ("h2", "All the input types", ""),
+            {"path", "glob", "explicit", "filename"},
+        ),
+        ("Test 1-F-R", None, ["plot_boo", "plot_cos"]),
+        ("Test 1-S", None, ["plot_sub2", "plot_sub1"]),
+        ("Test 3-N", None, {"path", "glob", "explicit", "filename"}),
+    ],
+)
+def test_minigallery_directive(minigallery_tree, test, heading, sortkey):
+    """Tests the functionality of the minigallery directive."""
+    assert test in minigallery_tree
+
+    text = minigallery_tree[test]
+
+    assert text is not None
+
+    heading_element = text.xpath(
+        'preceding-sibling::*[position()=1 and starts-with(name(), "h")]'
     )
-    filenamesortkey_example = re.compile(
-        r"(?s)<img .+" r"(plot_numpy_matplotlib).+" r"auto_examples\/\1\.html"
-    )
-    # Heading strings
-    heading_str = {
-        "Test 1-N": None,
-        "Test 1-D-D": r"<h2>Examples using .+ExplicitOrder.+<\/h2>",
-        "Test 1-D-C": r"<h3>Examples using .+ExplicitOrder.+<\/h3>",
-        "Test 1-C-D": r"<h2>This is a custom heading.*<\/h2>",
-        "Test 2-N": None,
-        "Test 2-D-D": r"<h2>Examples using one of multiple objects.*<\/h2>",
-        "Test 2-C-C": r"<h1>This is a different custom heading.*<\/h1>",
-    }
+    # Check headings
+    if heading:
+        assert heading_element[0].tag == heading[0]
+        assert heading_element[0].text_content().startswith(heading[1])
+    else:
+        assert heading_element == []
 
-    for i in range(len(lines)):
-        if test in lines[i]:
-            text = "".join(lines[i : i + nlines])
-            print(f"{test}: {text}")
-            # Check headings
-            if heading_str[test]:
-                heading = re.compile(heading_str[test])
-                assert heading.search(text) is not None
-            else:
-                # Confirm there isn't a heading
-                assert any_heading.search(text) is None
+    if test in ["Test 1-F-R", "Test 1-S"]:
+        img = text.xpath('descendant::img[starts-with(@src, "_images/sphx_glr")]')
+        href = text.xpath('descendant::a[starts-with(@href, "auto_examples_with_rst")]')
 
-            # Check for examples
-            assert explicitorder_example.search(text) is not None
-            if filenamesortkey:
-                assert filenamesortkey_example.search(text) is not None
+        for p, i, h in zip(sortkey, img, href):
+            assert (p in i.values()[-1]) and (p in h.values()[-1])
+    else:
+        examples = {
+            "explicit": "plot_second_future_imports",
+            "filename": "plot_numpy_matplotlib",
+            "path": "plot_log",
+            "glob": "plot_matplotlib_alt",
+        }
+
+        for key, fname in examples.items():
+            img = text.xpath(
+                f'descendant::img[@src = "_images/sphx_glr_{fname}_thumb.png"]'
+            )
+            href = text.xpath(
+                f'descendant::a[starts-with(@href, "auto_examples/{fname}.html")]'
+            )
+            if key in sortkey:
+                assert img and href
+
             else:
-                assert filenamesortkey_example.search(text) is None
+                assert not (img or href)
+
+    print(f"{test}: {lxml.html.tostring(text)}")
 
 
 def test_matplotlib_warning_filter(sphinx_app):

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -1127,6 +1127,7 @@ def minigallery_tree(sphinx_app):
             {"path", "glob", "explicit", "filename"},
         ),
         ("Test 1-F-R", None, ["plot_boo", "plot_cos"]),
+        # Also checks sort element is filename only (excluding path)
         ("Test 1-S", None, ["plot_sub2", "plot_sub1"]),
         ("Test 3-N", None, {"path", "glob", "explicit", "filename"}),
     ],

--- a/sphinx_gallery/tests/test_sorting.py
+++ b/sphinx_gallery/tests/test_sorting.py
@@ -12,6 +12,7 @@ from sphinx_gallery.sorting import (
     FileNameSortKey,
     FileSizeSortKey,
     ExampleTitleSortKey,
+    FunctionSortKey,
 )
 
 
@@ -48,3 +49,18 @@ def test_ExplicitOrder_sorting_key():
         assert str(sorter) == f"<{klass.__name__}>"
         out = sorter(op.basename(__file__))
         assert isinstance(out, type_), type(out)
+
+
+def test_Function_sorting_key():
+    data = [(1, 0), (3, 2), (5, 4), (7, 6), (9, 8)]
+
+    def f(x):
+        return x[0] * x[1]
+
+    sorter = FunctionSortKey(f)
+    assert str(sorter).startswith("FunctionSortKey")
+    assert sorted(data, key=f) == sorted(data, key=sorter)
+
+    sorter_repr = FunctionSortKey(f, "f(x,y) = x*y")
+    assert str(sorter_repr).startswith("f(x,y) = x*y")
+    assert sorted(data, key=sorter_repr) == sorted(data, key=sorter)

--- a/sphinx_gallery/tests/tinybuild/doc/conf.py
+++ b/sphinx_gallery/tests/tinybuild/doc/conf.py
@@ -72,6 +72,21 @@ class MockScrapeProblem:
             colorConverter.to_rgba = self._orig
 
 
+class MockSort:
+    """Fake sort used to test that mini-gallery sort is correct."""
+
+    def __repr__(self):
+        return "MockSort"
+
+    def __call__(self, f):
+        """Sort plot_sub* for one test case."""
+        if f.endswith("plot_sub2.py"):
+            return 0
+        if f.endswith("plot_sub1.py"):
+            return 1
+        return f
+
+
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
@@ -129,6 +144,7 @@ sphinx_gallery_conf = {
     ],
     "backreferences_dir": "gen_modules/backreferences",
     "within_subsection_order": FileNameSortKey,
+    "minigallery_sort_order": MockSort(),
     "image_scrapers": (matplotlib_format_scraper(),),
     "expected_failing_examples": [
         "../examples/future/plot_future_imports_broken.py",

--- a/sphinx_gallery/tests/tinybuild/doc/conf.py
+++ b/sphinx_gallery/tests/tinybuild/doc/conf.py
@@ -80,9 +80,9 @@ class MockSort:
 
     def __call__(self, f):
         """Sort plot_sub* for one test case."""
-        if f.endswith("plot_sub2.py"):
+        if f == "plot_sub2.py":
             return 0
-        if f.endswith("plot_sub1.py"):
+        if f == "plot_sub1.py":
             return 1
         return f
 

--- a/sphinx_gallery/tests/tinybuild/doc/make.bat
+++ b/sphinx_gallery/tests/tinybuild/doc/make.bat
@@ -1,0 +1,45 @@
+@ECHO OFF
+
+REM Command file for Sphinx documentation
+
+set SPHINXOPTS = -v
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set BUILDDIR=_build
+set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% .
+
+if "%1" == "clean" (
+	for /d %%i in (%BUILDDIR%\*) do rmdir /q /s %%i
+	del /q /s %BUILDDIR%\*
+	if exist auto_examples rd /q /s auto_examples
+	if exist auto_plotly_examples rd /q /s auto_plotly_examples
+	if exist auto_pyvista_examples rd /q /s auto_pyvista_examples
+	if exist tutorials rd /q /s tutorials
+	if exist gen_modules rd /q /s gen_modules
+	goto end
+)
+
+
+if "%1" == "html" (
+	%SPHINXBUILD% -b html %ALLSPHINXOPTS% %BUILDDIR%/html
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. The HTML pages are in %BUILDDIR%/html.
+	goto end
+)
+
+
+if "%1" == "latexpdf" (
+	%SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
+	cd %BUILDDIR%/latex
+	make all-pdf
+	cd %BUILDDIR%/..
+	echo.
+	echo.Build finished; the PDF files are in %BUILDDIR%/latex.
+	goto end
+)
+
+
+:end

--- a/sphinx_gallery/tests/tinybuild/doc/minigallery.rst
+++ b/sphinx_gallery/tests/tinybuild/doc/minigallery.rst
@@ -35,3 +35,36 @@ Test 2-C-C
 .. minigallery:: sphinx_gallery.sorting.ExplicitOrder sphinx_gallery.sorting.FileNameSortKey
     :add-heading: This is a different custom heading
     :heading-level: =
+
+Test 1-F
+
+.. minigallery:: ../examples/plot_log.py
+
+Test 2-F-G
+
+.. minigallery:: ../examples/plot_matplotlib*.py
+    
+
+Test 3-F-G-B
+
+.. minigallery:: ../examples/plot_log.py ../examples/*matplotlib*.py sphinx_gallery.sorting.ExplicitOrder sphinx_gallery.sorting.FileNameSortKey
+    :add-heading: All the input types
+
+
+Test 1-F-R
+
+.. minigallery:: ../examples_with_rst/*.py
+
+
+Test 1-S
+
+.. minigallery:: ../examples_rst_index/*/*.py
+
+Test 3-N
+
+.. minigallery::
+   
+   ../examples/plot_log.py 
+   ../examples/*matplotlib*.py 
+   sphinx_gallery.sorting.ExplicitOrder 
+   sphinx_gallery.sorting.FileNameSortKey

--- a/sphinx_gallery/tests/tinybuild/doc/minigallery.rst
+++ b/sphinx_gallery/tests/tinybuild/doc/minigallery.rst
@@ -43,7 +43,7 @@ Test 1-F
 Test 2-F-G
 
 .. minigallery:: ../examples/plot_matplotlib*.py
-    
+
 
 Test 3-F-G-B
 
@@ -63,8 +63,8 @@ Test 1-S
 Test 3-N
 
 .. minigallery::
-   
-   ../examples/plot_log.py 
-   ../examples/*matplotlib*.py 
-   sphinx_gallery.sorting.ExplicitOrder 
+
+   ../examples/plot_log.py
+   ../examples/*matplotlib*.py
+   sphinx_gallery.sorting.ExplicitOrder
    sphinx_gallery.sorting.FileNameSortKey


### PR DESCRIPTION
Closes #1029

- [x] still have to finish up tests and docs, but wanted some feedback if this was in the right direction.

- [x] If so, I'm also wondering if I could strip the thumbnail parent div out of the backref files so that I could do it in the loop.
- [x] get .py files in .rst folders working - seems to work by default and issue was sorting
- [x] file sort order