### PR TITLE
MNT: Turn the block tuple into a namedtuple

### DIFF
--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -162,14 +162,14 @@ The function should take the following inputs (in this order):
 
 1. ``block`` - a Sphinx-Gallery ``.py`` file is separated into consecutive
    lines of 'code' and reST 'text', called 'blocks'. For each
-   block, a tuple containing the (label, content, line_number)
-   (e.g. ``('code', 'print("Hello world")', 5)``) of the block is created.
+   block, a `namedtuple` with ("type", "content", "lineno") items
+   (e.g. ``('code', 'print("Hello world")', 5)``) is created.
 
    * 'label' is a string that can either be ``'text'`` or ``'code'``. In this
      context, it should only be ``'code'`` as this function is only called for
      code blocks.
    * 'content' is a string containing the actual content of the code block.
-   * 'line_number' is an integer, indicating the line number that the block
+   * 'lineno' is an integer, indicating the line number that the block
      starts at.
 
 2. ``block_vars`` - dictionary of configuration and runtime variables. Of

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -262,7 +262,7 @@ def identify_names(script_blocks, ref_regex, global_variables=None, node=""):
                 backreference (referred to by sphinx markup) (bool)
     """
     if node == "":  # mostly convenience for testing functions
-        c = "\n".join(txt for kind, txt, _ in script_blocks if kind == "code")
+        c = "\n".join(block.content for block in script_blocks if block.type == "code")
         node = ast.parse(c)
     # Get matches from the code (AST, implicit matches)
     finder = NameFinder(global_variables)
@@ -270,7 +270,7 @@ def identify_names(script_blocks, ref_regex, global_variables=None, node=""):
         finder.visit(node)
     names = list(finder.get_mapping())
     # Get matches from docstring inspection (explicit matches)
-    text = "\n".join(txt for kind, txt, _ in script_blocks if kind == "text")
+    text = "\n".join(block.content for block in script_blocks if block.type == "text")
     names.extend((x, x, False, False, True) for x in re.findall(ref_regex, text))
     example_code_obj = collections.OrderedDict()  # order is important
     # Make a list of all guesses, in `_embed_code_links` we will break

--- a/sphinx_gallery/block_parser.py
+++ b/sphinx_gallery/block_parser.py
@@ -301,7 +301,11 @@ class BlockParser:
         if len(blocks) >= 2 and blocks[0].type == "code" and blocks[1].type == "text":
             blocks[0], blocks[1] = blocks[1], blocks[0]
             if len(blocks) >= 3 and blocks[2].type == "code":
-                blocks[1] = Block("code", f"{blocks[1].content}\n{blocks[2].content}", blocks[1].lineno)
+                blocks[1] = Block(
+                    "code",
+                    f"{blocks[1].content}\n{blocks[2].content}",
+                    blocks[1].lineno,
+                )
                 blocks.pop(2)
 
         return file_conf, blocks, None

--- a/sphinx_gallery/block_parser.py
+++ b/sphinx_gallery/block_parser.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from sphinx.errors import ExtensionError
 from sphinx.util.logging import getLogger
 
-from .py_source_parser import FLAG_BODY
+from .py_source_parser import FLAG_BODY, Block
 
 logger = getLogger("sphinx-gallery")
 
@@ -224,7 +224,7 @@ class BlockParser:
                 text = dedent("\n".join(block[first:last]))
             else:
                 text = "\n".join(block)
-            return mode, text, n - len(block)
+            return Block(mode, text, n - len(block))
 
         block = []
         mode = None
@@ -298,10 +298,10 @@ class BlockParser:
         # For examples that start with a code block before the file docstring due to
         # language conventions or requirements, swap these blocks so the title block
         # comes first and merge consecutive code blocks if needed.
-        if len(blocks) >= 2 and blocks[0][0] == "code" and blocks[1][0] == "text":
+        if len(blocks) >= 2 and blocks[0].type == "code" and blocks[1].type == "text":
             blocks[0], blocks[1] = blocks[1], blocks[0]
-            if len(blocks) >= 3 and blocks[2][0] == "code":
-                blocks[1] = ("code", f"{blocks[1][1]}\n{blocks[2][1]}", blocks[1][2])
+            if len(blocks) >= 3 and blocks[2].type == "code":
+                blocks[1] = Block("code", f"{blocks[1].content}\n{blocks[2].content}", blocks[1].lineno)
                 blocks.pop(2)
 
         return file_conf, blocks, None

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -155,7 +155,9 @@ class MiniGallery(Directive):
                 _, script_blocks = split_code_and_text_blocks(
                     str(path), return_node=False
                 )
-                intro, title = extract_intro_and_title(str(path), script_blocks[0].content)
+                intro, title = extract_intro_and_title(
+                    str(path), script_blocks[0].content
+                )
 
                 thumbnail = _thumbnail_div(target_dir, src_dir, path.name, intro, title)
                 lines.append(thumbnail)

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -155,7 +155,7 @@ class MiniGallery(Directive):
                 _, script_blocks = split_code_and_text_blocks(
                     str(path), return_node=False
                 )
-                intro, title = extract_intro_and_title(str(path), script_blocks[0][1])
+                intro, title = extract_intro_and_title(str(path), script_blocks[0].content)
 
                 thumbnail = _thumbnail_div(target_dir, src_dir, path.name, intro, title)
                 lines.append(thumbnail)

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -950,7 +950,7 @@ def execute_code_block(
     match = re.search(
         r"^[\ \t]*#\s*sphinx_gallery_defer_figures[\ \t]*\n?",
         block.content,
-        re.MULTILINE
+        re.MULTILINE,
     )
     need_save_figures = match is None
 
@@ -1234,7 +1234,9 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf, seen_backrefs=No
 
     if gallery_conf["remove_config_comments"]:
         script_blocks = [
-            py_source_parser.Block(label, parser.remove_config_comments(content), line_number)
+            py_source_parser.Block(
+                label, parser.remove_config_comments(content), line_number
+            )
             for label, content, line_number in script_blocks
         ]
 
@@ -1366,15 +1368,13 @@ def rst_blocks(
     # example introduction/explanation and one for the code
     is_example_notebook_like = len(script_blocks) > 2
     example_rst = ""
-    for bi, (script_block, code_output) in enumerate(
-        zip(script_blocks, output_blocks)
-    ):
+    for bi, (script_block, code_output) in enumerate(zip(script_blocks, output_blocks)):
         # do not add comment to the title block, otherwise the linking does
         # not work properly
         if bi > 0:
             example_rst += RST_BLOCK_HEADER.format(
                 script_block.lineno,
-                script_block.lineno + script_block.content.count("\n")
+                script_block.lineno + script_block.content.count("\n"),
             )
         if script_block.type == "code":
             lineno = (
@@ -1383,7 +1383,9 @@ def rst_blocks(
                 else None
             )
 
-            code_rst = codestr2rst(script_block.content, lang=language, lineno=lineno) + "\n"
+            code_rst = (
+                codestr2rst(script_block.content, lang=language, lineno=lineno) + "\n"
+            )
             if is_example_notebook_like:
                 example_rst += code_rst
                 example_rst += code_output
@@ -1394,7 +1396,9 @@ def rst_blocks(
                     example_rst += "\n\n|\n\n"
                 example_rst += code_rst
         else:
-            block_separator = "\n\n" if not script_block.content.endswith("\n") else "\n"
+            block_separator = (
+                "\n\n" if not script_block.content.endswith("\n") else "\n"
+            )
             example_rst += script_block.content + block_separator
 
     return example_rst

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -910,9 +910,8 @@ def execute_code_block(
     ----------
     compiler : codeop.Compile
         Compiler to compile AST of code block.
-    block : List[Tuple[str, str, int]]
-        List of Tuples, each Tuple contains label ('text' or 'code'),
-        the corresponding content string of block and the leading line number.
+    block : sphinx_gallery.py_source_parser.Block
+        The code block to be executed.
     example_globals: Dict[str, Any]
         Global variables for examples.
     script_vars : Dict[str, Any]
@@ -930,9 +929,8 @@ def execute_code_block(
     """
     if example_globals is None:  # testing shortcut
         example_globals = script_vars["fake_main"].__dict__
-    blabel, bcontent, lineno = block
     # If example is not suitable to run, skip executing its blocks
-    if not script_vars["execute_script"] or blabel == "text":
+    if not script_vars["execute_script"] or block.type == "text":
         return ""
 
     cwd = os.getcwd()
@@ -950,7 +948,9 @@ def execute_code_block(
 
     # Save figures unless there is a `sphinx_gallery_defer_figures` flag
     match = re.search(
-        r"^[\ \t]*#\s*sphinx_gallery_defer_figures[\ \t]*\n?", bcontent, re.MULTILINE
+        r"^[\ \t]*#\s*sphinx_gallery_defer_figures[\ \t]*\n?",
+        block.content,
+        re.MULTILINE
     )
     need_save_figures = match is None
 
@@ -958,7 +958,7 @@ def execute_code_block(
         # The "compile" step itself can fail on a SyntaxError, so just prepend
         # newlines to get the correct failing line to show up in the traceback
         code_ast = compile(
-            "\n" * (lineno - 1) + bcontent,
+            "\n" * (block.lineno - 1) + block.content,
             src_file,
             "exec",
             flags=ast.PyCF_ONLY_AST | compiler.flags,
@@ -1171,7 +1171,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf, seen_backrefs=No
         src_file, return_node=True
     )
 
-    intro, title = extract_intro_and_title(fname, script_blocks[0][1])
+    intro, title = extract_intro_and_title(fname, script_blocks[0].content)
     gallery_conf["titles"][src_file] = title
 
     executable = executable_script(src_file, gallery_conf)
@@ -1228,19 +1228,19 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf, seen_backrefs=No
     # Ignore blocks must be processed before the
     # remaining config comments are removed.
     script_blocks = [
-        (label, parser.remove_ignore_blocks(content), line_number)
+        py_source_parser.Block(label, parser.remove_ignore_blocks(content), line_number)
         for label, content, line_number in script_blocks
     ]
 
     if gallery_conf["remove_config_comments"]:
         script_blocks = [
-            (label, parser.remove_config_comments(content), line_number)
+            py_source_parser.Block(label, parser.remove_config_comments(content), line_number)
             for label, content, line_number in script_blocks
         ]
 
     # Remove final empty block, which can occur after config comments
     # are removed
-    if script_blocks[-1][1].isspace():
+    if script_blocks[-1].content.isspace():
         script_blocks = script_blocks[:-1]
         output_blocks = output_blocks[:-1]
 
@@ -1366,20 +1366,24 @@ def rst_blocks(
     # example introduction/explanation and one for the code
     is_example_notebook_like = len(script_blocks) > 2
     example_rst = ""
-    for bi, ((blabel, bcontent, lineno), code_output) in enumerate(
+    for bi, (script_block, code_output) in enumerate(
         zip(script_blocks, output_blocks)
     ):
         # do not add comment to the title block, otherwise the linking does
         # not work properly
         if bi > 0:
             example_rst += RST_BLOCK_HEADER.format(
-                lineno, lineno + bcontent.count("\n")
+                script_block.lineno,
+                script_block.lineno + script_block.content.count("\n")
             )
-        if blabel == "code":
-            if not file_conf.get("line_numbers", gallery_conf["line_numbers"]):
-                lineno = None
+        if script_block.type == "code":
+            lineno = (
+                script_block.lineno
+                if file_conf.get("line_numbers", gallery_conf["line_numbers"])
+                else None
+            )
 
-            code_rst = codestr2rst(bcontent, lang=language, lineno=lineno) + "\n"
+            code_rst = codestr2rst(script_block.content, lang=language, lineno=lineno) + "\n"
             if is_example_notebook_like:
                 example_rst += code_rst
                 example_rst += code_output
@@ -1390,8 +1394,8 @@ def rst_blocks(
                     example_rst += "\n\n|\n\n"
                 example_rst += code_rst
         else:
-            block_separator = "\n\n" if not bcontent.endswith("\n") else "\n"
-            example_rst += bcontent + block_separator
+            block_separator = "\n\n" if not script_block.content.endswith("\n") else "\n"
+            example_rst += script_block.content + block_separator
 
     return example_rst
 

--- a/sphinx_gallery/recommender.py
+++ b/sphinx_gallery/recommender.py
@@ -260,7 +260,7 @@ def _write_recommendations(recommender, fname, gallery_conf):
             _, script_blocks = split_code_and_text_blocks(
                 example_fname, return_node=False
             )
-            intro, title = extract_intro_and_title(fname, script_blocks[0][1])
+            intro, title = extract_intro_and_title(fname, script_blocks[0].content)
             ex_file.write(
                 _thumbnail_div(
                     example_path.parent,

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -108,8 +108,8 @@ def matplotlib_scraper(block, block_vars, gallery_conf, **kwargs):
 
     Parameters
     ----------
-    block : tuple
-        A tuple containing the (label, content, line_number) of the block.
+    block : sphinx_gallery.py_source_parser.Block
+        The code block to be executed. Format (label, content, lineno).
     block_vars : dict
         Dict of block variables.
     gallery_conf : dict
@@ -356,8 +356,8 @@ def save_figures(block, block_vars, gallery_conf):
 
     Parameters
     ----------
-    block : tuple
-        A tuple containing the (label, content, line_number) of the block.
+    block : sphinx_gallery.py_source_parser.Block
+        The code block to be executed. Format (label, content, lineno).
     block_vars : dict
         Dict of block variables.
     gallery_conf : dict

--- a/sphinx_gallery/sorting.py
+++ b/sphinx_gallery/sorting.py
@@ -111,8 +111,7 @@ class NumberOfCodeLinesSortKey(_SortKey):
         src_file = os.path.normpath(os.path.join(self.src_dir, filename))
         file_conf, script_blocks = split_code_and_text_blocks(src_file)
         amount_of_code = sum(
-            len(block.content)
-            for block in script_blocks if block.type == "code"
+            len(block.content) for block in script_blocks if block.type == "code"
         )
         return amount_of_code
 

--- a/sphinx_gallery/sorting.py
+++ b/sphinx_gallery/sorting.py
@@ -111,11 +111,8 @@ class NumberOfCodeLinesSortKey(_SortKey):
         src_file = os.path.normpath(os.path.join(self.src_dir, filename))
         file_conf, script_blocks = split_code_and_text_blocks(src_file)
         amount_of_code = sum(
-            [
-                len(bcontent)
-                for blabel, bcontent, lineno in script_blocks
-                if blabel == "code"
-            ]
+            len(block.content)
+            for block in script_blocks if block.type == "code"
         )
         return amount_of_code
 
@@ -162,7 +159,7 @@ class ExampleTitleSortKey(_SortKey):
         """Return title of example."""
         src_file = os.path.normpath(os.path.join(self.src_dir, filename))
         _, script_blocks = split_code_and_text_blocks(src_file)
-        _, title = extract_intro_and_title(src_file, script_blocks[0][1])
+        _, title = extract_intro_and_title(src_file, script_blocks[0].content)
         return title
 
 

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 from sphinx.errors import ExtensionError
 
 import sphinx_gallery.backreferences as sg
-from sphinx_gallery.py_source_parser import split_code_and_text_blocks
+from sphinx_gallery.py_source_parser import split_code_and_text_blocks, Block
 from sphinx_gallery.gen_rst import _sanitize_rst
 
 
@@ -258,7 +258,7 @@ cobj = dict(module="m", module_short="m", name="n", is_class=False, is_explicit=
 def test_identify_names_explicit(text, default_role, ref, cobj, gallery_conf):
     """Test explicit name identification."""
     default_role = "" if default_role is None else default_role
-    script_blocks = [("text", text, 1)]
+    script_blocks = [Block("text", text, 1)]
     expected = {ref: [cobj]} if ref else {}
     ref_regex = sg._make_ref_regex(default_role)
     actual = sg.identify_names(script_blocks, ref_regex)

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -27,7 +27,7 @@ from sphinx_gallery.gen_gallery import (
 )
 
 # TODO: The tests of this method should probably be moved to test_py_source_parser.py
-from sphinx_gallery.py_source_parser import split_code_and_text_blocks
+from sphinx_gallery.py_source_parser import split_code_and_text_blocks, Block
 from sphinx_gallery.scrapers import ImagePathIterator, figure_rst
 from sphinx_gallery.interactive_example import check_binder_conf
 
@@ -800,7 +800,7 @@ def test_output_indentation(gallery_conf, script_vars):
 
     test_string = r"\n".join(["  A B", "A 1 2", "B 3 4"])
     code = "print('" + test_string + "')"
-    code_block = ("code", code, 1)
+    code_block = Block("code", code, 1)
     file_conf = {}
     output = sg.execute_code_block(
         compiler, code_block, None, script_vars, gallery_conf, file_conf
@@ -820,7 +820,7 @@ def test_output_no_ansi(gallery_conf, script_vars):
     compiler = codeop.Compile()
 
     code = 'print("\033[94m0.25")'
-    code_block = ("code", code, 1)
+    code_block = Block("code", code, 1)
     file_conf = {}
     output = sg.execute_code_block(
         compiler, code_block, None, script_vars, gallery_conf, file_conf
@@ -843,7 +843,7 @@ def test_absl_logging(gallery_conf, script_vars):
     compiler = codeop.Compile()
     code = 'from absl import logging\nlogging.info("Should not crash!")'
     sg.execute_code_block(
-        compiler, ("code", code, 1), None, script_vars, gallery_conf, {}
+        compiler, Block("code", code, 1), None, script_vars, gallery_conf, {}
     )
 
     # Previously, absl crashed during shutdown, after all tests had run, so
@@ -857,7 +857,7 @@ def test_empty_output_box(gallery_conf, script_vars):
     gallery_conf.update(image_scrapers=())
     compiler = codeop.Compile()
 
-    code_block = ("code", "print(__doc__)", 1)
+    code_block = Block("code", "print(__doc__)", 1)
     file_conf = {}
 
     output = sg.execute_code_block(
@@ -1015,7 +1015,7 @@ def test_capture_repr(
 ):
     """Tests output capturing with various capture_repr settings."""
     compiler = codeop.Compile()
-    code_block = ("code", code, 1)
+    code_block = Block("code", code, 1)
     gallery_conf["capture_repr"] = capture_repr
     file_conf = {}
     output = sg.execute_code_block(
@@ -1042,7 +1042,7 @@ def test_per_file_capture_repr(
 ):
     """Tests that per file capture_repr overrides gallery_conf."""
     compiler = codeop.Compile()
-    code_block = ("code", "a=2\n2", 1)
+    code_block = Block("code", "a=2\n2", 1)
     gallery_conf["capture_repr"] = caprepr_gallery
     file_conf = {"capture_repr": caprepr_file}
     output = sg.execute_code_block(
@@ -1054,7 +1054,7 @@ def test_per_file_capture_repr(
 def test_ignore_repr_types(gallery_conf, req_mpl, req_pil, script_vars):
     """Tests output capturing with various capture_repr settings."""
     compiler = codeop.Compile()
-    code_block = ("code", "a=2\na", 1)
+    code_block = Block("code", "a=2\na", 1)
     gallery_conf["ignore_repr_types"] = r"int"
     file_conf = {}
     output = sg.execute_code_block(

--- a/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
@@ -18,6 +18,7 @@ from itertools import compress  # noqa
 import matplotlib
 import matplotlib.pyplot as plt
 import sphinx_gallery.backreferences
+from sphinx_gallery.py_source_parser import Block
 
 from local_module import N  # N = 1000
 
@@ -40,7 +41,7 @@ x = Figure()  # plt.Figure should be decorated (class), x shouldn't (inst)
 rng = np.random.RandomState(0)
 # test Issue 583
 sphinx_gallery.backreferences.identify_names(
-    [("text", "Text block", 1)],
+    [Block("text", "Text block", 1)],
     sphinx_gallery.backreferences._make_ref_regex(),
 )
 # 583: methods don't link properly


### PR DESCRIPTION
It's better to give the "Block" concept its own entity and thus be able to access it's attributes by name.

I anticipate that I will need to expand the Block data to support per-block options for #1283, and that expansion will be simpler when blocks are no longer pure tuples. I've decided to split this out for simpler review and advertise this PR as code cleanup.