### PR TITLE
BUG: Fix serialization with Sphinx 7.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,12 @@ jobs:
       - attach_workspace:
           at: ~/
       - bash_env
-      - run: sphinx-build doc doc/_build/html -nW --keep-going -b html
+      - run: sphinx-build doc doc/_build/html -nW --keep-going -b html 2>&1 | tee sphinx_log.txt
+      - run:
+          name: Check sphinx log for warnings (which are treated as errors)
+          when: always
+          command: |
+            ! grep "^.* WARNING: .*$" sphinx_log.txt
       - store_artifacts:
           path: doc/_build/html/
           destination: html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           command: |
             pip install --upgrade --only-binary ":all:" pip setuptools
             pip install --upgrade --only-binary ":all:" \
-                numpy matplotlib seaborn statsmodels pillow joblib sphinx pytest traits pyvista memory_profiler "ipython!=8.7.0" plotly graphviz "docutils>=0.18" imageio pydata-sphinx-theme \
+                numpy matplotlib seaborn statsmodels pillow joblib "sphinx!=7.3.2,!=7.3.3,!=7.3.4,!=7.3.5,!=7.3.6" pytest traits pyvista memory_profiler "ipython!=8.7.0" plotly graphviz "docutils>=0.18" imageio pydata-sphinx-theme \
                 "jupyterlite-sphinx>=0.8.0,<0.9.0" "jupyterlite-pyodide-kernel<0.1.0" libarchive-c
             pip uninstall -yq vtk  # pyvista installs vtk above
             pip install --upgrade --only-binary ":all" --extra-index-url https://wheels.vtk.org vtk-osmesa

--- a/.github/install.sh
+++ b/.github/install.sh
@@ -31,6 +31,8 @@ if [ "$SPHINX_VERSION" == "dev" ]; then
     PIP_DEPENDENCIES="--upgrade --pre https://api.github.com/repos/sphinx-doc/sphinx/zipball/master --default-timeout=60 --extra-index-url 'https://pypi.anaconda.org/scientific-python-nightly-wheels/simple' $PIP_DEPENDENCIES"
 elif [ "$SPHINX_VERSION" != "default" ]; then
     PIP_DEPENDENCIES="sphinx==${SPHINX_VERSION}.* $PIP_DEPENDENCIES"
+else
+    PIP_DEPENDENCIES="sphinx!=7.3.2,!=7.3.3,!=7.3.4,!=7.3.5,!=7.3.6"
 fi
 
 set -x

--- a/.github/install.sh
+++ b/.github/install.sh
@@ -32,7 +32,7 @@ if [ "$SPHINX_VERSION" == "dev" ]; then
 elif [ "$SPHINX_VERSION" != "default" ]; then
     PIP_DEPENDENCIES="sphinx==${SPHINX_VERSION}.* $PIP_DEPENDENCIES"
 else
-    PIP_DEPENDENCIES="sphinx!=7.3.2,!=7.3.3,!=7.3.4,!=7.3.5,!=7.3.6"
+    PIP_DEPENDENCIES="sphinx!=7.3.2,!=7.3.3,!=7.3.4,!=7.3.5,!=7.3.6 $PIP_DEPENDENCIES"
 fi
 
 set -x

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: ruff-format
         exclude: plot_syntaxerror
       - id: ruff
+        args: ["--fix"]
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,22 @@
 Changelog
 =========
 
+v0.16.0
+-------
+Sphinx 7.3.2 and above changed caching and serialization checks. Now instead of passing
+instantiated classes like ``ResetArgv()``, classes like ``FileNameSortKey``, or
+callables like ``notebook_modification_function`` in  ``sphinx_gallery_conf``,
+you should pass fully qualified names to classes (that SG will instantiate for you) or
+instantiated instances that have a stable ``__repr__``. For example, instead of defining
+a ``ResetArgV`` class in ``conf.py``, define it in an importable module somewhere in
+your path. This could be for example:
+
+- ``"mymod.utils._ResetArgv"`` where you define a ``_ResetArgv`` class in
+  ``mymod.utils``
+- ``sphinxext.reset.ResetArgv`` where you define a ``ResetArgv`` class in
+  ``doc/sphinxext/reset.py`` and do something like
+  ``sys.path.insert(0, os.path.dirname(__file__) + "/sphinxext")`` in your ``conf.py``
+
 v0.15.0
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Sphinx 7.3.0 and above changed caching and serialization checks. Now instead of 
 instantiated classes like ``ResetArgv()``, classes like ``FileNameSortKey``, or
 callables like ``notebook_modification_function`` in  ``sphinx_gallery_conf``,
 you should pass fully qualified name strings to classes or callables. If you change
-to using name strings, you can simply use function as the use of classes to ensure
+to using name strings, you can simply use a function as the use of classes to ensure
 a stable ``__repr__`` would be redundant.
 
 See :ref:`importing_callables` for details.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ somewhere in your path and instantiate an instance of it. For ``ResetArgv`` this
 be for example either of:
 
 1. ``"mymod.utils.reset_argv"`` where you define a ``class _ResetArgv`` class in
-   ``mymod.utils`` and instantiate it in your ``conf.py`` as
+   ``mymod.utils`` and instantiate it an instance of it in ``mymod/utils.py`` with
    ``reset_argv = _ResetArgv()``.
 2. ``"sphinxext.reset.ResetArgv"`` where you define a ``ResetArgv`` class in
    ``doc/sphinxext/reset.py``, instantiate an instance with

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,10 +11,10 @@ defining a ``ResetArgV`` class in ``conf.py``, define it in an importable module
 somewhere in your path and instantiate an instance of it. For ``ResetArgv`` this could
 be for example either of:
 
-1. ``"mymod.utils.reset_argv"`` where you define a ``class _ResetArgv`` class in
-   ``mymod.utils`` and instantiate it an instance of it in ``mymod/utils.py`` with
+1. ``"reset_argv": "mymod.utils.reset_argv"`` where you define a ``class _ResetArgv`` class in
+   ``mymod.utils`` and instantiate an instance of it in ``mymod/utils.py`` with
    ``reset_argv = _ResetArgv()``.
-2. ``"sphinxext.reset.ResetArgv"`` where you define a ``ResetArgv`` class in
+2. ``"reset_argv": "sphinxext.reset.ResetArgv"`` where you define a ``ResetArgv`` class in
    ``doc/sphinxext/reset.py``, instantiate an instance with
    ``reset_argv = ResetArgv()``, and do something like
    ``sys.path.insert(0, os.path.dirname(__file__) + "/sphinxext")`` in your ``conf.py``.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,19 +6,11 @@ v0.16.0
 Sphinx 7.3.0 and above changed caching and serialization checks. Now instead of passing
 instantiated classes like ``ResetArgv()``, classes like ``FileNameSortKey``, or
 callables like ``notebook_modification_function`` in  ``sphinx_gallery_conf``,
-you should pass fully qualified names to classes or callables. For example, instead of
-defining a ``ResetArgV`` class in ``conf.py``, define it in an importable module
-somewhere in your path and instantiate an instance of it. For ``ResetArgv`` this could
-be for example either of:
+you should pass fully qualified name strings to classes or callables. If you change
+to using name strings, you can simply use function as the use of classes to ensure
+a stable ``__repr__`` would be redundant.
 
-1. ``"reset_argv": "mymod.utils.reset_argv"`` where you define function
-   ``def reset_argv`` class in ``mymod.utils``.
-2. ``"reset_argv": "sphinxext.reset.reset_argv"`` where you define a ``def reset_argv``
-   in ``doc/sphinxext/reset.py``, and do something like
-   ``sys.path.insert(0, os.path.dirname(__file__) + "/sphinxext")`` in your ``conf.py``.
-
-Built in classes like :class:`sphinx_gallery.sorting.FileNameSortKey` and similar can
-be used with shorter direct alias strings like ``"FileNameSortKey"``.
+See :ref:`importing_callables` for details.
 
 v0.15.0
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,12 +12,12 @@ somewhere in your path and instatiate an instance of it. For ``ResetArgv`` this 
 for example either of:
 
 1. ``"mymod.utils.reset_argv"`` where you define a ``class _ResetArgv`` class in
-  ``mymod.utils`` and instantiate it in your ``conf.py`` as
-  ``reset_argv = _ResetArgv()``.
+   ``mymod.utils`` and instantiate it in your ``conf.py`` as
+   ``reset_argv = _ResetArgv()``.
 2. ``"sphinxext.reset.ResetArgv"`` where you define a ``ResetArgv`` class in
-  ``doc/sphinxext/reset.py``, instantiate an instance with ``reset_argv = ResetArgv()``,
-  and do something like
-  ``sys.path.insert(0, os.path.dirname(__file__) + "/sphinxext")`` in your ``conf.py``.
+   ``doc/sphinxext/reset.py``, instantiate an instance with
+   ``reset_argv = ResetArgv()``, and do something like
+   ``sys.path.insert(0, os.path.dirname(__file__) + "/sphinxext")`` in your ``conf.py``.
 
 Built in classes like :class:`sphinx_gallery.sorting.FileNameSortKey` and similar can
 be used with shorter direct alias strings like ``"FileNameSortKey"``.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,8 @@ instantiated classes like ``ResetArgv()``, classes like ``FileNameSortKey``, or
 callables like ``notebook_modification_function`` in  ``sphinx_gallery_conf``,
 you should pass fully qualified names to classes or callables. For example, instead of
 defining a ``ResetArgV`` class in ``conf.py``, define it in an importable module
-somewhere in your path and instatiate an instance of it. For ``ResetArgv`` this could be
-for example either of:
+somewhere in your path and instantiate an instance of it. For ``ResetArgv`` this could
+be for example either of:
 
 1. ``"mymod.utils.reset_argv"`` where you define a ``class _ResetArgv`` class in
    ``mymod.utils`` and instantiate it in your ``conf.py`` as

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,12 +11,10 @@ defining a ``ResetArgV`` class in ``conf.py``, define it in an importable module
 somewhere in your path and instantiate an instance of it. For ``ResetArgv`` this could
 be for example either of:
 
-1. ``"reset_argv": "mymod.utils.reset_argv"`` where you define a ``class _ResetArgv`` class in
-   ``mymod.utils`` and instantiate an instance of it in ``mymod/utils.py`` with
-   ``reset_argv = _ResetArgv()``.
-2. ``"reset_argv": "sphinxext.reset.ResetArgv"`` where you define a ``ResetArgv`` class in
-   ``doc/sphinxext/reset.py``, instantiate an instance with
-   ``reset_argv = ResetArgv()``, and do something like
+1. ``"reset_argv": "mymod.utils.reset_argv"`` where you define function
+   ``def reset_argv`` class in ``mymod.utils``.
+2. ``"reset_argv": "sphinxext.reset.reset_argv"`` where you define a ``def reset_argv``
+   in ``doc/sphinxext/reset.py``, and do something like
    ``sys.path.insert(0, os.path.dirname(__file__) + "/sphinxext")`` in your ``conf.py``.
 
 Built in classes like :class:`sphinx_gallery.sorting.FileNameSortKey` and similar can

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 v0.16.0
 -------
-Sphinx 7.3.2 and above changed caching and serialization checks. Now instead of passing
+Sphinx 7.3.0 and above changed caching and serialization checks. Now instead of passing
 instantiated classes like ``ResetArgv()``, classes like ``FileNameSortKey``, or
 callables like ``notebook_modification_function`` in  ``sphinx_gallery_conf``,
 you should pass fully qualified names to classes or callables. For example, instead of

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,16 +6,21 @@ v0.16.0
 Sphinx 7.3.2 and above changed caching and serialization checks. Now instead of passing
 instantiated classes like ``ResetArgv()``, classes like ``FileNameSortKey``, or
 callables like ``notebook_modification_function`` in  ``sphinx_gallery_conf``,
-you should pass fully qualified names to classes (that SG will instantiate for you) or
-instantiated instances that have a stable ``__repr__``. For example, instead of defining
-a ``ResetArgV`` class in ``conf.py``, define it in an importable module somewhere in
-your path. This could be for example:
+you should pass fully qualified names to classes or callables. For example, instead of
+defining a ``ResetArgV`` class in ``conf.py``, define it in an importable module
+somewhere in your path and instatiate an instance of it. For ``ResetArgv`` this could be
+for example either of:
 
-- ``"mymod.utils._ResetArgv"`` where you define a ``_ResetArgv`` class in
-  ``mymod.utils``
-- ``sphinxext.reset.ResetArgv`` where you define a ``ResetArgv`` class in
-  ``doc/sphinxext/reset.py`` and do something like
-  ``sys.path.insert(0, os.path.dirname(__file__) + "/sphinxext")`` in your ``conf.py``
+1. ``"mymod.utils.reset_argv"`` where you define a ``class _ResetArgv`` class in
+  ``mymod.utils`` and instantiate it in your ``conf.py`` as
+  ``reset_argv = _ResetArgv()``.
+2. ``"sphinxext.reset.ResetArgv"`` where you define a ``ResetArgv`` class in
+  ``doc/sphinxext/reset.py``, instantiate an instance with ``reset_argv = ResetArgv()``,
+  and do something like
+  ``sys.path.insert(0, os.path.dirname(__file__) + "/sphinxext")`` in your ``conf.py``.
+
+Built in classes like :class:`sphinx_gallery.sorting.FileNameSortKey` and similar can
+be used with shorter direct alias strings like ``"FileNameSortKey"``.
 
 v0.15.0
 -------

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-sphinx >= 4, != 5.2.0
+sphinx>=4,!= 5.2.0,!=7.3.2,!=7.3.3,!=7.3.4,!=7.3.5,!=7.3.6
 pydata-sphinx-theme
 pytest
 pytest-coverage

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+# see https://github.com/sphinx-doc/sphinx/issues/12299
 sphinx>=4,!= 5.2.0,!=7.3.2,!=7.3.3,!=7.3.4,!=7.3.5,!=7.3.6
 pydata-sphinx-theme
 pytest

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -404,7 +404,7 @@ For example, to reset matplotlib to always use the ``ggplot`` style, you could d
 
 Any custom functions can be defined (or imported) in ``conf.py`` and given to
 the ``reset_modules`` configuration key. To add the function defined above (assuming
-you've defined it in a ``doc/sphinxext.py`` where ``doc/`` is in your ``sys.path``)::
+you've make it :ref:`importable <importing_callables>`)::
 
    sphinx_gallery_conf = {
        ...

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -171,22 +171,22 @@ Two common ways to achieve this are:
    that it can be resolved at build time. For example, you could create a file
    ``doc/sphinxext.py`` and define your function:
 
-    .. code-block::
+.. code-block::
 
-        def plotted_sorter(fname):
-            return not fname.startswith("plot_"), fname
+    def plotted_sorter(fname):
+        return not fname.startswith("plot_"), fname
 
    And set in your configuration:
 
-    .. code-block::
+.. code-block::
 
-        sys.path.insert(0, os.path.dirname(__file__))
+    sys.path.insert(0, os.path.dirname(__file__))
 
-        sphinx_gallery_conf = {
-        #...,
-        "minigallery_sort_order": "sphinxext.plotted_sorter",
-        #...
-        }
+    sphinx_gallery_conf = {
+    #...,
+    "minigallery_sort_order": "sphinxext.plotted_sorter",
+    #...
+    }
 
    And Sphinx-Gallery would resolve ``"sphinxext.plotted_sorter"`` to the
    ``plotted_sorter`` object because the ``doc/`` directory is first on the path.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -169,14 +169,14 @@ Two common ways to achieve this are:
 2. Define your object with your documentation. For example,
    you can add documentation-specific stuff in a different path and ensure
    that it can be resolved at build time. For example, you could create a file
-   ``doc/sphinxext.py``:
+   ``doc/sphinxext.py`` and define your function:
 
     .. code-block::
 
         def plotted_sorter(fname):
             return not fname.startswith("plot_"), fname
 
-    And set in your configuration:
+   And set in your configuration:
 
     .. code-block::
 
@@ -188,8 +188,8 @@ Two common ways to achieve this are:
         #...
         }
 
-    And Sphinx-Gallery would resolve ``"sphinxext.plotted_sorter"`` to the
-    ``plotted_sorter`` object because the ``doc/`` directory is first on the path.
+   And Sphinx-Gallery would resolve ``"sphinxext.plotted_sorter"`` to the
+   ``plotted_sorter`` object because the ``doc/`` directory is first on the path.
 
 Built in classes like :class:`sphinx_gallery.sorting.FileNameSortKey` and similar can
 be used with shorter direct alias strings like ``"FileNameSortKey"`` (see
@@ -205,7 +205,7 @@ be used with shorter direct alias strings like ``"FileNameSortKey"`` (see
     configuration values via name strings. When using name strings, the configuration
     object can just be a function.
 
-.. _stable_repr::
+.. _stable_repr:
 
 Ensuring a stable ``__repr__``
 ==============================

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -326,7 +326,7 @@ needs to be a Callable that accepts the ``gallery_conf`` and ``script_vars``
 dictionaries as input and returns a list of strings that are passed as
 additional command line arguments to the interpreter.
 
-An example in ``doc/sphinxext.py`` (assuming you have added ``doc/`` to ``sys.path`` so
+A ``reset_argv`` example defined in ``doc/sphinxext.py`` (assuming you have added ``doc/`` to ``sys.path`` so
 that ``sphinxext.reset_argv`` can be resolved by importlib) could be::
 
     from pathlib import Path
@@ -432,7 +432,7 @@ You can create a custom sort key callable for the following configurations:
 * :ref:`minigallery_sort_order <minigallery_order>`
 
 The best way to do this is to make use of a single instance of each class you want
-to use in some fully resolvable path, and then tell sphinx-gallery to resolve the
+to use, in some fully resolvable path, and then tell sphinx-gallery to resolve the
 callable from the fully qualified name. For example, you could write a function
 ``def my_sorter`` and put it in ``mymod/utils.py``, then use::
 
@@ -460,8 +460,8 @@ And set in your configuration::
     #...
     }
 
-And sphinx-gallery would resolve ``"sphinxext.function_sorter"`` to the
-``function_sorter`` object because the ``doc/`` directory is first on the path.
+And sphinx-gallery would resolve ``"sphinxext.plotted_sorter"`` to the
+``plotted_sorter`` object because the ``doc/`` directory is first on the path.
 
 .. _link_to_documentation:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -403,11 +403,15 @@ set to
 :class:`NumberOfCodeLinesSortKey(src_dir) <sphinx_gallery.sorting.NumberOfCodeLinesSortKey>`,
 which sorts the files based on the number of code lines::
 
-    from sphinx_gallery.sorting import NumberOfCodeLinesSortKey
     sphinx_gallery_conf = {
         ...
-        'within_subsection_order': NumberOfCodeLinesSortKey,
+        'within_subsection_order': "NumberOfCodeLinesSortKey",
     }
+
+Note that you must provide a *class* here, not an instance of the class. Because of how
+sphinx caches the environment, this should be provided as a fully qualified string
+that can be imported (though passing a class directly is supported for backward
+compatibility).
 
 In addition, multiple convenience classes are provided for use with
 ``within_subsection_order``:
@@ -417,6 +421,17 @@ In addition, multiple convenience classes are provided for use with
 - :class:`sphinx_gallery.sorting.FileSizeSortKey` to sort by file size.
 - :class:`sphinx_gallery.sorting.FileNameSortKey` to sort by file name.
 - :class:`sphinx_gallery.sorting.ExampleTitleSortKey` to sort by example title.
+
+Each of these can be used by passing the class name as a string to
+``within_subsection_order``. For example, to sort by file size::
+
+    sphinx_gallery_conf = {
+        ...
+        'within_subsection_order': "FileSizeSortKey",
+    }
+
+This is equivalent to passing the fully qualified name
+``'sphinx_gallery.sorting.FileSizeSortKey'``.
 
 .. _own_sort_keys:
 
@@ -1365,7 +1380,7 @@ You can configure JupyterLite integration by setting
       ...
       'jupyterlite': {
          'use_jupyter_lab': <bool>, # Whether JupyterLite links should start Jupyter Lab instead of the Retrolab Notebook interface.
-         'notebook_modification_function': <function>, # function that implements JupyterLite-specific modifications of notebooks
+         'notebook_modification_function': <str>, # fully qualified name of a function that implements JupyterLite-specific modifications of notebooks
          'jupyterlite_contents': <str>, # where to copy the example notebooks (relative to Sphinx source directory)
          }
     }
@@ -1376,8 +1391,9 @@ use_jupyter_lab (type: bool, default: ``True``)
   Whether the default interface activated by the JupyterLite link will be for
   Jupyter Lab or the RetroLab Notebook interface.
 
-notebook_modification_function (type: function, default: ``None``)
-  Function that implements JupyterLite-specific modifications of notebooks. By
+notebook_modification_function (type: str, default: ``None``)
+  Fully qualified name of a
+  function that implements JupyterLite-specific modifications of notebooks. By
   default, it is ``None`` which means that notebooks are not going to be
   modified. Its signature should be ``notebook_modification_function(json_dict:
   dict, notebook_filename: str) -> None`` where ``json_dict`` is what you get
@@ -1389,7 +1405,8 @@ notebook_modification_function (type: function, default: ``None``)
   are installing additional packages with a ``%pip install seaborn`` code cell,
   or adding a markdown cell to indicate that a notebook is not expected to work
   inside JupyterLite, for example because it is using packages that are not
-  packaged inside Pyodide.
+  packaged inside Pyodide. For backward compatibility it can also be a callable
+  but this is incompatible with Sphinx 7.3.2 and above.
 
 jupyterlite_contents (type: string, default: ``jupyterlite_contents``)
   The name of a folder where the built Jupyter notebooks will be copied,

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -171,22 +171,22 @@ Two common ways to achieve this are:
    that it can be resolved at build time. For example, you could create a file
    ``doc/sphinxext.py`` and define your function:
 
-.. code-block::
+   .. code-block::
 
-    def plotted_sorter(fname):
-        return not fname.startswith("plot_"), fname
+       def plotted_sorter(fname):
+           return not fname.startswith("plot_"), fname
 
    And set in your configuration:
 
-.. code-block::
+   .. code-block::
 
-    sys.path.insert(0, os.path.dirname(__file__))
+       sys.path.insert(0, os.path.dirname(__file__))
 
-    sphinx_gallery_conf = {
-    #...,
-    "minigallery_sort_order": "sphinxext.plotted_sorter",
-    #...
-    }
+       sphinx_gallery_conf = {
+       #...,
+       "minigallery_sort_order": "sphinxext.plotted_sorter",
+       #...
+       }
 
    And Sphinx-Gallery would resolve ``"sphinxext.plotted_sorter"`` to the
    ``plotted_sorter`` object because the ``doc/`` directory is first on the path.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -169,13 +169,16 @@ Two common ways to achieve this are:
 2. Define your object with your documentation. For example,
    you can add documentation-specific stuff in a different path and ensure
    that it can be resolved at build time. For example, you could create a file
-   ``doc/sphinxext.py``::
+   ``doc/sphinxext.py``:
+
+    .. code-block::
 
         def plotted_sorter(fname):
             return not fname.startswith("plot_"), fname
-        )
 
-    And set in your configuration::
+    And set in your configuration:
+
+    .. code-block::
 
         sys.path.insert(0, os.path.dirname(__file__))
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -347,12 +347,11 @@ which is included in the configuration dictionary as::
         'reset_argv': "sphinxext.reset_argv",
     }
 
-which is then used by Sphinx-Gallery as::
+which is then resolved by Sphinx-Gallery to the callable ``reset_argv`` and used as::
 
     import sys
     sys.argv[0] = script_vars['src_file']
-    sys.argv[1:] = gallery_conf['reset_argv'](gallery_conf, script_vars)
-
+    sys.argv[1:] = reset_argv(gallery_conf, script_vars)
 
 
 .. _sub_gallery_order:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -413,8 +413,7 @@ specified using just the stem for example as ``"NumberOfLinesSortKey"``, which i
 functionally equivalent to providing the fully qualified name
 ``"sphinx_gallery.sorting.NumberOfCodeLinesSortKey"``.
 
-In addition, multiple convenience classes are provided for use with
-``within_subsection_order``:
+Built in convenience classes supported by ``within_subsection_order``:
 
 - :class:`sphinx_gallery.sorting.NumberOfCodeLinesSortKey` (default) to sort by
   the number of code lines.

--- a/doc/sphinxext/sg_doc_build.py
+++ b/doc/sphinxext/sg_doc_build.py
@@ -1,0 +1,58 @@
+"""Utilities for building docs."""
+
+from sphinx_gallery.notebook import add_code_cell, add_markdown_cell
+
+
+def notebook_modification_function(notebook_content, notebook_filename):
+    """Implement JupyterLite-specific modifications of notebooks."""
+    notebook_content_str = str(notebook_content)
+    warning_template = "\n".join(
+        [
+            "<div class='alert alert-{message_class}'>",
+            "",
+            "# JupyterLite warning",
+            "",
+            "{message}",
+            "</div>",
+        ]
+    )
+
+    if "pyvista_examples" in notebook_filename:
+        message_class = "danger"
+        message = (
+            "PyVista is not packaged in Pyodide, this notebook is not "
+            "expected to work inside JupyterLite"
+        )
+    elif "import plotly" in notebook_content_str:
+        message_class = "danger"
+        message = (
+            "This notebook is not expected to work inside JupyterLite for now."
+            " There seems to be some issues with Plotly, see "
+            "[this]('https://github.com/jupyterlite/jupyterlite/pull/950') "
+            "for more details."
+        )
+    else:
+        message_class = "warning"
+        message = (
+            "JupyterLite integration in sphinx-gallery is beta "
+            "and it may break in unexpected ways"
+        )
+
+    markdown = warning_template.format(message_class=message_class, message=message)
+
+    dummy_notebook_content = {"cells": []}
+    add_markdown_cell(dummy_notebook_content, markdown)
+
+    code_lines = []
+
+    if "seaborn" in notebook_content_str:
+        code_lines.append("%pip install seaborn")
+
+    if code_lines:
+        code_lines = ["# JupyterLite-specific code"] + code_lines
+        code = "\n".join(code_lines)
+        add_code_cell(dummy_notebook_content, code)
+
+    notebook_content["cells"] = (
+        dummy_notebook_content["cells"] + notebook_content["cells"]
+    )

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -216,12 +216,11 @@ def _get_short_module_name(module_name, obj_name):
     return short_name
 
 
-def _make_ref_regex(config=None):
+def _make_ref_regex(default_role=""):
     """Make regex to find reference to python objects."""
     # keep roles variable in sync values shown in configuration.rst
     # "Add mini-galleries for API documentation"
     roles = "func|meth|attr|obj|class"
-    default_role = config["default_role"] or "" if config else ""
     def_role_regex = (
         "|[^:]?" if re.fullmatch(f"(?:py:)?({roles})", default_role) else ""
     )

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -55,6 +55,8 @@ class MiniGallery(Directive):
 
     def run(self):
         """Generate mini-gallery from backreference and example files."""
+        from .gen_rst import _get_callables
+
         if not (self.arguments or self.content):
             raise ExtensionError("No arguments passed to 'minigallery'")
 
@@ -112,7 +114,12 @@ class MiniGallery(Directive):
         lines.append(THUMBNAIL_PARENT_DIV)
 
         # sort on the str(file_path) but keep (obj, path) pair
-        sortkey = config.sphinx_gallery_conf["minigallery_sort_order"]
+        if config.sphinx_gallery_conf["minigallery_sort_order"] is None:
+            sortkey = None
+        else:
+            (sortkey,) = _get_callables(
+                config.sphinx_gallery_conf, "minigallery_sort_order"
+            )
         for obj, path in sorted(
             set(file_paths),
             key=((lambda x: sortkey(os.path.abspath(x[-1]))) if sortkey else None),

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -444,7 +444,10 @@ def get_subsections(srcdir, examples_dir, gallery_conf, check_for_index=True):
     out : list
         sorted list of gallery subsection folder names
     """
-    sortkey = gallery_conf["subsection_order"]
+    if gallery_conf["subsection_order"] is None:
+        sortkey = None
+    else:
+        (sortkey,) = _get_callables(gallery_conf, "subsection_order")
     subfolders = [subfolder for subfolder in os.listdir(examples_dir)]
     if check_for_index:
         subfolders = [

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -10,7 +10,6 @@ import codecs
 import copy
 from datetime import timedelta, datetime
 from difflib import get_close_matches
-from importlib import import_module
 from pathlib import Path
 from textwrap import indent
 import re
@@ -25,11 +24,17 @@ from sphinx.util.console import blue, red, purple, bold
 from . import glr_path_static, __version__ as _sg_version
 from .utils import _replace_md5, _has_optipng, _has_pypandoc, _has_graphviz
 from .backreferences import _finalize_backreferences
-from .gen_rst import generate_dir_rst, SPHX_GLR_SIG, _get_memory_base, _get_readme
-from .scrapers import _scraper_dict, _reset_dict, _import_matplotlib
+from .gen_rst import (
+    generate_dir_rst,
+    SPHX_GLR_SIG,
+    _get_readme,
+    _get_class,
+    _get_callables,
+    _get_call_memory_and_base,
+)
+from .scrapers import _import_matplotlib
 from .docs_resolv import embed_code_links
 from .downloads import generate_zipfiles
-from .sorting import NumberOfCodeLinesSortKey
 from .interactive_example import (
     copy_binder_files,
     check_binder_conf,
@@ -69,7 +74,7 @@ DEFAULT_GALLERY_CONF = {
     "notebook_extensions": {".py"},
     "reset_argv": DefaultResetArgv(),
     "subsection_order": None,
-    "within_subsection_order": NumberOfCodeLinesSortKey,
+    "within_subsection_order": "NumberOfCodeLinesSortKey",
     "minigallery_sort_order": None,
     "gallery_dirs": "auto_examples",
     "backreferences_dir": None,
@@ -189,7 +194,14 @@ def _fill_gallery_conf_defaults(sphinx_gallery_conf, app=None, check_keys=True):
         "run_stale_examples",
     ):
         gallery_conf[key] = _bool_eval(gallery_conf[key])
-    gallery_conf["app"] = app
+    gallery_conf["default_role"] = ""
+    gallery_conf["source_suffix"] = {".rst": "restructuredtext"}
+    if app is not None:
+        if app.config["default_role"]:
+            gallery_conf["default_role"] = app.config["default_role"]
+        gallery_conf["source_suffix"] = app.config["source_suffix"]
+        if isinstance(gallery_conf["source_suffix"], str):
+            gallery_conf["source_suffix"] = {gallery_conf["source_suffix"]: None}
 
     # Check capture_repr
     capture_repr = gallery_conf["capture_repr"]
@@ -211,65 +223,19 @@ def _fill_gallery_conf_defaults(sphinx_gallery_conf, app=None, check_keys=True):
         )
 
     # deal with show_memory
-    gallery_conf["memory_base"] = 0.0
-    if gallery_conf["show_memory"]:
-        if not callable(gallery_conf["show_memory"]):  # True-like
-            try:
-                from memory_profiler import memory_usage  # noqa
-            except ImportError:
-                logger.warning(
-                    "Please install 'memory_profiler' to enable "
-                    "peak memory measurements."
-                )
-                gallery_conf["show_memory"] = False
-            else:
+    _get_call_memory_and_base(gallery_conf)
 
-                def call_memory(func):
-                    mem, out = memory_usage(
-                        func, max_usage=True, retval=True, multiprocess=True
-                    )
-                    try:
-                        mem = mem[0]  # old MP always returned a list
-                    except TypeError:  # 'float' object is not subscriptable
-                        pass
-                    return mem, out
+    # check callables
+    for key in (
+        "image_scrapers",
+        "reset_argv",
+        "minigallery_sort_order",
+        "reset_modules",
+    ):
+        if key == "minigallery_sort_order" and gallery_conf[key] is None:
+            continue
+        _get_callables(gallery_conf, key)
 
-                gallery_conf["call_memory"] = call_memory
-                gallery_conf["memory_base"] = _get_memory_base(gallery_conf)
-        else:
-            gallery_conf["call_memory"] = gallery_conf["show_memory"]
-    if not gallery_conf["show_memory"]:  # can be set to False above
-
-        def call_memory(func):
-            return 0.0, func()
-
-        gallery_conf["call_memory"] = call_memory
-    assert callable(gallery_conf["call_memory"])
-
-    # deal with scrapers
-    scrapers = gallery_conf["image_scrapers"]
-    if not isinstance(scrapers, (tuple, list)):
-        scrapers = [scrapers]
-    scrapers = list(scrapers)
-    for si, scraper in enumerate(scrapers):
-        if isinstance(scraper, str):
-            if scraper in _scraper_dict:
-                scraper = _scraper_dict[scraper]
-            else:
-                orig_scraper = scraper
-                try:
-                    scraper = import_module(scraper)
-                    scraper = getattr(scraper, "_get_sg_image_scraper")
-                    scraper = scraper()
-                except Exception as exp:
-                    raise ConfigError(
-                        f"Unknown image scraper {orig_scraper!r}, got:\n{exp}"
-                    )
-            scrapers[si] = scraper
-        if not callable(scraper):
-            raise ConfigError(f"Scraper {scraper!r} was not callable")
-    gallery_conf["image_scrapers"] = tuple(scrapers)
-    del scrapers
     # Here we try to set up matplotlib but don't raise an error,
     # we will raise an error later when we actually try to use it
     # (if we do so) in scrapers.py.
@@ -338,19 +304,8 @@ def _fill_gallery_conf_defaults(sphinx_gallery_conf, app=None, check_keys=True):
     gallery_conf["compress_images"] = compress_images
     gallery_conf["compress_images_args"] = compress_images_args
 
-    # deal with resetters
-    resetters = gallery_conf["reset_modules"]
-    if not isinstance(resetters, (tuple, list)):
-        resetters = [resetters]
-    resetters = list(resetters)
-    for ri, resetter in enumerate(resetters):
-        if isinstance(resetter, str):
-            if resetter not in _reset_dict:
-                raise ConfigError(f"Unknown module resetter named {resetter!r}")
-            resetters[ri] = _reset_dict[resetter]
-        elif not callable(resetter):
-            raise ConfigError(f"Module resetter {resetter!r} was not callable")
-    gallery_conf["reset_modules"] = tuple(resetters)
+    # check resetters
+    _get_callables(gallery_conf, "reset_modules")
 
     if not isinstance(gallery_conf["reset_modules_order"], str):
         raise ConfigError(
@@ -363,8 +318,6 @@ def _fill_gallery_conf_defaults(sphinx_gallery_conf, app=None, check_keys=True):
             "['before', 'after', 'both'], "
             f"got {gallery_conf['reset_modules_order']!r}"
         )
-
-    del resetters
 
     # Ensure the first cell text is a string if we have it
     first_cell = gallery_conf.get("first_notebook_cell")
@@ -434,7 +387,8 @@ def _fill_gallery_conf_defaults(sphinx_gallery_conf, app=None, check_keys=True):
 
     # jupyterlite
     gallery_conf["jupyterlite"] = check_jupyterlite_conf(
-        gallery_conf.get("jupyterlite", {}), app
+        gallery_conf["jupyterlite"],
+        app,
     )
 
     if not isinstance(gallery_conf["css"], (list, tuple)):
@@ -444,8 +398,8 @@ def _fill_gallery_conf_defaults(sphinx_gallery_conf, app=None, check_keys=True):
     for css in gallery_conf["css"]:
         if css not in _KNOWN_CSS:
             raise ConfigError(f"Unknown css {css!r}, must be one of {_KNOWN_CSS!r}")
-        if gallery_conf["app"] is not None:  # can be None in testing
-            gallery_conf["app"].add_css_file(css + ".css")
+        if app is not None:  # can be None in testing
+            app.add_css_file(css + ".css")
 
     # check API usage
     if not isinstance(gallery_conf["api_usage_ignore"], str):
@@ -462,6 +416,9 @@ def _fill_gallery_conf_defaults(sphinx_gallery_conf, app=None, check_keys=True):
             'gallery_conf["show_api_usage"] must be True, False or "unused", '
             f'got {gallery_conf["show_api_usage"]}'
         )
+
+    # classes (not pickleable so need to resolve using fully qualified name)
+    _get_class(gallery_conf, "within_subsection_order")  # make sure it works
 
     _update_gallery_conf_exclude_implicit_doc(gallery_conf)
 
@@ -710,7 +667,7 @@ def generate_gallery_rst(app):
                         for fname in Path(src_dir).iterdir()
                         if fname.suffix == ".py"
                     ],
-                    key=gallery_conf["within_subsection_order"](src_dir),
+                    key=_get_class(gallery_conf, "within_subsection_order")(src_dir),
                 )
                 gallery_py_files.append(
                     [os.path.join(src_dir, fname) for fname in py_files]

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1536,7 +1536,7 @@ def _get_class(gallery_conf, key):
 
 
 def _get_callables(gallery_conf, key):
-    """Get callables for the given conf key."""
+    """Get callables for the given conf key, returning tuple of callable(s)."""
     singletons = ("reset_argv", "minigallery_sort_order", "subsection_order")
     # the following should be the case (internal use only):
     assert key in ("image_scrapers", "reset_modules", "jupyterlite") + singletons, key

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1536,7 +1536,7 @@ def _get_class(gallery_conf, key):
 
 def _get_callables(gallery_conf, key):
     # the following should be the case (internal use only)
-    singletons = ("reset_argv", "minigallery_sort_order")
+    singletons = ("reset_argv", "minigallery_sort_order", "subsection_order")
     assert key in ("image_scrapers", "reset_modules", "jupyterlite") + singletons, key
     which = gallery_conf[key]
     if key == "jupyterlite":

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1606,6 +1606,8 @@ def _get_call_memory_and_base(gallery_conf):
             out = _get_memprof_call_memory()
             if out is not None:
                 call_memory, memory_base = out
+            else:
+                gallery_conf["show_memory"] = False
 
     assert callable(call_memory)
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1501,6 +1501,7 @@ def save_rst_example(
 
 
 def _get_class(gallery_conf, key):
+    """Get a class for the given conf key."""
     what = f"sphinx_gallery_conf[{repr(key)}]"
     val = gallery_conf[key]
     if key == "within_subsection_order":
@@ -1535,8 +1536,9 @@ def _get_class(gallery_conf, key):
 
 
 def _get_callables(gallery_conf, key):
-    # the following should be the case (internal use only)
+    """Get callables for the given conf key."""
     singletons = ("reset_argv", "minigallery_sort_order", "subsection_order")
+    # the following should be the case (internal use only):
     assert key in ("image_scrapers", "reset_modules", "jupyterlite") + singletons, key
     which = gallery_conf[key]
     if key == "jupyterlite":

--- a/sphinx_gallery/interactive_example.py
+++ b/sphinx_gallery/interactive_example.py
@@ -328,6 +328,8 @@ def post_configure_jupyterlite_sphinx(app, config):
 
 def create_jupyterlite_contents(app, exception):
     """Create Jupyterlite contents according to "jupyterlite" configuration."""
+    from .gen_rst import _get_callables
+
     if exception is not None:
         return
 
@@ -371,6 +373,7 @@ def create_jupyterlite_contents(app, exception):
     if notebook_modification_function is None:
         return
 
+    (notebook_modification_function,) = _get_callables(gallery_conf, "jupyterlite")
     notebook_pattern = os.path.join(contents_dir, "**", "*.ipynb")
     notebook_filename_list = sorted(glob.glob(notebook_pattern, recursive=True))
 

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -332,10 +332,12 @@ def save_figures(block, block_vars, gallery_conf):
     images_rst : str
         rst code to embed the images in the document.
     """
+    from .gen_rst import _get_callables
+
     image_path_iterator = block_vars["image_path_iterator"]
     all_rst = ""
     prev_count = len(image_path_iterator)
-    for scraper in gallery_conf["image_scrapers"]:
+    for scraper in _get_callables(gallery_conf, "image_scrapers"):
         rst = scraper(block, block_vars, gallery_conf)
         if not isinstance(rst, str):
             raise ExtensionError(
@@ -546,7 +548,9 @@ def clean_modules(gallery_conf, fname, when):
         This parameter is only forwarded when the callables accept 3
         parameters.
     """
-    for reset_module in gallery_conf["reset_modules"]:
+    from .gen_rst import _get_callables
+
+    for reset_module in _get_callables(gallery_conf, "reset_modules"):
         sig = inspect.signature(reset_module)
         if len(sig.parameters) == 3:
             third_param = list(sig.parameters.keys())[2]

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -17,7 +17,7 @@ from sphinx_gallery.scrapers import _import_matplotlib
 from sphinx_gallery.utils import _get_image
 
 
-def pytest_report_header(config, startdir):
+def pytest_report_header(config, startdir=None):
     """Add information to the pytest run header."""
     return f"Sphinx:  {sphinx.__version__} ({sphinx.__file__})"
 

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -137,7 +137,7 @@ def test_identify_names(unicode_sample, gallery_conf):
         ],
     }
     _, script_blocks = split_code_and_text_blocks(unicode_sample)
-    ref_regex = sg._make_ref_regex(gallery_conf["app"].config)
+    ref_regex = sg._make_ref_regex()
     res = sg.identify_names(script_blocks, ref_regex)
     assert expected == res
 
@@ -217,7 +217,7 @@ h.i.j()
     fname.write(code_str, "wb")
 
     _, script_blocks = split_code_and_text_blocks(fname.strpath)
-    ref_regex = sg._make_ref_regex(gallery_conf["app"].config)
+    ref_regex = sg._make_ref_regex()
     res = sg.identify_names(script_blocks, ref_regex)
 
     assert expected == res
@@ -257,10 +257,9 @@ cobj = dict(module="m", module_short="m", name="n", is_class=False, is_explicit=
 # and docutils.sourceforge.io/docs/ref/rst/roles.html
 def test_identify_names_explicit(text, default_role, ref, cobj, gallery_conf):
     """Test explicit name identification."""
-    if default_role:
-        gallery_conf["app"].config["default_role"] = default_role
+    default_role = "" if default_role is None else default_role
     script_blocks = [("text", text, 1)]
     expected = {ref: [cobj]} if ref else {}
-    ref_regex = sg._make_ref_regex(gallery_conf["app"].config)
+    ref_regex = sg._make_ref_regex(default_role)
     actual = sg.identify_names(script_blocks, ref_regex)
     assert expected == actual

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -10,6 +10,7 @@ import json
 
 import pytest
 
+from sphinx.config import is_serializable
 from sphinx.errors import ConfigError, ExtensionError, SphinxWarning
 from sphinx_gallery.gen_gallery import (
     check_duplicate_filenames,
@@ -29,12 +30,21 @@ def test_bad_config():
     sphinx_gallery_conf = dict(example_dir="")
     with pytest.raises(
         ConfigError, match="example_dir.*did you mean 'examples_dirs'?.*"
-    ):  # noqa: E501
+    ):
         _fill_gallery_conf_defaults(sphinx_gallery_conf)
     sphinx_gallery_conf = dict(n_subsection_order="")
     with pytest.raises(
         ConfigError, match=r"did you mean one of \['subsection_order', 'within_.*"
-    ):  # noqa: E501
+    ):
+        _fill_gallery_conf_defaults(sphinx_gallery_conf)
+    sphinx_gallery_conf = dict(within_subsection_order="sphinx_gallery.a.b.Key")
+    with pytest.raises(ConfigError, match="must be a fully qualified"):
+        _fill_gallery_conf_defaults(sphinx_gallery_conf)
+    sphinx_gallery_conf = dict(within_subsection_order=1.0)
+    with pytest.raises(ConfigError, match="a fully qualified.*got float"):
+        _fill_gallery_conf_defaults(sphinx_gallery_conf)
+    sphinx_gallery_conf = dict(minigallery_sort_order=int)
+    with pytest.raises(ConfigError, match="Got class rather than callable instance"):
         _fill_gallery_conf_defaults(sphinx_gallery_conf)
 
 
@@ -47,6 +57,17 @@ def test_default_config(sphinx_app_wrapper):
     with pytest.raises(ExtensionError) as excinfo:
         sphinx_app.add_config_value("sphinx_gallery_conf", "x", True)
     assert "already present" in str(excinfo.value)
+
+
+def test_serializable(sphinx_app_wrapper):
+    """Test that the default config is serializable."""
+    bad = list()
+    for key, val in _fill_gallery_conf_defaults({}).items():
+        if not is_serializable(val):
+            bad.append(f"{repr(key)}: {repr(val)}")
+
+    bad = "\n".join(bad)
+    assert not bad, f"Non-serializable values found:\n{bad}"
 
 
 @pytest.mark.conf_file(
@@ -76,7 +97,7 @@ def test_no_warning_simple_config(sphinx_app_wrapper):
     [
         pytest.param(
             ConfigError,
-            "Unknown module resetter",
+            "Unknown string option reset_modules",
             id="Resetter unknown",
             marks=pytest.mark.conf_file(
                 content="sphinx_gallery_conf={'reset_modules': ('f',)}"
@@ -84,7 +105,7 @@ def test_no_warning_simple_config(sphinx_app_wrapper):
         ),
         pytest.param(
             ConfigError,
-            "Module resetter .* was not callab",
+            "reset_modules.* must be callable",
             id="Resetter not callable",
             marks=pytest.mark.conf_file(
                 content="sphinx_gallery_conf={'reset_modules': (1.,),}"
@@ -254,11 +275,10 @@ def test_example_sorting_default(sphinx_app_wrapper):
 
 @pytest.mark.conf_file(
     content="""
-from sphinx_gallery.sorting import FileSizeSortKey
 sphinx_gallery_conf = {
     'examples_dirs': 'src',
     'gallery_dirs': 'ex',
-    'within_subsection_order': FileSizeSortKey,
+    'within_subsection_order': "FileSizeSortKey",
 }"""
 )
 def test_example_sorting_filesize(sphinx_app_wrapper):
@@ -269,11 +289,10 @@ def test_example_sorting_filesize(sphinx_app_wrapper):
 
 @pytest.mark.conf_file(
     content="""
-from sphinx_gallery.sorting import FileNameSortKey
 sphinx_gallery_conf = {
     'examples_dirs': 'src',
     'gallery_dirs': 'ex',
-    'within_subsection_order': FileNameSortKey,
+    'within_subsection_order': "FileNameSortKey",
 }"""
 )
 def test_example_sorting_filename(sphinx_app_wrapper):
@@ -284,11 +303,10 @@ def test_example_sorting_filename(sphinx_app_wrapper):
 
 @pytest.mark.conf_file(
     content="""
-from sphinx_gallery.sorting import ExampleTitleSortKey
 sphinx_gallery_conf = {
     'examples_dirs': 'src',
     'gallery_dirs': 'ex',
-    'within_subsection_order': ExampleTitleSortKey,
+    'within_subsection_order': "ExampleTitleSortKey",
 }"""
 )
 def test_example_sorting_title(sphinx_app_wrapper):
@@ -484,8 +502,10 @@ def test_examples_not_expected_to_pass(sphinx_app_wrapper):
 
 @pytest.mark.conf_file(
     content="""
+from sphinx_gallery.gen_rst import _sg_call_memory_noop
+
 sphinx_gallery_conf = {
-    'show_memory': lambda func: (0., func()),
+    'show_memory': _sg_call_memory_noop,
     'gallery_dirs': 'ex',
 }"""
 )

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -97,7 +97,7 @@ def test_no_warning_simple_config(sphinx_app_wrapper):
     [
         pytest.param(
             ConfigError,
-            "Unknown string option reset_modules",
+            "Unknown string option for reset_modules",
             id="Resetter unknown",
             marks=pytest.mark.conf_file(
                 content="sphinx_gallery_conf={'reset_modules': ('f',)}"

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -32,6 +32,8 @@ from sphinx_gallery.py_source_parser import split_code_and_text_blocks
 from sphinx_gallery.scrapers import ImagePathIterator, figure_rst
 from sphinx_gallery.interactive_example import check_binder_conf
 
+root = Path(__file__).parents[2]
+
 CONTENT = [
     '"""',
     "================",
@@ -69,7 +71,9 @@ CONTENT = [
 
 def test_split_code_and_text_blocks():
     """Test if a known example file gets properly split."""
-    file_conf, blocks = split_code_and_text_blocks("examples/no_output/just_code.py")
+    file_conf, blocks = split_code_and_text_blocks(
+        root / "examples" / "no_output" / "just_code.py",
+    )
 
     assert file_conf == {}
     assert blocks[0][0] == "text"
@@ -81,9 +85,10 @@ def test_bug_cases_of_notebook_syntax():
 
     `plot_parse.py` uses both '#'s' and '#%%' as cell separators.
     """
-    with open("sphinx_gallery/tests/reference_parse.txt") as reference:
-        ref_blocks = ast.literal_eval(reference.read())
-    file_conf, blocks = split_code_and_text_blocks("tutorials/plot_parse.py")
+    ref_blocks = ast.literal_eval(
+        (Path(__file__).parent / "reference_parse.txt").read_text("utf-8")
+    )
+    file_conf, blocks = split_code_and_text_blocks(root / "tutorials" / "plot_parse.py")
 
     assert file_conf == {}
     assert blocks == ref_blocks

--- a/sphinx_gallery/tests/test_notebook.py
+++ b/sphinx_gallery/tests/test_notebook.py
@@ -4,6 +4,7 @@ r"""Testing the Jupyter notebook parser."""
 
 from collections import defaultdict
 from itertools import count
+from pathlib import Path
 import json
 import tempfile
 import os
@@ -23,6 +24,8 @@ from sphinx_gallery.notebook import (
     promote_jupyter_cell_magic,
     python_to_jupyter_cli,
 )
+
+root = Path(__file__).parents[2]
 
 
 def test_latex_conversion(gallery_conf):
@@ -339,7 +342,7 @@ def test_notebook_images_data_uri(gallery_conf):
 
 def test_jupyter_notebook(gallery_conf):
     """Test that written ipython notebook file corresponds to python object."""
-    file_conf, blocks = split_code_and_text_blocks("tutorials/plot_parse.py")
+    file_conf, blocks = split_code_and_text_blocks(root / "tutorials" / "plot_parse.py")
     target_dir = "tutorials"
     example_nb = jupyter_notebook(blocks, gallery_conf, target_dir)
 
@@ -407,8 +410,9 @@ def test_missing_file():
     excinfo.match(r"No such file or directory.+nofile\.py")
 
 
-def test_file_is_generated():
+def test_file_is_generated(tmp_path):
     """Check notebook file created when user passes good python file."""
-    python_to_jupyter_cli(["examples/plot_0_sin.py"])
-    assert os.path.isfile("examples/plot_0_sin.ipynb")
-    os.remove("examples/plot_0_sin.ipynb")
+    out = str(tmp_path / "plot_0_sin.py")
+    shutil.copyfile(root / "examples" / "plot_0_sin.py", out)
+    python_to_jupyter_cli([out])
+    assert os.path.isfile(f"{out[:-3]}.ipynb")

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -157,11 +157,11 @@ def test_custom_scraper(make_gallery_conf, monkeypatch):
     # degenerate
     # without the monkey patch to add sphinx_gallery._get_sg_image_scraper,
     # we should get an error
-    with pytest.raises(ConfigError, match="has no attribute '_get_sg_image_scraper'"):
+    with pytest.raises(ConfigError, match="Unknown string option"):
         make_gallery_conf({"image_scrapers": ["sphinx_gallery"]})
 
     # other degenerate conditions
-    with pytest.raises(ConfigError, match="Unknown image_scraper"):
+    with pytest.raises(ConfigError, match="Unknown string option for image_scraper"):
         make_gallery_conf({"image_scrapers": ["foo"]})
     for cust, msg in [
         (_custom_func, "did not produce expected image"),
@@ -177,7 +177,7 @@ def test_custom_scraper(make_gallery_conf, monkeypatch):
     # degenerate string interface
     with monkeypatch.context() as m:
         m.setattr(sphinx_gallery, "_get_sg_image_scraper", "foo", raising=False)
-        with pytest.raises(ConfigError, match="^Unknown image.*\n.*callable"):
+        with pytest.raises(ConfigError, match="^Unknown string option for image_"):
             make_gallery_conf({"image_scrapers": ["sphinx_gallery"]})
     with monkeypatch.context() as m:
         m.setattr(sphinx_gallery, "_get_sg_image_scraper", lambda: "foo", raising=False)

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -161,7 +161,7 @@ def test_custom_scraper(make_gallery_conf, monkeypatch):
         make_gallery_conf({"image_scrapers": ["sphinx_gallery"]})
 
     # other degenerate conditions
-    with pytest.raises(ConfigError, match="Unknown image scraper"):
+    with pytest.raises(ConfigError, match="Unknown image_scraper"):
         make_gallery_conf({"image_scrapers": ["foo"]})
     for cust, msg in [
         (_custom_func, "did not produce expected image"),
@@ -181,7 +181,7 @@ def test_custom_scraper(make_gallery_conf, monkeypatch):
             make_gallery_conf({"image_scrapers": ["sphinx_gallery"]})
     with monkeypatch.context() as m:
         m.setattr(sphinx_gallery, "_get_sg_image_scraper", lambda: "foo", raising=False)
-        with pytest.raises(ConfigError, match="^Scraper.*was not callable"):
+        with pytest.raises(ConfigError, match="craper.*must be callable"):
             make_gallery_conf({"image_scrapers": ["sphinx_gallery"]})
 
 

--- a/sphinx_gallery/tests/tinybuild/doc/conf.py
+++ b/sphinx_gallery/tests/tinybuild/doc/conf.py
@@ -2,90 +2,10 @@
 
 import os.path as op
 import sphinx
-from sphinx_gallery.scrapers import matplotlib_scraper
-from sphinx_gallery.sorting import FileNameSortKey
 
 
-class matplotlib_format_scraper:
-    """Calls Matplotlib scraper, passing required `format` kwarg for testing."""
-
-    def __repr__(self):
-        return self.__class__.__name__
-
-    def __call__(self, block, block_vars, gallery_conf):
-        """Call Matplotlib scraper with required `format` kwarg for testing."""
-        kwargs = dict()
-        if (
-            op.basename(block_vars["target_file"]) == "plot_svg.py"
-            and gallery_conf["builder_name"] != "latex"
-        ):
-            kwargs["format"] = "svg"
-        elif (
-            op.basename(block_vars["target_file"]) == "plot_webp.py"
-            and gallery_conf["builder_name"] != "latex"
-        ):
-            kwargs["format"] = "webp"
-        return matplotlib_scraper(block, block_vars, gallery_conf, **kwargs)
-
-
-class ResetArgv:
-    """Provide `reset_argv` callable returning required `sys.argv` for test."""
-
-    def __repr__(self):
-        return "ResetArgv"
-
-    def __call__(self, sphinx_gallery_conf, script_vars):
-        """Return 'plot' arg if 'plot_command_line_args' example, for testing."""
-        if "plot_command_line_args.py" in script_vars["src_file"]:
-            return ["plot"]
-        else:
-            return []
-
-
-def _raise(*args, **kwargs):
-    import matplotlib.pyplot as plt
-
-    plt.close("all")
-    raise ValueError(
-        "zero-size array to reduction operation minimum which " "has no identity"
-    )
-
-
-class MockScrapeProblem:
-    """Used in 'reset_modules' to mock error during scraping."""
-
-    def __init__(self):
-        from matplotlib.colors import colorConverter
-
-        self._orig = colorConverter.to_rgba
-
-    def __repr__(self):
-        return "MockScrapeProblem"
-
-    def __call__(self, gallery_conf, fname):
-        """Raise error for 'scraper_broken' example."""
-        from matplotlib.colors import colorConverter
-
-        if "scraper_broken" in fname:
-            colorConverter.to_rgba = _raise
-        else:
-            colorConverter.to_rgba = self._orig
-
-
-class MockSort:
-    """Fake sort used to test that mini-gallery sort is correct."""
-
-    def __repr__(self):
-        return "MockSort"
-
-    def __call__(self, f):
-        """Sort plot_sub* for one test case."""
-        if "subdir2" in f:
-            return 0
-        if "subdir1" in f:
-            return 1
-        return f
-
+# Where our helpers live
+util_root = "sphinx_gallery.tests.tinybuild.utils"
 
 extensions = [
     "sphinx.ext.autodoc",
@@ -109,13 +29,6 @@ intersphinx_mapping = {
 }
 
 
-def notebook_modification_function(notebook_content, notebook_filename):
-    """Implement JupyterLite-specific modifications of notebooks."""
-    source = f"JupyterLite-specific change for {notebook_filename}"
-    markdown_cell = {"cell_type": "markdown", "metadata": {}, "source": source}
-    notebook_content["cells"] = [markdown_cell] + notebook_content["cells"]
-
-
 sphinx_gallery_conf = {
     "doc_module": ("sphinx_gallery",),
     "reference_url": {
@@ -131,21 +44,23 @@ sphinx_gallery_conf = {
         "notebooks_dir": "notebooks",
         "use_jupyter_lab": True,
     },
-    "jupyterlite": {"notebook_modification_function": notebook_modification_function},
+    "jupyterlite": {
+        "notebook_modification_function": f"{util_root}.notebook_modification_function",
+    },
     "examples_dirs": ["../examples/", "../examples_with_rst/", "../examples_rst_index"],
     "example_extensions": {".py", ".cpp", ".m", ".jl"},
     "filetype_parsers": {".m": "Matlab"},
-    "reset_argv": ResetArgv(),
-    "reset_modules": (MockScrapeProblem(), "matplotlib"),
+    "reset_argv": f"{util_root}.reset_argv",
+    "reset_modules": (f"{util_root}.mock_scrape_problem", "matplotlib"),
     "gallery_dirs": [
         "auto_examples",
         "auto_examples_with_rst",
         "auto_examples_rst_index",
     ],
     "backreferences_dir": "gen_modules/backreferences",
-    "within_subsection_order": FileNameSortKey,
-    "minigallery_sort_order": MockSort(),
-    "image_scrapers": (matplotlib_format_scraper(),),
+    "within_subsection_order": "FileNameSortKey",
+    "minigallery_sort_order": f"{util_root}.mock_sort",
+    "image_scrapers": (f"{util_root}.matplotlib_format_scraper",),
     "expected_failing_examples": [
         "../examples/future/plot_future_imports_broken.py",
         "../examples/plot_scraper_broken.py",

--- a/sphinx_gallery/tests/tinybuild/doc/conf.py
+++ b/sphinx_gallery/tests/tinybuild/doc/conf.py
@@ -58,6 +58,7 @@ sphinx_gallery_conf = {
         "auto_examples_rst_index",
     ],
     "backreferences_dir": "gen_modules/backreferences",
+    "subsection_order": f"{util_root}.noop_key",
     "within_subsection_order": "FileNameSortKey",
     "minigallery_sort_order": f"{util_root}.mock_sort",
     "image_scrapers": (f"{util_root}.matplotlib_format_scraper",),

--- a/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
@@ -41,7 +41,7 @@ rng = np.random.RandomState(0)
 # test Issue 583
 sphinx_gallery.backreferences.identify_names(
     [("text", "Text block", 1)],
-    sphinx_gallery.backreferences._make_ref_regex({"default_role": None}),
+    sphinx_gallery.backreferences._make_ref_regex(),
 )
 # 583: methods don't link properly
 dc = sphinx_gallery.backreferences.DummyClass()

--- a/sphinx_gallery/tests/tinybuild/utils.py
+++ b/sphinx_gallery/tests/tinybuild/utils.py
@@ -1,0 +1,98 @@
+"""Utility functions for doc building."""
+
+import os.path as op
+from sphinx_gallery.scrapers import matplotlib_scraper
+
+
+def notebook_modification_function(notebook_content, notebook_filename):
+    """Implement JupyterLite-specific modifications of notebooks."""
+    source = f"JupyterLite-specific change for {notebook_filename}"
+    markdown_cell = {"cell_type": "markdown", "metadata": {}, "source": source}
+    notebook_content["cells"] = [markdown_cell] + notebook_content["cells"]
+
+
+class MatplotlibFormatScraper:
+    """Calls Matplotlib scraper, passing required `format` kwarg for testing."""
+
+    def __repr__(self):
+        return self.__class__.__name__
+
+    def __call__(self, block, block_vars, gallery_conf):
+        """Call Matplotlib scraper with required `format` kwarg for testing."""
+        kwargs = dict()
+        if (
+            op.basename(block_vars["target_file"]) == "plot_svg.py"
+            and gallery_conf["builder_name"] != "latex"
+        ):
+            kwargs["format"] = "svg"
+        elif (
+            op.basename(block_vars["target_file"]) == "plot_webp.py"
+            and gallery_conf["builder_name"] != "latex"
+        ):
+            kwargs["format"] = "webp"
+        return matplotlib_scraper(block, block_vars, gallery_conf, **kwargs)
+
+
+class ResetArgv:
+    """Provide `reset_argv` callable returning required `sys.argv` for test."""
+
+    def __repr__(self):
+        return "ResetArgv"
+
+    def __call__(self, sphinx_gallery_conf, script_vars):
+        """Return 'plot' arg if 'plot_command_line_args' example, for testing."""
+        if "plot_command_line_args.py" in script_vars["src_file"]:
+            return ["plot"]
+        else:
+            return []
+
+
+def _raise(*args, **kwargs):
+    import matplotlib.pyplot as plt
+
+    plt.close("all")
+    raise ValueError(
+        "zero-size array to reduction operation minimum which " "has no identity"
+    )
+
+
+class MockScrapeProblem:
+    """Used in 'reset_modules' to mock error during scraping."""
+
+    def __init__(self):
+        from matplotlib.colors import colorConverter
+
+        self._orig = colorConverter.to_rgba
+
+    def __repr__(self):
+        return "MockScrapeProblem"
+
+    def __call__(self, gallery_conf, fname):
+        """Raise error for 'scraper_broken' example."""
+        from matplotlib.colors import colorConverter
+
+        if "scraper_broken" in fname:
+            colorConverter.to_rgba = _raise
+        else:
+            colorConverter.to_rgba = self._orig
+
+
+class MockSort:
+    """Fake sort used to test that mini-gallery sort is correct."""
+
+    def __repr__(self):
+        return "MockSort"
+
+    def __call__(self, f):
+        """Sort plot_sub* for one test case."""
+        if "subdir2" in f:
+            return 0
+        if "subdir1" in f:
+            return 1
+        return f
+
+
+mock_scrape_problem = MockScrapeProblem()
+matplotlib_format_scraper = MatplotlibFormatScraper()
+reset_argv = ResetArgv()
+mock_sort = MockSort()

--- a/sphinx_gallery/tests/tinybuild/utils.py
+++ b/sphinx_gallery/tests/tinybuild/utils.py
@@ -96,3 +96,8 @@ mock_scrape_problem = MockScrapeProblem()
 matplotlib_format_scraper = MatplotlibFormatScraper()
 reset_argv = ResetArgv()
 mock_sort = MockSort()
+
+
+def noop_key(x):
+    """Sortkey that passes x."""
+    return x


### PR DESCRIPTION
Closes #1286

1. Support fully qualified names of classes / callables
2. Add aliases for our own ones like `"FileNameSortKey"` as an alias for `"sphinx_gallery.sorting.FileNameSortKey"`
3. Keep `sphinx_gallery_conf` clean: don't store `app` in there or any functions
    1. Check for existence when filling the conf
    2. Load them on the fly when they need to be used
 4. Add to release notes

Kind of a pain to figure out but ultimately it does seem cleaner!