### PR TITLE
BUG: Fix bug with traceback with SyntaxError

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -379,7 +379,7 @@ else:
 
 min_reported_time = 0
 if "SOURCE_DATE_EPOCH" in os.environ:
-    min_reported_time = sys.maxint if sys.version_info[0] == 2 else sys.maxsize
+    min_reported_time = sys.maxsize
 
 
 sphinx_gallery_conf = {

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -10,7 +10,6 @@ import pickle
 import posixpath
 import re
 import shelve
-import sys
 import urllib.request as urllib_request
 import urllib.parse as urllib_parse
 from pathlib import Path
@@ -49,10 +48,6 @@ def _get_data(url):
 
 def get_data(url, gallery_dir):
     """Persistent dictionary usage to retrieve the search indexes."""
-    # shelve keys need to be str in python 2
-    if sys.version_info[0] == 2 and isinstance(url, str):
-        url = url.encode("utf-8")
-
     cached_file = os.path.join(gallery_dir, "searchindex")
     search_index = shelve.open(cached_file)
     if url in search_index:

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -745,8 +745,7 @@ def _get_memory_base():
         close_fds=True,
     )
     memories = memory_usage(proc, interval=1e-3, timeout=timeout)
-    kwargs = dict(timeout=timeout) if sys.version_info >= (3, 5) else {}
-    proc.communicate(**kwargs)
+    proc.communicate(timeout=timeout)
     # On OSX sometimes the last entry can be None
     memories = [mem for mem in memories if mem is not None] + [0.0]
     memory_base = max(memories)

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -799,6 +799,7 @@ def _exec_and_get_memory(compiler, *, code_ast, gallery_conf, script_vars):
         body = [
             ast.Assign(targets=[ast.Name(id="___", ctx=ast.Store())], value=last_val)
         ]
+        # `type_ignores` empty list deals with: https://bugs.python.org/issue3589
         last_val_ast = ast.Module(body=body, type_ignores=[])
         ast.fix_missing_locations(last_val_ast)
         mem_last, _ = call_memory(

--- a/sphinx_gallery/tests/test_docs_resolv.py
+++ b/sphinx_gallery/tests/test_docs_resolv.py
@@ -4,7 +4,6 @@
 
 import os
 import tempfile
-import sys
 
 import pytest
 
@@ -34,10 +33,6 @@ def test_shelve(tmpdir):
 
     # test if cached data is available after temporary file has vanished
     assert sg.get_data(f.name, tmp_cache) == test_string
-
-    # shelve keys need to be str in python 2, deal with unicode input
-    if sys.version_info[0] == 2:
-        assert sg.get_data(f.name, tmp_cache) == test_string
 
 
 def test_parse_sphinx_docopts():

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -450,6 +450,7 @@ Should emit a syntax error in the second code block.
         sphinx_app_wrapper.build_sphinx_app()
     tb = str(excinfo.value)
     assert "Unexpected failing examples" in tb
+    # Check traceback points to correct line (see #1301)
     assert f"line {bad_line_no}" in tb
     assert bad_line in tb
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -12,7 +12,6 @@ import tempfile
 import re
 import os
 import shutil
-import sys
 from unittest import mock
 import zipfile
 import codeop
@@ -621,10 +620,7 @@ def test_exclude_implicit(gallery_conf, exclusion, expected, monkeypatch, req_pi
         gallery_conf["exclude_implicit_doc"] = exclusion
         _update_gallery_conf_exclude_implicit_doc(gallery_conf)
     _generate_rst(gallery_conf, "test_exclude_implicit.py", EXCLUDE_CONTENT)
-    if sys.version_info >= (3, 8, 0):
-        assert mock_write_backreferences.call_args.args[0] == expected
-    else:
-        assert mock_write_backreferences.call_args[0][0] == expected
+    assert mock_write_backreferences.call_args.args[0] == expected
 
 
 @pytest.mark.parametrize("ext", (".txt", ".rst", ".bad"))


### PR DESCRIPTION
Fixes an incorrect traceback:
```
    ../examples/inverse/read_inverse.py failed leaving traceback:

    Traceback (most recent call last):
      File "/home/circleci/project/examples/inverse/read_inverse.py", line 26
        meg_path = data_path / "MEG" / "sample"
                                               ^
```
to:
```
../examples/inverse/read_inverse.py unexpectedly failed to execute correctly:

    Traceback (most recent call last):
      File "/home/larsoner/python/sphinx-gallery/sphinx_gallery/gen_rst.py", line 961, in execute_code_block
        code_ast = compile(
                   ^^^^^^^^
      File "/home/larsoner/python/mne-python/examples/inverse/read_inverse.py", line 43
        print(f"Number of vertices on the right hemisphere: {len(src[1]["rr"])}")
                                                                         ^^
    SyntaxError: f-string: unmatched '['
```
By just prepending `"\n"`'s when trying to `compile` the code.

Also cleans up some code since we're 3.8+ now.

Draft until I add a regression test.