### PR TITLE
MNT Use `os.sep` everywhere

### DIFF
--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -352,7 +352,7 @@ def _thumbnail_div(
     # Inside rst files forward slash defines paths
     thumb = thumb.replace(os.sep, "/")
 
-    ref_name = os.path.join(full_dir, fname).replace(os.path.sep, "_")
+    ref_name = os.path.join(full_dir, fname).replace(os.sep, "_")
 
     template = BACKREF_THUMBNAIL_TEMPLATE if is_backref else THUMBNAIL_TEMPLATE
     return template.format(

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -835,7 +835,7 @@ def _format_for_writing(costs, *, src_dir, kind="rst"):
         rel_path = os.path.relpath(src_file, src_dir)
         if kind in ("rst", "rst-full"):  # like in sg_execution_times
             target_dir_clean = os.path.relpath(cost["target_dir"], src_dir).replace(
-                os.path.sep, "_"
+                os.sep, "_"
             )
             paren = rel_path if kind == "rst-full" else os.path.basename(src_file)
             name = ":ref:`sphx_glr_{0}_{1}` (``{2}``)".format(
@@ -874,7 +874,7 @@ def write_computation_times(gallery_conf, target_dir, costs):
         out_dir = target_dir
         where = os.path.relpath(target_dir, gallery_conf["src_dir"])
         kind = "rst"
-        ref_extra = f'{where.replace(os.path.sep, "_")}_'
+        ref_extra = f'{where.replace(os.sep, "_")}_'
     new_ref = f"sphx_glr_{ref_extra}sg_execution_times"
     out_file = Path(out_dir) / "sg_execution_times.rst"
     if out_file.is_file() and total_time == 0:  # a re-run

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -571,7 +571,7 @@ def generate_dir_rst(
         subsection_index_path = os.path.join(target_dir, "index.rst.new")
         with codecs.open(subsection_index_path, "w", encoding="utf-8") as (findex):
             findex.write(
-                "\n\n.. _sphx_glr_{}:\n\n".format(head_ref.replace(os.path.sep, "_"))
+                "\n\n.. _sphx_glr_{}:\n\n".format(head_ref.replace(os.sep, "_"))
             )
             findex.write(subsection_index_content)
 
@@ -1447,7 +1447,7 @@ def save_rst_example(
     """
     example_file = Path(example_file)
     example_fname = str(example_file.relative_to(gallery_conf["src_dir"]))
-    ref_fname = example_fname.replace(os.path.sep, "_")
+    ref_fname = example_fname.replace(os.sep, "_")
 
     binder_conf = gallery_conf["binder"]
     is_binder_enabled = len(binder_conf) > 0

--- a/sphinx_gallery/interactive_example.py
+++ b/sphinx_gallery/interactive_example.py
@@ -58,7 +58,7 @@ def gen_binder_url(fpath, binder_conf, gallery_conf):
         path_link = "/".join([fpath_prefix.strip("/"), path_link])
 
     # Make sure we have the right slashes (in case we're on Windows)
-    path_link = path_link.replace(os.path.sep, "/")
+    path_link = path_link.replace(os.sep, "/")
 
     # Create the URL
     binder_url = "/".join(
@@ -408,13 +408,13 @@ def gen_jupyterlite_rst(fpath, gallery_conf):
     relative_link = os.path.relpath(fpath, gallery_conf["src_dir"])
     notebook_location = relative_link.replace(".py", ".ipynb")
     # Make sure we have the right slashes (in case we're on Windows)
-    notebook_location = notebook_location.replace(os.path.sep, "/")
+    notebook_location = notebook_location.replace(os.sep, "/")
 
     lite_root_url = os.path.relpath(
         os.path.join(gallery_conf["src_dir"], "lite"), os.path.dirname(fpath)
     )
     # Make sure we have the right slashes (in case we're on Windows)
-    lite_root_url = lite_root_url.replace(os.path.sep, "/")
+    lite_root_url = lite_root_url.replace(os.sep, "/")
 
     if gallery_conf["jupyterlite"]["use_jupyter_lab"]:
         lite_root_url += "/lab"


### PR DESCRIPTION
Picked the most common one (it's also shorter) to use everywhere for consistency.

