### PR TITLE
FIX generate zipfiles when index passed by user

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -608,13 +608,15 @@ def _finish_index_rst(
         )
         indexst += subsections_toctree
 
-    if sg_root_index:
-        # Download examples
-        if gallery_conf["download_all_examples"]:
-            download_fhindex = generate_zipfiles(
-                gallery_dir_abs_path, app.builder.srcdir, gallery_conf
-            )
+    # Always generate download zipfiles, only add to index.rst if required
+    if gallery_conf["download_all_examples"]:
+        download_fhindex = generate_zipfiles(
+            gallery_dir_abs_path, app.builder.srcdir, gallery_conf
+        )
+        if sg_root_index:
             indexst += download_fhindex
+
+    if sg_root_index:
         # Signature
         if app.config.sphinx_gallery_conf["show_signature"]:
             indexst += SPHX_GLR_SIG

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -83,7 +83,14 @@ def _sphinx_app(tmpdir_factory, buildername):
     src_dir = Path(__file__).parent / "tinybuild"
 
     def ignore(src, names):
-        return ("_build", "gen_modules", "auto_examples")
+        return (
+            "_build",
+            "gen_modules",
+            "auto_examples",
+            "auto_examples_README_header",
+            "auto_examples_rst_index",
+            "auto_examples_with_rst",
+        )
 
     shutil.copytree(src_dir, temp_dir, ignore=ignore)
     # For testing iteration, you can get similar behavior just doing `make`
@@ -306,6 +313,13 @@ def test_run_sphinx(sphinx_app):
     warning = sphinx_app._warning.getvalue()
     want = ".*fetching .*wrong_url.*404.*"
     assert re.match(want, warning, re.DOTALL) is not None, warning
+
+
+def test_user_index_download(sphinx_app):
+    """Test download zipfiles still generated when user supplies index.rst"""
+    src_dir = Path(sphinx_app.srcdir) / "auto_examples_rst_index"
+    assert (src_dir / "auto_examples_rst_index_jupyter.zip").is_file()
+    assert (src_dir / "auto_examples_rst_index_python.zip").is_file()
 
 
 def test_thumbnail_path(sphinx_app, tmpdir):
@@ -607,8 +621,12 @@ def test_backreferences(sphinx_app):
     assert op.isfile(html)
     with codecs.open(html, "r", "utf-8") as fid:
         html = fid.read()
-    assert "sphinx_gallery.sorting.html#sphinx_gallery.sorting.ExplicitOrder" in html  # noqa: E501
-    assert "sphinx_gallery.scrapers.html#sphinx_gallery.scrapers.clean_modules" in html  # noqa: E501
+    assert (
+        "sphinx_gallery.sorting.html#sphinx_gallery.sorting.ExplicitOrder" in html
+    )  # noqa: E501
+    assert (
+        "sphinx_gallery.scrapers.html#sphinx_gallery.scrapers.clean_modules" in html
+    )  # noqa: E501
     assert "figure_rst.html" not in html  # excluded
 
 

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -621,12 +621,8 @@ def test_backreferences(sphinx_app):
     assert op.isfile(html)
     with codecs.open(html, "r", "utf-8") as fid:
         html = fid.read()
-    assert (
-        "sphinx_gallery.sorting.html#sphinx_gallery.sorting.ExplicitOrder" in html
-    )  # noqa: E501
-    assert (
-        "sphinx_gallery.scrapers.html#sphinx_gallery.scrapers.clean_modules" in html
-    )  # noqa: E501
+    assert "sphinx_gallery.sorting.html#sphinx_gallery.sorting.ExplicitOrder" in html  # noqa: E501
+    assert "sphinx_gallery.scrapers.html#sphinx_gallery.scrapers.clean_modules" in html  # noqa: E501
     assert "figure_rst.html" not in html  # excluded
 
 


### PR DESCRIPTION
Fixes https://github.com/sphinx-gallery/sphinx-gallery/pull/1332#issuecomment-2244559782

When top level index.rst is passed by user we were not generating the zipfiles.