### PR TITLE
Introduction tooltip corresponds to the first paragraph

### DIFF
--- a/sphinx_gallery/_static/sg_gallery.css
+++ b/sphinx_gallery/_static/sg_gallery.css
@@ -185,16 +185,18 @@ thumbnail with its default link Background color */
   border-radius: 4px;
   color: var(--sg-tooltip-foreground);
   content: attr(tooltip);
-  padding: 10px;
+  padding: 10px 10px 5px;
   z-index: 98;
   width: 100%;
-  height: 100%;
   position: absolute;
   pointer-events: none;
   top: 0;
   box-sizing: border-box;
   overflow: hidden;
   backdrop-filter: blur(3px);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 6;
 }
 
 .sphx-glr-script-out {

--- a/sphinx_gallery/_static/sg_gallery.css
+++ b/sphinx_gallery/_static/sg_gallery.css
@@ -178,8 +178,27 @@ thumbnail with its default link Background color */
   max-height: 112px;
   max-width: 160px;
 }
-.sphx-glr-thumbcontainer[tooltip]:hover:after {
-  background: var(--sg-tooltip-background);
+
+.sphx-glr-thumbcontainer[tooltip]::before {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 97;
+  background-color: var(--sg-tooltip-background);
+  backdrop-filter: blur(3px);
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.sphx-glr-thumbcontainer[tooltip]:hover::before {
+  opacity: 1;
+}
+
+.sphx-glr-thumbcontainer[tooltip]:hover::after {
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
@@ -188,12 +207,12 @@ thumbnail with its default link Background color */
   padding: 10px 10px 5px;
   z-index: 98;
   width: 100%;
+  max-height: 100%;
   position: absolute;
   pointer-events: none;
   top: 0;
   box-sizing: border-box;
   overflow: hidden;
-  backdrop-filter: blur(3px);
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 6;

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -331,9 +331,6 @@ def extract_intro_and_title(filename, docstring):
     # Concatenate all lines of the first paragraph and truncate at 95 chars
     intro = re.sub("\n", " ", intro_paragraph)
     intro = _sanitize_rst(intro)
-    if len(intro) > 95:
-        intro = intro[:95] + "..."
-
     title = _sanitize_rst(title)
 
     return intro, title

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -352,15 +352,14 @@ def test_extract_intro_and_title():
     )  # noqa: E501
     assert title == '"-`Header"-with:; punct mark\'s'
 
-    # Long intro paragraph gets shortened
+    # Long intro paragraph are preserved
     intro_paragraph = "\n".join(["this is one line" for _ in range(10)])
     intro, _ = sg.extract_intro_and_title(
         "filename", "Title\n-----\n\n" + intro_paragraph
     )
     assert len(intro_paragraph) > 100
-    assert len(intro) < 100
-    assert intro.endswith("...")
-    assert intro_paragraph.replace("\n", " ")[:95] == intro[:95]
+    assert len(intro) > 100
+    assert intro_paragraph.replace("\n", " ") == intro
 
     # Errors
     with pytest.raises(ExtensionError, match="should have a header"):


### PR DESCRIPTION
Closes: #1066 (related to #1085).


- [x] Introduction tooltip corresponds to the first paragraph and is no longer truncated.
- [x] Tooltip representation is handled using CSS.


### With my custom-sized gallery

#### Without adjusting the `padding`, I got this:

![image](https://github.com/sphinx-gallery/sphinx-gallery/assets/281007/05da88b5-1625-4e5c-b200-5bbc54a11554)

Note that given the padding was `10px 10px 10px 10px`, the bottom exposes the top content of the next truncated line:

![image](https://github.com/sphinx-gallery/sphinx-gallery/assets/281007/c2f63419-bf5f-478d-ac0d-276f6363dee3)


#### Adjusting the `padding`, I got this:

![image](https://github.com/sphinx-gallery/sphinx-gallery/assets/281007/2c49ad85-14bf-4c28-89e8-5b42ccdfc8dd)


### With full default CSS

I've adjusted the clamp to 6 lines, so longer texts use full space, and smaller ones are automatically reduced (states forced to :hover):

![image](https://github.com/sphinx-gallery/sphinx-gallery/assets/281007/a9a41787-2968-45a4-a238-2c37ce1f1c84)
