### PR TITLE
FIX Jupyterlite in CircleCI artifact

### DIFF
--- a/sphinx_gallery/interactive_example.py
+++ b/sphinx_gallery/interactive_example.py
@@ -421,7 +421,7 @@ def gen_jupyterlite_rst(fpath, gallery_conf):
     else:
         lite_root_url += "/retro/notebooks"
 
-    lite_url = f"{lite_root_url}/?path={notebook_location}"
+    lite_url = f"{lite_root_url}/index.html?path={notebook_location}"
 
     # Similar work-around for badge file as in
     # gen_binder_rst

--- a/sphinx_gallery/tests/test_interactive_example.py
+++ b/sphinx_gallery/tests/test_interactive_example.py
@@ -204,7 +204,7 @@ def test_gen_jupyterlite_rst(use_jupyter_lab, example_file, tmpdir):
     image_rst = " .. image:: images/jupyterlite_badge_logo.svg"
 
     target_rst_template = (
-        ":target: {root_url}/lite/{jupyter_part}.+path={notebook_path}"
+        ":target: {root_url}/lite/{jupyter_part}.+index.html.+path={notebook_path}"
     )
     if "subdir" not in file_path:
         root_url = r"\.\."


### PR DESCRIPTION
A while ago, there was some CircleCI limitation that prevented JupyterLite to work inside CircleCI artifact, see https://github.com/sphinx-gallery/sphinx-gallery/pull/977#issuecomment-1330438821 if you are really curious.

It seems something has changed now, but for some reason you need to be explicit and add `index.html` to the URL, don't ask me why ... edit: I found this very old [discussion]( https://discuss.circleci.com/t/circle-artifacts-com-not-using-index-html/320) from 2015 but nothing more recent.

Let's try this in this PR!

An example of a recent scikit-learn doc build CircleCI artifact [example](https://output.circle-artifacts.com/output/job/13caab71-1b1d-444a-b316-93ac215ec6ef/artifacts/0/doc/auto_examples/release_highlights/plot_release_highlights_1_5_0.html)

The JupyterLite link points to `https://output.circle-artifacts.com/output/job/13caab71-1b1d-444a-b316-93ac215ec6ef/artifacts/0/doc/lite/lab/?path=auto_examples/release_highlights/plot_release_highlights_1_5_0.ipynb` which shows
![image](https://github.com/sphinx-gallery/sphinx-gallery/assets/1680079/f77c791d-59f6-4d54-924b-c6c43b17705d)

Add `index.html` i.e. `lite/lab/index.html?path=...` instead of `lite/lab/?path=...` and now it works:
`https://output.circle-artifacts.com/output/job/13caab71-1b1d-444a-b316-93ac215ec6ef/artifacts/0/doc/lite/lab/index.html?path=auto_examples/release_highlights/plot_release_highlights_1_5_0.ipynb`

