### PR TITLE
readme: add link to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ Sphinx-Gallery
 
 A `Sphinx <https://www.sphinx-doc.org/en/master/>`_ extension that builds an
 HTML gallery of examples from any set of Python scripts.
+Checkout the `documentation <sphinx-gallery.github.io>`_ for introductions on how to use it and more...
 
 .. tagline-end-content
 


### PR DESCRIPTION
It took me a while to find the link to docs, and mostly, it is mentioned in the readme, or there is a docs badge, but there is none of these yet...
Also, it may be a good idea to add a section with a simple/quick explanation of how to use it...

cc: @lucyleeow