### PR TITLE
Fix typo in `test_fileno`

### DIFF
--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -1191,7 +1191,7 @@ def test_textio_compat(log_collector_wrap):
     assert tee.writable()
 
 
-def test_fileno(monkeypatch, log_collector_wrap):
+def test_fileno(log_collector_wrap):
     _, _, tee, _ = log_collector_wrap
     with pytest.raises(io.UnsupportedOperation):
         tee.fileno()


### PR DESCRIPTION
See: https://github.com/sphinx-gallery/sphinx-gallery/pull/1151/files#r1269969694

Remove unused fixture