### PR TITLE
MAINT Add `sphinxcontrib-video` to dev requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,3 +14,4 @@ graphviz
 packaging
 jupyterlite-sphinx
 lxml
+sphinxcontrib-video

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -69,14 +69,6 @@ Most of the Sphinx Gallery dependencies are listed in :file:`requirements.txt`
 
     python -m pip install -r dev-requirements.txt
 
-
-Sphinx Gallery requires `graphviz <https://graphviz.org/>`_ for drawing API
- entry graphs:
-
-.. code-block:: console
-
-    python -m pip install graphviz
-
 Sphinx Gallery requires that `setuptools <https://setuptools.pypa.io/en/latest/setuptools.html>`_
  is installed. It is usually packaged with python, but if necessary can be installed
  using ``pip``:

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -67,7 +67,7 @@ Most of the Sphinx Gallery dependencies are listed in :file:`requirements.txt`
 
 .. code-block:: console
 
-    python -m pip install -r requirements.txt -r dev-requirements.txt
+    python -m pip install -r dev-requirements.txt
 
 
 Sphinx Gallery requires `graphviz <https://graphviz.org/>`_ for drawing API


### PR DESCRIPTION
Also updates our dev Install Dependencies doc - we no longer have a `requirements.txt` file and graphviz is already in dev requirements.

