### PR TITLE
BUG: `UnicodeDecodeError` in recommender

### DIFF
--- a/sphinx_gallery/recommender.py
+++ b/sphinx_gallery/recommender.py
@@ -191,7 +191,7 @@ class ExampleRecommender:
 
         freq_func = self.token_freqs
         counts_matrix = self.dict_vectorizer(
-            [freq_func(Path(fname).read_text()) for fname in file_names]
+            [freq_func(Path(fname).read_text(encoding="utf-8")) for fname in file_names]
         )
         if isinstance(min_df, float):
             min_df = int(np.ceil(min_df * counts_matrix.shape[0]))


### PR DESCRIPTION
See also scikit-learn/scikit-learn#27969. Without specifying the encoding such as utf-8, some systems would use other codecs (e.g. gbk) which cannot decode some characters (e.g. `–`, `“`, `”`). This PR specifies `encoding="utf-8"`.