### PR TITLE
Simplify Matplotlib scraper

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -284,6 +284,30 @@ def _fill_gallery_conf_defaults(sphinx_gallery_conf, app=None, check_keys=True):
     except (ImportError, ValueError):
         pass
 
+    # Check for srcset hidpi images
+    srcset = gallery_conf["image_srcset"]
+    if not isinstance(srcset, (list, tuple)):
+        raise ConfigError(
+            "image_srcset must be a list of strings with the "
+            'multiplicative factor followed by an "x", '
+            'e.g. ["2.0x", "1.5x"]'
+        )
+    srcset_mult_facs = set()
+    for st in srcset:
+        if not isinstance(st, str) or st[-1:] not in ("", "x"):
+            raise ConfigError(
+                f"Invalid value for image_srcset parameter: {st!r}. "
+                "Must be a list of strings with the multiplicative "
+                'factor followed by an "x".  e.g. ["2.0x", "1.5x"]'
+            )
+        if st == "":
+            continue
+        # "2x" = "2.0"
+        srcset_mult_facs.add(float(st[:-1]))
+    srcset_mult_facs -= {1}  # 1x is always saved.
+    gallery_conf["image_srcset"] = [*sorted(srcset_mult_facs)]
+    del srcset, srcset_mult_facs
+
     # compress_images
     compress_images = gallery_conf["compress_images"]
     if isinstance(compress_images, str):

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -128,21 +128,7 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
 
     image_path_iterator = block_vars["image_path_iterator"]
     image_rsts = []
-    # Check for srcset hidpi images
     srcset = gallery_conf["image_srcset"]
-    srcset_mult_facs = [1]  # one is always supplied...
-    for st in srcset:
-        if (len(st) > 0) and (st[-1] == "x"):
-            # "2x" = "2.0"
-            srcset_mult_facs += [float(st[:-1])]
-        elif st == "":
-            pass
-        else:
-            raise ExtensionError(
-                f'Invalid value for image_srcset parameter: "{st}". '
-                "Must be a list of strings with the multiplicative "
-                'factor followed by an "x".  e.g. ["2.0x", "1.5x"]'
-            )
 
     # Check for animations
     anims = list()
@@ -189,15 +175,13 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
             srcsetpaths = {0: image_path}
 
             # save other srcset paths, keyed by multiplication factor:
-            for mult in srcset_mult_facs:
-                if not (mult == 1):
-                    multst = f"{mult:.2f}".replace(".", "_")
-                    name = f"{image_path.stem}_{multst}x{image_path.suffix}"
-                    hipath = image_path.parent / PurePosixPath(name)
-                    hikwargs = these_kwargs.copy()
-                    hikwargs["dpi"] = mult * dpi0
-                    fig.savefig(hipath, **hikwargs)
-                    srcsetpaths[mult] = hipath
+            for mult in srcset:
+                multst = f"{mult:.2f}".replace(".", "_")
+                name = f"{image_path.stem}_{multst}x{image_path.suffix}"
+                hipath = image_path.parent / PurePosixPath(name)
+                hikwargs = {**these_kwargs, "dpi": mult * dpi0}
+                fig.savefig(hipath, **hikwargs)
+                srcsetpaths[mult] = hipath
             srcsetpaths = [srcsetpaths]
         except Exception:
             plt.close("all")

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -109,10 +109,12 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
         Contains the configuration of Sphinx-Gallery
     **kwargs : dict
         Additional keyword arguments to pass to
-        :meth:`~matplotlib.figure.Figure.savefig`, e.g. ``format='svg'``.
-        The ``format`` kwarg in particular is used to set the file extension
-        of the output file (currently only 'png', 'jpg', 'svg', 'gif', and
-        'webp' are supported).
+        :meth:`~matplotlib.figure.Figure.savefig`, e.g. ``format='svg'``. The
+        ``format`` keyword argument in particular is used to set the file
+        extension of the output file (currently only 'png', 'jpg', 'svg',
+        'gif', and 'webp' are supported).
+
+        This is not used internally, but intended for use when overriding the scraper.
 
     Returns
     -------

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -19,17 +19,20 @@ from sphinx_gallery.scrapers import (
 
 
 @pytest.fixture(scope="function")
-def gallery_conf(tmpdir):
+def make_gallery_conf(tmpdir):
     """Sets up a test sphinx-gallery configuration."""
     # Skip if numpy not installed
     pytest.importorskip("numpy")
 
-    gallery_conf = _fill_gallery_conf_defaults({})
-    gallery_conf.update(
-        src_dir=str(tmpdir), examples_dir=str(tmpdir), gallery_dir=str(tmpdir)
-    )
+    def make_gallery_conf(init=None):
+        gallery_conf = _fill_gallery_conf_defaults(init or {})
+        gallery_conf.update(
+            src_dir=str(tmpdir), examples_dir=str(tmpdir), gallery_dir=str(tmpdir)
+        )
 
-    return gallery_conf
+        return gallery_conf
+
+    return make_gallery_conf
 
 
 class matplotlib_svg_scraper:
@@ -44,10 +47,11 @@ class matplotlib_svg_scraper:
 
 
 @pytest.mark.parametrize("ext", ("png", "svg"))
-def test_save_matplotlib_figures(gallery_conf, ext):
+def test_save_matplotlib_figures(make_gallery_conf, ext):
     """Test matplotlib figure save."""
-    if ext == "svg":
-        gallery_conf["image_scrapers"] = (matplotlib_svg_scraper(),)
+    gallery_conf = make_gallery_conf(
+        {"image_scrapers": (matplotlib_svg_scraper(),)} if ext == "svg" else {}
+    )
     import matplotlib.pyplot as plt  # nest these so that Agg can be set
 
     plt.plot(1, 1)
@@ -77,10 +81,24 @@ def test_save_matplotlib_figures(gallery_conf, ext):
         assert os.path.isfile(fname)
 
 
-def test_save_matplotlib_figures_hidpi(gallery_conf):
+def test_image_srcset_config(make_gallery_conf):
+    with pytest.raises(ConfigError, match="image_srcset must be a list of strings"):
+        make_gallery_conf({"image_srcset": "2x"})
+    with pytest.raises(ConfigError, match="Invalid value for image_srcset parameter"):
+        make_gallery_conf({"image_srcset": [False]})
+    with pytest.raises(ConfigError, match="Invalid value for image_srcset parameter"):
+        make_gallery_conf({"image_srcset": ["200"]})
+
+    conf = make_gallery_conf({"image_srcset": ["2x"]})
+    assert conf["image_srcset"] == [2.0]
+    conf = make_gallery_conf({"image_srcset": ["", "1x", "2x"]})
+    assert conf["image_srcset"] == [2.0]  # "" and "1x" are implied.
+
+
+def test_save_matplotlib_figures_hidpi(make_gallery_conf):
     """Test matplotlib hidpi figure save."""
+    gallery_conf = make_gallery_conf({"image_srcset": ["2x"]})
     ext = "png"
-    gallery_conf["image_srcset"] = [2]
 
     import matplotlib.pyplot as plt  # nest these so that Agg can be set
 
@@ -126,7 +144,7 @@ def _custom_func(x, y, z):
     return y["image_path_iterator"].next()
 
 
-def test_custom_scraper(gallery_conf, monkeypatch):
+def test_custom_scraper(make_gallery_conf, monkeypatch):
     """Test custom scrapers."""
     # Test the API contract for custom scrapers
     with monkeypatch.context() as m:
@@ -134,40 +152,37 @@ def test_custom_scraper(gallery_conf, monkeypatch):
             sphinx_gallery, "_get_sg_image_scraper", lambda: _custom_func, raising=False
         )
         for cust in (_custom_func, "sphinx_gallery"):
-            gallery_conf.update(image_scrapers=[cust])
             # smoke test that it works
-            _fill_gallery_conf_defaults(gallery_conf, check_keys=False)
+            make_gallery_conf({"image_scrapers": [cust]})
     # degenerate
     # without the monkey patch to add sphinx_gallery._get_sg_image_scraper,
     # we should get an error
-    gallery_conf.update(image_scrapers=["sphinx_gallery"])
     with pytest.raises(ConfigError, match="has no attribute '_get_sg_image_scraper'"):
-        _fill_gallery_conf_defaults(gallery_conf, check_keys=False)
+        make_gallery_conf({"image_scrapers": ["sphinx_gallery"]})
 
     # other degenerate conditions
-    gallery_conf.update(image_scrapers=["foo"])
     with pytest.raises(ConfigError, match="Unknown image scraper"):
-        _fill_gallery_conf_defaults(gallery_conf, check_keys=False)
-    gallery_conf.update(image_scrapers=[_custom_func])
-    fname_template = os.path.join(gallery_conf["gallery_dir"], "image{0}.png")
-    image_path_iterator = ImagePathIterator(fname_template)
-    block = ("",) * 3
-    block_vars = dict(image_path_iterator=image_path_iterator)
-    with pytest.raises(ExtensionError, match="did not produce expected image"):
-        save_figures(block, block_vars, gallery_conf)
-    gallery_conf.update(image_scrapers=[lambda x, y, z: 1.0])
-    with pytest.raises(ExtensionError, match="was not a string"):
-        save_figures(block, block_vars, gallery_conf)
+        make_gallery_conf({"image_scrapers": ["foo"]})
+    for cust, msg in [
+        (_custom_func, "did not produce expected image"),
+        (lambda x, y, z: 1.0, "was not a string"),
+    ]:
+        conf = make_gallery_conf({"image_scrapers": [cust]})
+        fname_template = os.path.join(conf["gallery_dir"], "image{0}.png")
+        image_path_iterator = ImagePathIterator(fname_template)
+        block = ("",) * 3
+        block_vars = dict(image_path_iterator=image_path_iterator)
+        with pytest.raises(ExtensionError, match=msg):
+            save_figures(block, block_vars, conf)
     # degenerate string interface
-    gallery_conf.update(image_scrapers=["sphinx_gallery"])
     with monkeypatch.context() as m:
         m.setattr(sphinx_gallery, "_get_sg_image_scraper", "foo", raising=False)
         with pytest.raises(ConfigError, match="^Unknown image.*\n.*callable"):
-            _fill_gallery_conf_defaults(gallery_conf, check_keys=False)
+            make_gallery_conf({"image_scrapers": ["sphinx_gallery"]})
     with monkeypatch.context() as m:
         m.setattr(sphinx_gallery, "_get_sg_image_scraper", lambda: "foo", raising=False)
         with pytest.raises(ConfigError, match="^Scraper.*was not callable"):
-            _fill_gallery_conf_defaults(gallery_conf, check_keys=False)
+            make_gallery_conf({"image_scrapers": ["sphinx_gallery"]})
 
 
 @pytest.mark.parametrize("ext", _KNOWN_IMG_EXTS)
@@ -230,7 +245,7 @@ def test_figure_rst_srcset():
     assert image_rst == single_image
 
     hipaths += [{0: "second.png", 2.0: "second_2_00.png"}]
-    image_rst = figure_rst(figure_list + ["second.png"], ".", srcsetpaths=hipaths + [])
+    image_rst = figure_rst(figure_list + ["second.png"], ".", srcsetpaths=hipaths)
     image_list_rst = """
 .. rst-class:: sphx-glr-horizontal
 
@@ -268,13 +283,14 @@ def test_iterator():
             pass
 
 
-def test_reset_matplotlib(gallery_conf):
+def test_reset_matplotlib(make_gallery_conf):
     """Test _reset_matplotlib."""
     import matplotlib
 
     matplotlib.rcParams["lines.linewidth"] = 42
     matplotlib.units.registry.clear()
 
+    gallery_conf = make_gallery_conf()
     _reset_matplotlib(gallery_conf, "")
 
     assert matplotlib.rcParams["lines.linewidth"] != 42

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -80,7 +80,7 @@ def test_save_matplotlib_figures(gallery_conf, ext):
 def test_save_matplotlib_figures_hidpi(gallery_conf):
     """Test matplotlib hidpi figure save."""
     ext = "png"
-    gallery_conf["image_srcset"] = ["2x"]
+    gallery_conf["image_srcset"] = [2]
 
     import matplotlib.pyplot as plt  # nest these so that Agg can be set
 


### PR DESCRIPTION
Three things:
- Validate `image_srcset` once during configuration, instead of repeatedly on every scraper run. Note, I also passed the scaling numbers through a set, in order to prevent saving extra times.
- Simplify the animation part of the scraper; instead of looping through all animations to match a figure, use a dictionary for direct lookup.
- Add a note about `kwargs` to `matplotlib_scraper`. I was confused why nothing seemed to call it with `kwargs`, but was able to find it in other parts of the documentation. So I mentioned that in the docstring as well.