### PR TITLE
More informative title for 'check label' CI workflow

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -16,10 +16,12 @@ jobs:
   check-type-label:
     name: Please wait for a maintainer to add a label
     runs-on: ubuntu-latest
+    # skip for draft PRs
+    if: github.event.pull_request.draft == false
     steps:
       - run: |
           echo "Labels: $LABELS"
           if [[ "$LABELS" != *"bug"* ]] && [[ "$LABELS" != *"enhancement"* ]] && [[ "$LABELS" != *"api"* ]] && [[ "$LABELS" != *"maintenance"* ]] && [[ "$LABELS" != *"documentation"* ]]; then
-            echo "Please add a type label to this PR"
+            echo "A maintainer needs to add an appropriate label before merge."
             exit 1
           fi

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   check-type-label:
-    name: ensure labeled
+    name: Please wait for a maintainer to add a label
     runs-on: ubuntu-latest
     steps:
       - run: |


### PR DESCRIPTION
Follows on from #1270, I agree this CI test is confusing and its annoying to have it be the cause of a PR being 'red'.

This is just a temporary, slight improvement, to at least help prevent confusion for new contributors: change the CI workflow name so contributors can easily see why this test has failed. Happy to change change wording. It's similar to what scikit-learn has for their 'Check Changelog'  check.

Also skips drafts and improves message, copied from #1270.