### PR TITLE
DOC Use 'nested_sections' `True` for docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -474,7 +474,7 @@ sphinx_gallery_conf = {
     "capture_repr": ("_repr_html_", "__repr__"),
     "matplotlib_animations": True,
     "image_srcset": ["2x"],
-    "nested_sections": False,
+    "nested_sections": True,
     "show_api_usage": True,
 }
 


### PR DESCRIPTION
closes #1262

It seems PST does not have the TOC problems described in https://github.com/sphinx-gallery/sphinx-gallery/pull/944#discussion_r916603188 and gives us the sub gallery sub heading in the LHS TOC.

I'll double check the rendered docs to make sure it looks okay.