### PR TITLE
Improve minigallery directive path input resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,4 +167,5 @@ filterwarnings = [
 junit_family = "xunit2"
 markers = [
   "conf_file: Configuration file.",
+  "add_rst: Add rst file to src.",
 ]

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -108,9 +108,9 @@ class MiniGallery(Directive):
         file_paths = []
         for obj in obj_list:
             if backreferences_dir and (path := has_backrefs(obj)):
-                file_paths.append((obj, path))
+                file_paths.append((obj, path.resolve()))
             elif paths := Path(src_dir).glob(obj):
-                file_paths.extend([(obj, p) for p in paths])
+                file_paths.extend([(obj, p.resolve()) for p in paths])
 
         if len(file_paths) == 0:
             return []
@@ -126,7 +126,7 @@ class MiniGallery(Directive):
             )
         for obj, path in sorted(
             set(file_paths),
-            key=((lambda x: sortkey(os.path.abspath(x[-1]))) if sortkey else None),
+            key=((lambda x: sortkey(str(x[-1]))) if sortkey else None),
         ):
             if path.suffix == ".examples":
                 # Insert the backreferences file(s) using the `include` directive.
@@ -144,21 +144,38 @@ class MiniGallery(Directive):
                 gallery_dirs = config.sphinx_gallery_conf["gallery_dirs"]
                 if not isinstance(gallery_dirs, list):
                     gallery_dirs = [gallery_dirs]
-                dirs = [
-                    (e, g)
-                    for e, g in zip(examples_dirs, gallery_dirs)
-                    if (obj.find(e) != -1)
-                ]
-                if len(dirs) != 1:
+
+                gal_matches = []
+                for e, g in zip(examples_dirs, gallery_dirs):
+                    e = Path(src_dir, e).resolve(strict=True)
+                    g = Path(src_dir, g).resolve(strict=True)
+                    try:
+                        gal_matches.append((path.relative_to(e), g))
+                    except ValueError:
+                        continue
+                # `path` inside one `examples_dirs`
+                if (n_match := len(gal_matches)) == 1:
+                    ex_parents, target_dir = gal_matches[0][0].parents, gal_matches[0][1]
+                # `path` inside several `examples_dirs`, take the longest match
+                elif n_match > 1:
+                    ex_parents, target_dir = max(
+                        [(match[0].parents, match[1]) for match in gal_matches],
+                        key=lambda x: len(x[0]),
+                    )
+                # `path` is not inside a `examples_dirs`
+                else:
                     raise ExtensionError(
-                        f"Error in minigallery file lookup: input={obj}, "
-                        f"matches={dirs}, examples_dirs={examples_dirs}"
+                        f"minigallery directive error: input: {obj} found file: "
+                        f"{path} but this does not live inside any examples_dirs: "
+                        f"{examples_dirs}"
                     )
 
-                example_dir, target_dir = [Path(src_dir, d) for d in dirs[0]]
-
-                # finds thumbnails in subdirs
-                target_dir = target_dir / path.relative_to(example_dir).parent
+                # Add subgallery path, if present
+                subdir = ""
+                if (ex_p := ex_parents[0]) != Path("."):
+                    subdir = ex_p
+                target_dir = target_dir / subdir
+                # Get thumbnail
                 _, script_blocks = split_code_and_text_blocks(
                     str(path), return_node=False
                 )

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -148,11 +148,14 @@ class MiniGallery(Directive):
                 gal_matches = []
                 for e, g in zip(examples_dirs, gallery_dirs):
                     e = Path(src_dir, e).resolve(strict=True)
+                    print(f'XXXX {e=}')
                     g = Path(src_dir, g).resolve(strict=True)
                     try:
                         gal_matches.append((path.relative_to(e), g))
                     except ValueError:
                         continue
+                print(f'XXXX {obj=}, {path=}')
+                print(f'XXXX gal matches: {gal_matches}')
                 # `path` inside one `examples_dirs`
                 if (n_match := len(gal_matches)) == 1:
                     ex_parents, target_dir = (

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -55,7 +55,6 @@ class MiniGallery(Directive):
 
     def _get_target_dir(self, config, src_dir, path, obj):
         """Get thumbnail target directory, errors when ambiguous/not in example dir."""
-        print(f'XXX {obj=}, {path=}')
         examples_dirs = config.sphinx_gallery_conf["examples_dirs"]
         if not isinstance(examples_dirs, list):
             examples_dirs = [examples_dirs]

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -155,7 +155,10 @@ class MiniGallery(Directive):
                         continue
                 # `path` inside one `examples_dirs`
                 if (n_match := len(gal_matches)) == 1:
-                    ex_parents, target_dir = gal_matches[0][0].parents, gal_matches[0][1]
+                    ex_parents, target_dir = (
+                        gal_matches[0][0].parents,
+                        gal_matches[0][1],
+                    )
                 # `path` inside several `examples_dirs`, take the longest match
                 elif n_match > 1:
                     ex_parents, target_dir = max(
@@ -165,8 +168,8 @@ class MiniGallery(Directive):
                 # `path` is not inside a `examples_dirs`
                 else:
                     raise ExtensionError(
-                        f"minigallery directive error: input: {obj} found file: "
-                        f"{path} but this does not live inside any examples_dirs: "
+                        f"minigallery directive error: path input '{obj}' found file:"
+                        f" '{path}' but this does not live inside any examples_dirs: "
                         f"{examples_dirs}"
                     )
 

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -17,6 +17,24 @@ from sphinx_gallery.scrapers import _import_matplotlib
 from sphinx_gallery.utils import _get_image
 
 
+NESTED_PY = """\"\"\"
+Header
+======
+
+Text.
+\"\"\"
+
+a = 1
+"""
+
+GALLERY_HEADER = """
+Gallery header
+==============
+
+Some text.
+"""
+
+
 def pytest_report_header(config, startdir=None):
     """Add information to the pytest run header."""
     return f"Sphinx:  {sphinx.__version__} ({sphinx.__file__})"
@@ -203,6 +221,18 @@ def sphinx_app_wrapper(tmpdir, conf_file, add_rst, req_mpl, req_pil):
     if add_rst:
         with open(os.path.join(srcdir, "minigallery_test.rst"), "w") as rstfile:
             rstfile.write(add_rst)
+        # Add nested gallery
+        if "sub_folder/sub_sub_folder" in add_rst:
+            dir_path = os.path.join(srcdir, "src", "sub_folder", "sub_sub_folder")
+            os.makedirs(dir_path)
+            with open(os.path.join(dir_path, "plot_nested.py"), "w") as pyfile:
+                pyfile.write(NESTED_PY)
+            with open(os.path.join(dir_path, "GALLERY_HEADER.rst"), "w") as rstfile:
+                rstfile.write(GALLERY_HEADER)
+
+    from pathlib import Path
+    for p in Path(srcdir).rglob('*.py'):
+        print(f'XX {p} XXX')
 
     base_config = f"""
 import os

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -16,7 +16,6 @@ from sphinx_gallery import docs_resolv, gen_gallery, gen_rst, py_source_parser
 from sphinx_gallery.scrapers import _import_matplotlib
 from sphinx_gallery.utils import _get_image
 
-
 NESTED_PY = """\"\"\"
 Header
 ======

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -203,9 +203,6 @@ def sphinx_app_wrapper(tmpdir, conf_file, add_rst, req_mpl, req_pil):
     if add_rst:
         with open(os.path.join(srcdir, "minigallery_test.rst"), "w") as rstfile:
             rstfile.write(add_rst)
-    from pathlib import Path
-    for p in Path(tmpdir).rglob("*"):
-        print(p)
 
     base_config = f"""
 import os

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -1,9 +1,9 @@
 """Pytest fixtures."""
 
-import os
 import shutil
 from contextlib import contextmanager
 from io import StringIO
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -210,29 +210,23 @@ class SphinxAppWrapper:
 
 @pytest.fixture
 def sphinx_app_wrapper(tmpdir, conf_file, add_rst, req_mpl, req_pil):
-    _fixturedir = os.path.join(os.path.dirname(__file__), "testconfs")
-    srcdir = os.path.join(str(tmpdir), "config_test")
+    _fixturedir = Path(__file__).parent / "testconfs"
+    srcdir = Path(tmpdir) / "config_test"
     shutil.copytree(_fixturedir, srcdir)
     # Copy files to 'examples/' as well because default `examples_dirs` is
     # '../examples' - for tests where we don't update config
-    shutil.copytree(
-        os.path.join(_fixturedir, "src"), os.path.join(str(tmpdir), "examples")
-    )
+    shutil.copytree((_fixturedir / "src"), (Path(tmpdir) / "examples"))
     if add_rst:
-        with open(os.path.join(srcdir, "minigallery_test.rst"), "w") as rstfile:
+        with open((srcdir / "minigallery_test.rst"), "w") as rstfile:
             rstfile.write(add_rst)
         # Add nested gallery
         if "sub_folder/sub_sub_folder" in add_rst:
-            dir_path = os.path.join(srcdir, "src", "sub_folder", "sub_sub_folder")
-            os.makedirs(dir_path)
-            with open(os.path.join(dir_path, "plot_nested.py"), "w") as pyfile:
+            dir_path = srcdir / "src" / "sub_folder" / "sub_sub_folder"
+            dir_path.mkdir(parents=True)
+            with open((dir_path / "plot_nested.py"), "w") as pyfile:
                 pyfile.write(NESTED_PY)
-            with open(os.path.join(dir_path, "GALLERY_HEADER.rst"), "w") as rstfile:
+            with open((dir_path / "GALLERY_HEADER.rst"), "w") as rstfile:
                 rstfile.write(GALLERY_HEADER)
-
-    from pathlib import Path
-    for p in Path(srcdir).rglob('*.py'):
-        print(f'XX {p} XXX')
 
     base_config = f"""
 import os
@@ -244,14 +238,14 @@ master_doc = 'index'
 # General information about the project.
 project = 'Sphinx-Gallery <Tests>'\n\n
 """
-    with open(os.path.join(srcdir, "conf.py"), "w") as conffile:
+    with open((srcdir / "conf.py"), "w") as conffile:
         conffile.write(base_config + conf_file["content"])
 
     return SphinxAppWrapper(
         srcdir,
         srcdir,
-        os.path.join(srcdir, "_build"),
-        os.path.join(srcdir, "_build", "toctree"),
+        (srcdir / "_build"),
+        (srcdir / "_build" / "toctree"),
         "html",
         warning=StringIO(),
         status=StringIO(),

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -614,6 +614,28 @@ def test_backreferences_dir_pathlib_config(sphinx_app_wrapper):
     fill_gallery_conf_defaults(app, app.config, check_keys=False)
 
 
+@pytest.mark.conf_file(
+    content="""
+sphinx_gallery_conf = {
+    'examples_dirs': 'src',
+    'gallery_dirs': 'ex',
+}"""
+)
+@pytest.mark.add_rst(
+    file="""
+Header
+======
+
+.. minigallery:: index.rst
+"""
+)
+def test_minigallery_not_in_examples_dirs(sphinx_app_wrapper):
+    """Check error raised when minigallery path input not in `examples_dirs`."""
+    msg = "minigallery directive error: path input 'index.rst'"
+    with pytest.raises(ExtensionError, match=msg):
+        sphinx_app_wrapper.build_sphinx_app()
+
+
 def test_write_computation_times_noop(sphinx_app_wrapper):
     app = sphinx_app_wrapper.create_sphinx_app()
     write_computation_times(app.config.sphinx_gallery_conf, None, [])

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -259,7 +259,7 @@ def _check_order(sphinx_app, key):
 
     Used to test that these keys (in index.rst) appear in a specific order.
     """
-    index_fname = os.path.join(sphinx_app.outdir, "..", "ex", "index.rst")
+    index_fname = Path(sphinx_app.outdir, "..", "ex", "index.rst")
     order = list()
     regex = f".*:{key}=(.):.*"
     with open(index_fname, "r", encoding="utf-8") as fid:
@@ -387,7 +387,7 @@ def test_collect_gallery_files_ignore_pattern(tmpdir, gallery_conf):
     expected_files = {
         ap.strpath
         for ap in abs_paths
-        if re.search(r"one", os.path.basename(ap.strpath)) is None
+        if re.search(r"one", Path(ap.strpath).name) is None
     }
 
     assert collected_files == expected_files
@@ -412,19 +412,17 @@ def test_binder_copy_files(sphinx_app_wrapper):
     sphinx_app = sphinx_app_wrapper.create_sphinx_app()
     gallery_conf = sphinx_app.config.sphinx_gallery_conf
     # Create requirements file
-    with open(os.path.join(sphinx_app.srcdir, "requirements.txt"), "w"):
+    with open(Path(sphinx_app.srcdir, "requirements.txt"), "w"):
         pass
     copy_binder_files(sphinx_app, None)
 
     for i_file in ["plot_1", "plot_2", "plot_3"]:
-        assert os.path.exists(
-            os.path.join(
-                sphinx_app.outdir,
-                "ntbk_folder",
-                gallery_conf["gallery_dirs"][0],
-                i_file + ".ipynb",
-            )
-        )
+        assert Path(
+            sphinx_app.outdir,
+            "ntbk_folder",
+            gallery_conf["gallery_dirs"][0],
+            i_file + ".ipynb",
+        ).exists()
 
 
 @pytest.mark.conf_file(
@@ -435,7 +433,7 @@ sphinx_gallery_conf = {
 }"""
 )
 def test_failing_examples_raise_exception(sphinx_app_wrapper):
-    example_dir = os.path.join(sphinx_app_wrapper.srcdir, "src")
+    example_dir = Path(sphinx_app_wrapper.srcdir, "src")
     bad_line = "print(f'{a[}')"  # never closed bracket inside print -> SyntaxError
     bad_code = f"""\
 '''
@@ -451,7 +449,7 @@ Should emit a syntax error in the second code block.
 {bad_line}
 """
     bad_line_no = bad_code.split("\n").index(bad_line) + 1
-    with open(os.path.join(example_dir, "plot_3.py"), "w", encoding="utf-8") as fid:
+    with open(Path(example_dir, "plot_3.py"), "w", encoding="utf-8") as fid:
         fid.write(bad_code)
     with pytest.raises(ExtensionError) as excinfo:
         sphinx_app_wrapper.build_sphinx_app()
@@ -726,14 +724,12 @@ def test_create_jupyterlite_contents(sphinx_app_wrapper):
     create_jupyterlite_contents(sphinx_app, exception=None)
 
     for i_file in ["plot_1", "plot_2", "plot_3"]:
-        assert os.path.exists(
-            os.path.join(
-                sphinx_app.srcdir,
-                "jupyterlite_contents",
-                gallery_conf["gallery_dirs"][0],
-                i_file + ".ipynb",
-            )
-        )
+        assert Path(
+            sphinx_app.srcdir,
+            "jupyterlite_contents",
+            gallery_conf["gallery_dirs"][0],
+            i_file + ".ipynb",
+        ).exists()
 
 
 @pytest.mark.conf_file(
@@ -756,14 +752,12 @@ def test_create_jupyterlite_contents_non_default_contents(sphinx_app_wrapper):
     create_jupyterlite_contents(sphinx_app, exception=None)
 
     for i_file in ["plot_1", "plot_2", "plot_3"]:
-        assert os.path.exists(
-            os.path.join(
-                sphinx_app.srcdir,
-                "this_is_the_contents_dir",
-                gallery_conf["gallery_dirs"][0],
-                i_file + ".ipynb",
-            )
-        )
+        assert Path(
+            sphinx_app.srcdir,
+            "this_is_the_contents_dir",
+            gallery_conf["gallery_dirs"][0],
+            i_file + ".ipynb",
+        ).exists()
 
 
 @pytest.mark.conf_file(
@@ -782,7 +776,7 @@ def test_create_jupyterlite_contents_without_jupyterlite_sphinx_loaded(
     sphinx_app = sphinx_app_wrapper.create_sphinx_app()
 
     create_jupyterlite_contents(sphinx_app, exception=None)
-    assert not os.path.exists(os.path.join(sphinx_app.srcdir, "jupyterlite_contents"))
+    assert not Path(sphinx_app.srcdir, "jupyterlite_contents").exists()
 
 
 @pytest.mark.conf_file(
@@ -807,7 +801,7 @@ def test_create_jupyterlite_contents_with_jupyterlite_disabled_via_config(
     sphinx_app = sphinx_app_wrapper.create_sphinx_app()
 
     create_jupyterlite_contents(sphinx_app, exception=None)
-    assert not os.path.exists(os.path.join(sphinx_app.outdir, "jupyterlite_contents"))
+    assert not Path(sphinx_app.outdir, "jupyterlite_contents").exists()
 
 
 @pytest.mark.conf_file(
@@ -841,13 +835,13 @@ def test_create_jupyterlite_contents_with_modification(sphinx_app_wrapper):
     create_jupyterlite_contents(sphinx_app, exception=None)
 
     for i_file in ["plot_1", "plot_2", "plot_3"]:
-        notebook_filename = os.path.join(
+        notebook_filename = Path(
             sphinx_app.srcdir,
             "jupyterlite_contents",
             gallery_conf["gallery_dirs"][0],
             i_file + ".ipynb",
         )
-        assert os.path.exists(notebook_filename)
+        assert notebook_filename.exists()
 
         with open(notebook_filename) as f:
             notebook_content = json.load(f)

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -658,7 +658,6 @@ def test_minigallery_multi_match(sphinx_app_wrapper):
     from the nested gallery should resolve to the nested gallery.
     """
     sphinx_app = sphinx_app_wrapper.build_sphinx_app()
-    from pathlib import Path
     minigallery_html = Path(sphinx_app.outdir) / "minigallery_test.html"
     with open(minigallery_html, "r") as fid:
         mg_html = fid.read()


### PR DESCRIPTION
closes #1356

Uses `relative_to` to get target gallery path - in particular improves the part where we figure out if the file is in a subgallery/subfolder. I think the `relative_to` is more robust and I think it should work as intended.

e.g., 
one glob match: `'.../sphinx-gallery/sphinx_gallery/tests/tinybuild/examples_rst_index/examp_subdir2/plot_sub2.py'`
example dir path: `.../sphinx_gallery/sphinx_gallery/tests/tinybuild/examples_rst_index/`

Uses `resolve` to get abs paths.

cc @story645 