### PR TITLE
ENH: minigallery_sort_order on full path

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -421,7 +421,7 @@ You can create a custom sort key callable for the following configurations:
 * :ref:`subsection_order <sub_gallery_order>`
 * :ref:`minigallery_sort_order <minigallery_order>`
 
-When creating a custom sort key callable, you must ensure that the ``__repr__`` of
+When creating a custom sort key callable, you must ensure that the ``__repr__``
 is stable across runs. Sphinx determines if the build environment has
 changed, and thus if *all* documents should be rewritten, by examining the
 config values using ``md5(str(obj).encode()).hexdigest()`` in
@@ -444,7 +444,7 @@ because it will ensure that the ``__repr__`` is stable across runs.
 Create your sort key callable by instantiating a
 :class:`~sphinx_gallery.sorting.FunctionSortKey` instance with your sort key
 function. For example, the following ``minigallery_sort_order`` configuration
-(which sorts on filenames) will sort using the first 10 letters of each filename:
+(which sorts on paths) will sort using the first 10 letters of each filename:
 
 .. code-block:: python
 
@@ -692,9 +692,9 @@ thumbnails corresponding to the input file strings or object names.
 You can specify minigallery thumbnails order via the ``minigallery_sort_order``
 configuration, which gets passed to the :py:func:`sorted` ``key`` parameter when
 sorting all minigalleries.
-Sorting uses the gallery example filenames (e.g., ``plot_example.py``) and
-backreference filenames (e.g., ``numpy.exp.examples``)
-corresponding to all inputs.
+Sorting uses the paths to the gallery examples (e.g., ``path/to/plot_example.py``)
+and backreferences (e.g., ``path/to/numpy.exp.examples``) corresponding to the
+inputs.
 
 See :ref:`own_sort_keys` for details on writing a custom sort key. Below is an
 example of using :class:`sphinx_gallery.sorting.FunctionSortKey` to put
@@ -707,7 +707,7 @@ of ``True`` (as 0 is less than 1).
     sphinx_gallery_conf = {
     #...,
     "minigallery_sort_order": FunctionSortKey(
-        lambda x: (not x.startswith("plot_"), x)),
+        lambda x: (not os.path.basename(x).startswith("plot_"), x)),
     #...
     }
 

--- a/doc/utils.rst
+++ b/doc/utils.rst
@@ -30,7 +30,7 @@ save it to the current folder. This is a stripped version of the
 Sphinx-Gallery module to incorporate in your project. You should also
 add it to your version control system.
 
-Minigalllery directive
+Minigallery directive
 ======================
 
 Sphinx-Gallery provides the ``minigallery`` directive so you can easily add a reduced

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -115,7 +115,7 @@ class MiniGallery(Directive):
         sortkey = config.sphinx_gallery_conf["minigallery_sort_order"]
         for obj, path in sorted(
             set(file_paths),
-            key=((lambda x: sortkey(str(x[-1].name))) if sortkey else None),
+            key=((lambda x: sortkey(os.path.abspath(x[-1]))) if sortkey else None),
         ):
             if path.suffix == ".examples":
                 # Insert the backreferences file(s) using the `include` directive.

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -51,7 +51,6 @@ N_OTHER = 9 + 1 + 1 + 1 + 1
 N_RST = N_EXAMPLES + N_PASS + N_INDEX + N_EXECUTE + N_OTHER
 N_RST = f"({N_RST}|{N_RST - 1}|{N_RST - 2})"  # AppVeyor weirdness
 
-
 pytest.importorskip("jupyterlite_sphinx")  # needed for tinybuild
 
 
@@ -1127,7 +1126,6 @@ def minigallery_tree(sphinx_app):
             {"path", "glob", "explicit", "filename"},
         ),
         ("Test 1-F-R", None, ["plot_boo", "plot_cos"]),
-        # Also checks sort element is filename only (excluding path)
         ("Test 1-S", None, ["plot_sub2", "plot_sub1"]),
         ("Test 3-N", None, {"path", "glob", "explicit", "filename"}),
     ],
@@ -1151,8 +1149,11 @@ def test_minigallery_directive(minigallery_tree, test, heading, sortkey):
         assert heading_element == []
 
     if test in ["Test 1-F-R", "Test 1-S"]:
+
         img = text.xpath('descendant::img[starts-with(@src, "_images/sphx_glr")]')
-        href = text.xpath('descendant::a[starts-with(@href, "auto_examples_with_rst")]')
+        href = text.xpath('descendant::a[contains(@href, "rst")]')
+
+        assert img and href
 
         for p, i, h in zip(sortkey, img, href):
             assert (p in i.values()[-1]) and (p in h.values()[-1])

--- a/sphinx_gallery/tests/tinybuild/doc/conf.py
+++ b/sphinx_gallery/tests/tinybuild/doc/conf.py
@@ -80,9 +80,9 @@ class MockSort:
 
     def __call__(self, f):
         """Sort plot_sub* for one test case."""
-        if f == "plot_sub2.py":
+        if "subdir2" in f:
             return 0
-        if f == "plot_sub1.py":
+        if "subdir1" in f:
             return 1
         return f
 


### PR DESCRIPTION
Follow on from #1226, this pr:
* has the sortkey work on full path to account for subdirectories
* fixes the sortkey test and adds check that test is working
* updates docs