### PR TITLE
FIX Allow str path minigallery entries when backreferences off

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -50,7 +50,7 @@ file, inside a ``sphinx_gallery_conf`` dictionary.
 
 - ``reference_url``, ``prefer_full_module`` (:ref:`link_to_documentation`)
 - ``backreferences_dir``, ``doc_module``, ``exclude_implicit_doc``,
-  and ``inspect_global_variables`` (:ref:`references_to_examples`)
+  and ``inspect_global_variables`` (:ref:`minigalleries_to_examples`)
 - ``minigallery_sort_order`` (:ref:`minigallery_order`)
 
 **Images and thumbnails**
@@ -659,9 +659,17 @@ directive so that you can easily add a reduced version of the Gallery to
 your Sphinx documentation ``.rst`` files. The mini-gallery directive therefore
 supports passing a list (space separated) of any of the following:
 
-* full qualified name of object (see :ref:`references_to_examples`)
+* full qualified name of object (see :ref:`references_to_examples`) - this
+  adds all examples where the object was used in the code or referenced in
+  the example text
 * pathlike strings to example Python files, including glob-style
   (see :ref:`file_based_minigalleries`)
+
+To use object names, you must enable backreference generation, see
+:ref:`references_to_examples` for details.
+If backreference generation is not enabled, object entries to the
+:class:`~sphinx_gallery.directives.MiniGallery` directive will be ignored
+and all entries will be treated as pathlike strings.
 
 .. _references_to_examples:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -656,10 +656,10 @@ Add mini-galleries
 
 Sphinx-Gallery provides the :class:`sphinx_gallery.directives.MiniGallery`
 directive so that you can easily add a reduced version of the Gallery to
-your Sphinx documentation ``.rst`` files. The mini-gallery directive therefore
+your Sphinx documentation ``.rst`` files. The minigallery directive therefore
 supports passing a list (space separated) of any of the following:
 
-* full qualified name of object (see :ref:`references_to_examples`) - this
+* fully qualified name of object (see :ref:`references_to_examples`) - this
   adds all examples where the object was used in the code or referenced in
   the example text
 * pathlike strings to example Python files, including glob-style
@@ -676,24 +676,30 @@ and all entries will be treated as pathlike strings.
 Add mini-galleries for API documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When documenting a given function/method/attribute/object/class, Sphinx-Gallery
-enables you to link to any examples that either:
+Sphinx-Gallery can generate minigalleries for objects for specified modules,
+consisting of all examples that either:
 
 1. Use the function/method/attribute/object or instantiate the class in the
-   code (generates *implicit backreferences*).
+   code (called *implicit backreferences*) or
 2. Refer to that function/method/attribute/object/class using sphinx markup
    ``:func:`` / ``:meth:`` / ``:attr:`` / ``:obj:`` / ``:class:`` in a text
    block. You can omit this role markup if you have set the `default_role
    <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-default_role>`_
-   in your ``conf.py`` to any of these roles (generates *explicit
+   in your ``conf.py`` to any of these roles (called *explicit
    backreferences*).
 
-The former is useful for auto-documenting functions/methods/attributes/objects
-that are used and classes that are explicitly instantiated. The generated links
-are called implicit backreferences. The latter is useful for classes that are
-typically implicitly returned rather than explicitly instantiated (e.g.,
+This allows you to pass a fully qualified name of an object (e.g., function, method,
+attribute, class) to the minigallery directive to add a minigallery of all examples
+relevant to that object. This can be useful in API documentation.
+
+**Implicit backreferences** are useful for auto-documenting objects
+that are used and classes that are explicitly instantiated, in the code. Any examples
+where an object is used in the code are added *implicitly* as backreferences.
+**Explicit backreferences** are for objects that are *explicitly* referred to
+in an example's text. They are useful for classes that are
+typically implicitly returned in the code rather than explicitly instantiated (e.g.,
 :class:`matplotlib.axes.Axes` which is most often instantiated only indirectly
-within function calls). Such links are called explicit backreferences.
+within function calls)..
 
 For example, we can embed a small gallery of all examples that use or
 refer to :obj:`numpy.exp`, which looks like this:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -676,7 +676,7 @@ and all entries will be treated as pathlike strings.
 Add mini-galleries for API documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Sphinx-Gallery can generate minigalleries for objects for specified modules,
+Sphinx-Gallery can generate minigalleries for objects from specified modules,
 consisting of all examples that either:
 
 1. Use the function/method/attribute/object or instantiate the class in the
@@ -727,9 +727,14 @@ your Sphinx-Gallery configuration ``conf.py`` file with::
 
 The path you specify in ``backreferences_dir`` (here we choose
 ``gen_modules/backreferences``) will be populated with
-ReStructuredText files. Each .rst file will contain a reduced version of the
+ReStructuredText files, with names ending with '.examples'.
+Each .rst file will contain a reduced version of the
 gallery specific to every function/class that is used across all the examples
 and belonging to the modules listed in ``doc_module``.
+Note that backreference files will be generated for all objects. Objects that
+are not used in any example will have an empty file to prevent inclusion
+errors during autodoc parsing.
+
 ``backreferences_dir`` should be a string or ``pathlib.Path`` object that is
 **relative** to the ``conf.py`` file, or ``None``. It is ``None`` by default.
 

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -152,8 +152,7 @@ class MiniGallery(Directive):
                 if len(dirs) != 1:
                     raise ExtensionError(
                         f"Error in minigallery file lookup: input={obj}, "
-                        f"matches={dirs}, "
-                        f"examples_dirs={config.sphinx_gallery_conf['examples_dirs']}"
+                        f"matches={dirs}, examples_dirs={examples_dirs}"
                     )
 
                 example_dir, target_dir = [Path(src_dir, d) for d in dirs[0]]

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -8,6 +8,7 @@ from docutils import nodes, statemachine
 from docutils.parsers.rst import Directive, directives
 from docutils.parsers.rst.directives import images
 from sphinx.errors import ExtensionError
+from sphinx.util.logging import getLogger
 
 from .backreferences import (
     THUMBNAIL_PARENT_DIV,
@@ -16,6 +17,8 @@ from .backreferences import (
 )
 from .gen_rst import extract_intro_and_title
 from .py_source_parser import split_code_and_text_blocks
+
+logger = getLogger("sphinx-gallery")
 
 
 class MiniGallery(Directive):
@@ -67,12 +70,16 @@ class MiniGallery(Directive):
         # Retrieve the backreferences directory
         config = self.state.document.settings.env.config
         backreferences_dir = config.sphinx_gallery_conf["backreferences_dir"]
+        if backreferences_dir is None:
+            logger.warning(
+                "'backreferences_dir' config is None, minigallery "
+                "directive will only add example file paths."
+            )
 
         # Retrieve source directory
         src_dir = config.sphinx_gallery_conf["src_dir"]
 
         # Parse the argument into the individual objects
-
         obj_list = []
 
         if self.arguments:
@@ -100,7 +107,7 @@ class MiniGallery(Directive):
 
         file_paths = []
         for obj in obj_list:
-            if path := has_backrefs(obj):
+            if backreferences_dir and (path := has_backrefs(obj)):
                 file_paths.append((obj, path))
             elif paths := Path(src_dir).glob(obj):
                 file_paths.extend([(obj, p) for p in paths])
@@ -131,18 +138,22 @@ class MiniGallery(Directive):
     :end-before: thumbnail-parent-div-close"""
                 )
             else:
+                examples_dirs = config.sphinx_gallery_conf["examples_dirs"]
+                if not isinstance(examples_dirs, list):
+                    examples_dirs = [examples_dirs]
+                gallery_dirs = config.sphinx_gallery_conf["gallery_dirs"]
+                if not isinstance(gallery_dirs, list):
+                    gallery_dirs = [gallery_dirs]
                 dirs = [
                     (e, g)
-                    for e, g in zip(
-                        config.sphinx_gallery_conf["examples_dirs"],
-                        config.sphinx_gallery_conf["gallery_dirs"],
-                    )
+                    for e, g in zip(examples_dirs, gallery_dirs)
                     if (obj.find(e) != -1)
                 ]
                 if len(dirs) != 1:
                     raise ExtensionError(
-                        f"Error in gallery lookup: input={obj}, matches={dirs}, "
-                        f"examples={config.sphinx_gallery_conf['examples_dirs']}"
+                        f"Error in minigallery file lookup: input={obj}, "
+                        f"matches={dirs}, "
+                        f"examples_dirs={config.sphinx_gallery_conf['examples_dirs']}"
                     )
 
                 example_dir, target_dir = [Path(src_dir, d) for d in dirs[0]]

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -539,6 +539,7 @@ from sphinx_gallery.gen_rst import _sg_call_memory_noop
 
 sphinx_gallery_conf = {
     'show_memory': _sg_call_memory_noop,
+    'examples_dirs': 'src',
     'gallery_dirs': 'ex',
 }"""
 )
@@ -583,6 +584,20 @@ def test_backreferences_dir_config(sphinx_app_wrapper):
     with pytest.raises(ConfigError, match="'backreferences_dir' config allowed types"):
         app = sphinx_app_wrapper.create_sphinx_app()
         fill_gallery_conf_defaults(app, app.config, check_keys=False)
+
+
+@pytest.mark.conf_file(
+    content="""
+sphinx_gallery_conf = {
+    'examples_dirs': 'src',
+    'gallery_dirs': 'ex',
+}"""
+)
+def test_minigallery_no_backreferences_dir(sphinx_app_wrapper):
+    """Check warning when no backreferences_dir set but minigallery directive used."""
+    sphinx_app = sphinx_app_wrapper.build_sphinx_app()
+    build_warn = sphinx_app._warning.getvalue()
+    assert "'backreferences_dir' config is None, minigallery" in build_warn
 
 
 @pytest.mark.conf_file(

--- a/sphinx_gallery/tests/testconfs/src/plot_1.py
+++ b/sphinx_gallery/tests/testconfs/src/plot_1.py
@@ -9,3 +9,7 @@ B test
 print("foo")
 print("bar")
 print("again")
+
+# %%
+#
+# .. minigallery:: src/plot_2.py


### PR DESCRIPTION
Closes #1354

Amend the minigallery directive, such that when `backreferences_dir` is `None`, we simply treat all entries as str paths and glob them.

I thought about adding additional check to the minigallery entries, to make sure they are not objects. But it would be very unusual to have a file named e.g., `sphinx_gallery.sorting.ExplicitOrder` in the source dir?
Happy to add a check though, WDYT @larsoner ?

Also fixes a bug where we were not converting `examples_dirs` and `gallery_dirs` to list when given as str.


Note to self: look into: https://github.com/sphinx-gallery/sphinx-gallery/pull/1226#discussion_r1690889760