### PR TITLE
BUG: Fix errors in example usage of ignore_repr_types and reset_argv

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2220,7 +2220,7 @@ etc. Similarly subclasses of 'matplotlib.axes' (e.g. 'matplotlib.axes.Axes',
     sphinx_gallery_conf = {
         ...
         'capture_repr': ('__repr__'),
-        'ignore_repr_types': r'matplotlib[text, axes]',
+        'ignore_repr_types': r'matplotlib\.(text|axes)',
     }
 
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -326,15 +326,20 @@ additional command line arguments to the interpreter.
 
 An example could be::
 
+    from pathlib import Path
+
     class ResetArgv:
         def __repr__(self):
             return 'ResetArgv'
 
         def __call__(self, sphinx_gallery_conf, script_vars):
-            if script_vars['src_file'] == 'example1.py':
+            src_file = Path(script_vars['src_file']).name
+            if src_file == 'example1.py':
                 return ['-a', '1']
-            elif script_vars['src_file'] == 'example2.py':
+            elif src_file == 'example2.py':
                 return ['-a', '2']
+            else:
+                return []
 
 which is included in the configuration dictionary as::
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -328,13 +328,13 @@ An example could be::
 
     class ResetArgv:
         def __repr__(self):
-        return 'ResetArgv'
+            return 'ResetArgv'
 
-    def __call__(self, sphinx_gallery_conf, script_vars):
+        def __call__(self, sphinx_gallery_conf, script_vars):
             if script_vars['src_file'] == 'example1.py':
-            return ['-a', '1']
+                return ['-a', '1']
             elif script_vars['src_file'] == 'example2.py':
-            return ['-a', '2']
+                return ['-a', '2']
 
 which is included in the configuration dictionary as::
 


### PR DESCRIPTION
- The example of how to use `reset_argv` is wrong, or at least misleading on two counts. One, it must return an iterable in all cases, so there should be a default case returning `[]`. Two, the value of `script_vars['src_file']` is an absolute path, not just a filename, so just `sample1.py` won't ever be matched.
- Rewrite the sample regex for `ignore_repr_types` so it actually does what's described in the text.