### PR TITLE
lint: switch from Black to Ruff's "Black"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,9 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.2.0
-    hooks:
-      - id: black
-        args: [--quiet]
-        exclude: plot_syntaxerror
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.2
     hooks:
+      - id: ruff-format
+        exclude: plot_syntaxerror
       - id: ruff
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -550,9 +550,7 @@ def _format_toctree(items, includehidden=False):
 """
     st += """
 
-   {}\n""".format(
-        "\n   ".join(items)
-    )
+   {}\n""".format("\n   ".join(items))
 
     st += "\n"
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -572,9 +572,7 @@ def generate_dir_rst(
    :hidden:
 
    {}\n
-""".format(
-                    "\n   ".join(subsection_toctree_filenames)
-                )
+""".format("\n   ".join(subsection_toctree_filenames))
                 findex.write(subsection_index_toctree)
 
     if have_index_rst:

--- a/sphinx_gallery/interactive_example.py
+++ b/sphinx_gallery/interactive_example.py
@@ -253,8 +253,9 @@ def check_binder_conf(binder_conf):
         binder_conf["binderhub_url"].startswith(ii) for ii in ["http://", "https://"]
     ):
         raise ConfigError(
-            "did not supply a valid url, "
-            "gave binderhub_url: {}".format(binder_conf["binderhub_url"])
+            "did not supply a valid url, " "gave binderhub_url: {}".format(
+                binder_conf["binderhub_url"]
+            )
         )
 
     # Ensure we have at least one dependency file
@@ -266,8 +267,9 @@ def check_binder_conf(binder_conf):
         binder_conf["dependencies"] = path_reqs
     elif not isinstance(path_reqs, (list, tuple)):
         raise ConfigError(
-            "`dependencies` value should be a list of strings. "
-            "Got type {}.".format(type(path_reqs))
+            "`dependencies` value should be a list of strings. " "Got type {}.".format(
+                type(path_reqs)
+            )
         )
 
     binder_conf.setdefault("filepath_prefix")

--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -93,8 +93,9 @@ def _get_docstring_and_rest(filename):
 
     if not isinstance(node, ast.Module):
         raise ExtensionError(
-            "This function only supports modules. "
-            "You provided {}".format(node.__class__.__name__)
+            "This function only supports modules. " "You provided {}".format(
+                node.__class__.__name__
+            )
         )
     if not (
         node.body

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -511,12 +511,8 @@ def test_backreferences(sphinx_app):
     assert op.isfile(html)
     with codecs.open(html, "r", "utf-8") as fid:
         html = fid.read()
-    assert (
-        "sphinx_gallery.sorting.html#sphinx_gallery.sorting.ExplicitOrder" in html
-    )  # noqa: E501
-    assert (
-        "sphinx_gallery.scrapers.html#sphinx_gallery.scrapers.clean_modules" in html
-    )  # noqa: E501
+    assert "sphinx_gallery.sorting.html#sphinx_gallery.sorting.ExplicitOrder" in html  # noqa: E501
+    assert "sphinx_gallery.scrapers.html#sphinx_gallery.scrapers.clean_modules" in html  # noqa: E501
     assert "figure_rst.html" not in html  # excluded
 
 
@@ -1149,7 +1145,6 @@ def test_minigallery_directive(minigallery_tree, test, heading, sortkey):
         assert heading_element == []
 
     if test in ["Test 1-F-R", "Test 1-S"]:
-
         img = text.xpath('descendant::img[starts-with(@src, "_images/sphx_glr")]')
         href = text.xpath('descendant::a[contains(@href, "rst")]')
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -315,9 +315,7 @@ def test_extract_intro_and_title():
     intro, title = sg.extract_intro_and_title("<string>", "\n".join(CONTENT[1:10]))
     assert title == "Docstring header"
     assert "Docstring" not in intro
-    assert (
-        intro == "This is the description of the example which goes on and on, Óscar"
-    )  # noqa
+    assert intro == "This is the description of the example which goes on and on, Óscar"  # noqa
     assert "second paragraph" not in intro
 
     # SG incorrectly grabbing description when a label is defined (gh-232)
@@ -497,9 +495,7 @@ Plot.
 """
 import matplotlib.pyplot as plt
 plt.plot([0, 1], [0, 1])
-'''.split(
-    "\n"
-)
+'''.split("\n")
 
 
 def _alpha_mpl_scraper(block, block_vars, gallery_conf):
@@ -594,9 +590,7 @@ EXCLUDE_CONTENT = '''
 import numpy
 numpy.pi
 numpy.e
-'''.split(
-    "\n"
-)
+'''.split("\n")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
As Ruff [claims](https://pypi.org/project/ruff/0.0.47/#:~:text=ruff%20is%20compatible%20with%20Black,that%20are%20obviated%20by%20autoformatting.) full compatibility with Black, it makes sense just to use one tool for both to prevent eventual collisions