### PR TITLE
MNT: fixed documentation links in the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -188,6 +188,6 @@ How to cite
 If you would like to cite Sphinx-Gallery you can do so using our `Zenodo
 deposit <https://zenodo.org/record/3741780>`_.
 
-.. citation-end-content
-
 .. _documentation: https://sphinx-gallery.github.io/
+
+.. citation-end-content


### PR DESCRIPTION
I'm getting the following 404 with the current links in the readme:
![image](https://github.com/sphinx-gallery/sphinx-gallery/assets/1300499/8712a330-b08e-4dc5-9b18-c530fe90c408)
