### PR TITLE
fix: Missing full stop in download message

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1317,7 +1317,7 @@ EXAMPLE_HEADER = """
         :class: sphx-glr-download-link-note
 
         :ref:`Go to the end <sphx_glr_download_{1}>`
-        to download the full example code{2}
+        to download the full example code.{2}
 
 .. rst-class:: sphx-glr-example-title
 


### PR DESCRIPTION
Add the missing full stop in the examples downlaod note.

Closes #1254 