### PR TITLE
Remove leftover config checking of `image_srcset`

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -294,15 +294,13 @@ def _fill_gallery_conf_defaults(sphinx_gallery_conf, app=None, check_keys=True):
         )
     srcset_mult_facs = set()
     for st in srcset:
-        if not isinstance(st, str) or st[-1:] not in ("", "x"):
+        if not (isinstance(st, str) and st[-1:] == "x"):
             raise ConfigError(
                 f"Invalid value for image_srcset parameter: {st!r}. "
                 "Must be a list of strings with the multiplicative "
                 'factor followed by an "x".  e.g. ["2.0x", "1.5x"]'
             )
-        if st == "":
-            continue
-        # "2x" = "2.0"
+        # "2x" -> "2.0"
         srcset_mult_facs.add(float(st[:-1]))
     srcset_mult_facs -= {1}  # 1x is always saved.
     gallery_conf["image_srcset"] = [*sorted(srcset_mult_facs)]

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -91,8 +91,8 @@ def test_image_srcset_config(make_gallery_conf):
 
     conf = make_gallery_conf({"image_srcset": ["2x"]})
     assert conf["image_srcset"] == [2.0]
-    conf = make_gallery_conf({"image_srcset": ["", "1x", "2x"]})
-    assert conf["image_srcset"] == [2.0]  # "" and "1x" are implied.
+    conf = make_gallery_conf({"image_srcset": ["1x", "2x"]})
+    assert conf["image_srcset"] == [2.0]  # "1x" is implied.
 
 
 def test_save_matplotlib_figures_hidpi(make_gallery_conf):


### PR DESCRIPTION
`image_srcset` config added in #808. Originally in that PR an empty string was meant to mean save the usual image: https://github.com/sphinx-gallery/sphinx-gallery/pull/808#issue-855178549. Later on we changed it to never neededing the empty string: https://github.com/sphinx-gallery/sphinx-gallery/pull/808#issuecomment-823736082

This removes the redundant config checking as `image_srcset` should not be taking an empty string.
 
First noticed: https://github.com/sphinx-gallery/sphinx-gallery/pull/1241/files#r1542174678
