### PR TITLE
MAINT: Fix deployment

### DIFF
--- a/.circleci/docs_deploy.sh
+++ b/.circleci/docs_deploy.sh
@@ -24,6 +24,9 @@ git config --global user.name "bot@try.out" > /dev/null 2>&1
 git clone git@github.com:sphinx-gallery/sphinx-gallery.github.io.git
 
 siteSource="${PWD}/${siteSource}"
+# Stuff that we persist to workspace that we don't want
+rm -Rf "${siteSource}/project"
+rm -Rf "${siteSource}/python_env"
 cd sphinx-gallery.github.io/
 mkdir -p ${destDir}
 destDir="${PWD}/${destDir}"


### PR DESCRIPTION
Closes #1235

Looking at https://github.com/sphinx-gallery/sphinx-gallery.github.io/commits/master you can see I broke stuff in https://github.com/sphinx-gallery/sphinx-gallery/pull/1216. I did the equivalent of the two steps in this PR -- namely, deleting two folders that were persisted to the workspace that should not have been -- and pushed to https://github.com/sphinx-gallery/sphinx-gallery.github.io and now docs are deployed properly. So this PR makes it so that hopefully the next `dev` and `stable` deployments work properly!