### PR TITLE
Fix handling of multi-module intersphinx registries

### DIFF
--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -387,6 +387,10 @@ def test_embed_links_and_styles(sphinx_app):
     assert ".html#matplotlib.figure.Figure.tight_layout" in lines
     assert "matplotlib.axes.Axes.plot.html#matplotlib.axes.Axes.plot" in lines
     assert "matplotlib_configuration_api.html#matplotlib.RcParams" in lines
+    assert (
+        "mpl_toolkits.mplot3d.axes3d.Axes3D.plot.html#mpl_toolkits.mplot3d.axes3d.Axes3D.plot"
+        in lines
+    )
     assert "stdtypes.html#list" in lines
     assert "warnings.html#warnings.warn" in lines
     assert "itertools.html#itertools.compress" in lines
@@ -1349,7 +1353,7 @@ def test_recommend_n_examples(sphinx_app):
     # Check the same 3 related examples are shown
     assert "sphx-glr-auto-examples-plot-repr-py" in html
     assert "sphx-glr-auto-examples-plot-webp-py" in html
-    assert "sphx-glr-auto-examples-plot-matplotlib-backend-py" in html
+    assert "sphx-glr-auto-examples-plot-numpy-matplotlib-py" in html
 
 
 def test_sidebar_components_download_links(sphinx_app):

--- a/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
@@ -33,6 +33,8 @@ orig_dpi = 80.0 if matplotlib.__version__[0] < "2" else 100.0
 assert plt.rcParams["figure.dpi"] == orig_dpi
 plt.rcParams["figure.dpi"] = 70.0
 assert plt.rcParams["figure.dpi"] == 70.0
+fig3d, ax3d = plt.subplots(subplot_kw={"projection": "3d"})
+ax3d.plot(t, t, win, color="r")  # This should map to Axes3D.plot, not Axes.plot.
 listy = [0, 1]
 compress("abc", [0, 0, 1])
 warn("This warning should show up in the output", RuntimeWarning)


### PR DESCRIPTION
Some registries may contain multiple modules (e.g., Python contains all the standard library modules, or Matplotlib contains modules in the `mpl_toolkits` namespace), and the previous lookup by the intersphinx mapping _only_ could cause these to be missed. There was already some special casing for Python, but this is now extended to all inventories, fixing the case for Matplotlib as well.

Fixes matplotlib/matplotlib#28250