### PR TITLE
Obey prefer_full_module setting when finding backreferences

### DIFF
--- a/sphinx_gallery/_dummy/__init__.py
+++ b/sphinx_gallery/_dummy/__init__.py
@@ -1,0 +1,14 @@
+from .nested import NestedDummyClass  # noqa: F401
+
+
+class DummyClass:
+    """Dummy class for testing method resolution."""
+
+    def run(self):
+        """Do nothing."""
+        pass
+
+    @property
+    def prop(self):
+        """Property."""
+        return "Property"

--- a/sphinx_gallery/_dummy/nested.py
+++ b/sphinx_gallery/_dummy/nested.py
@@ -1,0 +1,11 @@
+class NestedDummyClass:
+    """Nested dummy class for testing method resolution."""
+
+    def run(self):
+        """Do nothing."""
+        pass
+
+    @property
+    def prop(self):
+        """Property."""
+        return "Property"

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import sphinx.util
 from sphinx.errors import ExtensionError
 
+from ._dummy import DummyClass  # noqa: F401
 from .scrapers import _find_image_ext
 from .utils import _W_KW, _replace_md5
 
@@ -35,19 +36,6 @@ THUMBNAIL_PARENT_DIV_CLOSE = """
     </div>
 
 """
-
-
-class DummyClass:
-    """Dummy class for testing method resolution."""
-
-    def run(self):
-        """Do nothing."""
-        pass
-
-    @property
-    def prop(self):
-        """Property."""
-        return "Property"
 
 
 class NameFinder(ast.NodeVisitor):

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1234,8 +1234,16 @@ def _get_backreferences(gallery_conf, script_vars, script_blocks, node, target_f
     if example_code_obj:
         _write_code_obj(target_file, example_code_obj)
     exclude_regex = gallery_conf["exclude_implicit_doc_regex"]
+
+    def _normalize_name(cobj):
+        full_name = "{module}.{name}".format(**cobj)
+        for pattern in gallery_conf["prefer_full_module"]:
+            if re.search(pattern, full_name):
+                return full_name
+        return "{module_short}.{name}".format(**cobj)
+
     backrefs = {
-        "{module_short}.{name}".format(**cobj)
+        _normalize_name(cobj)
         for cobjs in example_code_obj.values()
         for cobj in cobjs
         if cobj["module"].startswith(gallery_conf["doc_module"])

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -88,8 +88,11 @@ br.identify_names
 from sphinx_gallery.back_references import identify_names
 identify_names
 
-from sphinx_gallery.back_references import DummyClass
+from sphinx_gallery._dummy import DummyClass
 DummyClass().prop
+
+from sphinx_gallery._dummy.nested import NestedDummyClass
+NestedDummyClass().prop
 
 import matplotlib.pyplot as plt
 _ = plt.figure()

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -128,8 +128,17 @@ def test_identify_names(unicode_sample, gallery_conf):
         "DummyClass": [
             {
                 "name": "DummyClass",
-                "module": "sphinx_gallery.back_references",
-                "module_short": "sphinx_gallery.back_references",
+                "module": "sphinx_gallery._dummy",
+                "module_short": "sphinx_gallery._dummy",
+                "is_class": False,
+                "is_explicit": False,
+            }
+        ],
+        "NestedDummyClass": [
+            {
+                "name": "NestedDummyClass",
+                "module": "sphinx_gallery._dummy.nested",
+                "module_short": "sphinx_gallery._dummy",
                 "is_class": False,
                 "is_explicit": False,
             }

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -54,7 +54,7 @@ N_INDEX = 2 + 1 + 3 + 1
 # (examples + examples_rst_index + examples_with_rst + examples_README_header + root-level)
 N_EXECUTE = 2 + 3 + 1 + 1 + 1
 # gen_modules + sg_api_usage + doc/index.rst + minigallery.rst
-N_OTHER = 9 + 1 + 1 + 1 + 1
+N_OTHER = 11 + 1 + 1 + 1 + 1
 N_RST = N_EXAMPLES + N_PASS + N_INDEX + N_EXECUTE + N_OTHER
 N_RST = f"({N_RST}|{N_RST - 1}|{N_RST - 2})"  # AppVeyor weirdness
 
@@ -548,25 +548,49 @@ def test_embed_links_and_styles(sphinx_app):
     # issue 617 (regex '-'s)
     # instance
     dummy_class_inst = re.search(
-        r'sphinx_gallery.backreferences.html#sphinx[_,-]gallery[.,-]backreferences[.,-][D,d]ummy[C,c]lass" title="sphinx_gallery.backreferences.DummyClass" class="sphx-glr-backref-module-sphinx_gallery-backreferences sphx-glr-backref-type-py-class sphx-glr-backref-instance"><span class="n">dc</span>',  # noqa: E501
+        r'sphinx_gallery._dummy.html#sphinx[_-]gallery[.-]_dummy[.-][Dd]ummy[Cc]lass" title="sphinx_gallery._dummy.DummyClass" class="sphx-glr-backref-module-sphinx_gallery-_dummy sphx-glr-backref-type-py-class sphx-glr-backref-instance"><span class="n">dc</span>',  # noqa: E501
         lines,
     )
     assert dummy_class_inst is not None
     # class
     dummy_class_class = re.search(
-        r'sphinx_gallery.backreferences.html#sphinx[_,-]gallery[.,-]backreferences[.,-][D,d]ummy[C,c]lass" title="sphinx_gallery.backreferences.DummyClass" class="sphx-glr-backref-module-sphinx_gallery-backreferences sphx-glr-backref-type-py-class"><span class="n">sphinx_gallery</span><span class="o">.</span><span class="n">backreferences</span><span class="o">.</span><span class="n">DummyClass</span>',  # noqa: E501
+        r'sphinx_gallery._dummy.html#sphinx[_-]gallery[.-]_dummy[.-][Dd]ummy[Cc]lass" title="sphinx_gallery._dummy.DummyClass" class="sphx-glr-backref-module-sphinx_gallery-_dummy sphx-glr-backref-type-py-class"><span class="n">sphinx_gallery</span><span class="o">.</span><span class="n">_dummy</span><span class="o">.</span><span class="n">DummyClass</span>',  # noqa: E501
         lines,
     )
     assert dummy_class_class is not None
     # method
     dummy_class_meth = re.search(
-        r'sphinx_gallery.backreferences.html#sphinx[_,-]gallery[.,-]backreferences[.,-][D,d]ummy[C,c]lass[.,-]run" title="sphinx_gallery.backreferences.DummyClass.run" class="sphx-glr-backref-module-sphinx_gallery-backreferences sphx-glr-backref-type-py-method"><span class="n">dc</span><span class="o">.</span><span class="n">run</span>',  # noqa: E501
+        r'sphinx_gallery._dummy.html#sphinx[_-]gallery[.-]_dummy[.-][Dd]ummy[Cc]lass[.-]run" title="sphinx_gallery._dummy.DummyClass.run" class="sphx-glr-backref-module-sphinx_gallery-_dummy sphx-glr-backref-type-py-method"><span class="n">dc</span><span class="o">.</span><span class="n">run</span>',  # noqa: E501
         lines,
     )
     assert dummy_class_meth is not None
     # property (Sphinx 2+ calls it a method rather than attribute, so regex)
     dummy_class_prop = re.compile(
-        r'sphinx_gallery.backreferences.html#sphinx[_,-]gallery[.,-]backreferences[.,-][D,d]ummy[C,c]lass[.,-]prop" title="sphinx_gallery.backreferences.DummyClass.prop" class="sphx-glr-backref-module-sphinx_gallery-backreferences sphx-glr-backref-type-py-(attribute|method|property)"><span class="n">dc</span><span class="o">.</span><span class="n">prop</span>'
+        r'sphinx_gallery._dummy.html#sphinx[_-]gallery[.-]_dummy[.-][Dd]ummy[Cc]lass[.-]prop" title="sphinx_gallery._dummy.DummyClass.prop" class="sphx-glr-backref-module-sphinx_gallery-_dummy sphx-glr-backref-type-py-(attribute|method|property)"><span class="n">dc</span><span class="o">.</span><span class="n">prop</span>'
+    )  # noqa: E501
+    assert dummy_class_prop.search(lines) is not None
+    # gh-1364: methods of nested classes in the module currently being documented
+    # instance
+    dummy_class_inst = re.search(
+        r'sphinx_gallery._dummy.nested.html#sphinx[_-]gallery[.-]_dummy[.-]nested[.-][Nn]ested[Dd]ummy[Cc]lass" title="sphinx_gallery._dummy.NestedDummyClass" class="sphx-glr-backref-module-sphinx_gallery-_dummy sphx-glr-backref-type-py-class sphx-glr-backref-instance"><span class="n">ndc</span>',  # noqa: E501
+        lines,
+    )
+    assert dummy_class_inst is not None
+    # class
+    dummy_class_class = re.search(
+        r'sphinx_gallery._dummy.nested.html#sphinx[_-]gallery[.-]_dummy[.-]nested[.-][Nn]ested[Dd]ummy[Cc]lass" title="sphinx_gallery._dummy.NestedDummyClass" class="sphx-glr-backref-module-sphinx_gallery-_dummy sphx-glr-backref-type-py-class"><span class="n">sphinx_gallery</span><span class="o">.</span><span class="n">_dummy</span><span class="o">.</span><span class="n">nested</span><span class="o">.</span><span class="n">NestedDummyClass</span>',  # noqa: E501
+        lines,
+    )
+    assert dummy_class_class is not None
+    # method
+    dummy_class_meth = re.search(
+        r'sphinx_gallery._dummy.nested.html#sphinx[_-]gallery[.-]_dummy[.-]nested[.-][Nn]ested[Dd]ummy[Cc]lass[.-]run" title="sphinx_gallery._dummy.NestedDummyClass.run" class="sphx-glr-backref-module-sphinx_gallery-_dummy sphx-glr-backref-type-py-method"><span class="n">ndc</span><span class="o">.</span><span class="n">run</span>',  # noqa: E501
+        lines,
+    )
+    assert dummy_class_meth is not None
+    # property (Sphinx 2+ calls it a method rather than attribute, so regex)
+    dummy_class_prop = re.compile(
+        r'sphinx_gallery._dummy.nested.html#sphinx[_-]gallery[.-]_dummy[.-]nested[.-][Nn]ested[Dd]ummy[Cc]lass[.-]prop" title="sphinx_gallery._dummy.NestedDummyClass.prop" class="sphx-glr-backref-module-sphinx_gallery-_dummy sphx-glr-backref-type-py-(attribute|method|property)"><span class="n">ndc</span><span class="o">.</span><span class="n">prop</span>'
     )  # noqa: E501
     assert dummy_class_prop.search(lines) is not None
 
@@ -666,19 +690,70 @@ def test_backreferences_examples_html(sphinx_app):
     regex = re.compile(r'<dt[ \S]*id="sphinx_gallery.backreferences.[ \S]*>')
     n_documented = len(regex.findall(lines))
     possible = "\n".join(line for line in lines.split("\n") if "<dt " in line)
-    # identify_names, DummyClass, DummyClass.prop, DummyClass.run, NameFinder
-    # NameFinder.get_mapping, NameFinder.visit_Attribute, NameFinder.visit_Import
-    # NameFinder.visit_ImportFrom, NameFinder.visit_Name
-    assert n_documented == 10, possible
-    # identify_names, DummyClass, NameFinder (3); once doc, once left bar (x2)
+    # identify_names, NameFinder NameFinder.get_mapping, NameFinder.visit_Attribute,
+    # NameFinder.visit_Import NameFinder.visit_ImportFrom, NameFinder.visit_Name
+    assert n_documented == 7, possible
+    # identify_names, NameFinder (2); once doc, once left bar (x2)
     n_mini = lines.count("Examples using ")
-    assert n_mini == 6
-    # only 3 actual mini-gallery divs
+    assert n_mini == 4
+    # only 2 actual mini-gallery divs
     n_div = lines.count('<div class="sphx-glr-thumbnails')
-    assert n_div == 3
+    assert n_div == 2
+    # 2 documented uses
+    n_thumb = lines.count('<div class="sphx-glr-thumbcontainer')
+    assert n_thumb == 2
+    # matched opening/closing divs
+    n_open = lines.count("<div")
+    n_close = lines.count("</div")
+    assert n_open == n_close  # should always be equal
+
+    backref_file = op.join(
+        sphinx_app.outdir, "gen_modules", "sphinx_gallery._dummy.html"
+    )
+    with codecs.open(backref_file, "r", "utf-8") as fid:
+        lines = fid.read()
+    # Class properties not properly checked on older Sphinx (e.g. 3)
+    # so let's use the "id" instead
+    regex = re.compile(r'<dt[ \S]*id="sphinx_gallery._dummy.[ \S]*>')
+    n_documented = len(regex.findall(lines))
+    possible = "\n".join(line for line in lines.split("\n") if "<dt " in line)
+    # DummyClass, DummyClass.prop, DummyClass.run
+    assert n_documented == 3, possible
+    # DummyClass (1); once doc, once left bar (x2)
+    n_mini = lines.count("Examples using ")
+    assert n_mini == 2
+    # only 1 actual mini-gallery divs
+    n_div = lines.count('<div class="sphx-glr-thumbnails')
+    assert n_div == 1
     # 3 documented uses
     n_thumb = lines.count('<div class="sphx-glr-thumbcontainer')
-    assert n_thumb == 3
+    assert n_thumb == 1
+    # matched opening/closing divs
+    n_open = lines.count("<div")
+    n_close = lines.count("</div")
+    assert n_open == n_close  # should always be equal
+
+    backref_file = op.join(
+        sphinx_app.outdir, "gen_modules", "sphinx_gallery._dummy.nested.html"
+    )
+    with codecs.open(backref_file, "r", "utf-8") as fid:
+        lines = fid.read()
+    # Class properties not properly checked on older Sphinx (e.g. 3)
+    # so let's use the "id" instead
+    regex = re.compile(r'<dt[ \S]*id="sphinx_gallery._dummy.nested.[ \S]*>')
+    n_documented = len(regex.findall(lines))
+    possible = "\n".join(line for line in lines.split("\n") if "<dt " in line)
+    # NestedDummyClass, NestedDummyClass.prop, NestedDummyClass.run
+    assert n_documented == 3, possible
+    # DummyClass (1); once doc, once left bar (x2)
+    n_mini = lines.count("Examples using ")
+    assert n_mini == 2
+    # only 1 actual mini-gallery divs
+    n_div = lines.count('<div class="sphx-glr-thumbnails')
+    assert n_div == 1
+    # 3 documented uses
+    n_thumb = lines.count('<div class="sphx-glr-thumbcontainer')
+    assert n_thumb == 1
     # matched opening/closing divs
     n_open = lines.count("<div")
     n_close = lines.count("</div")

--- a/sphinx_gallery/tests/tinybuild/doc/conf.py
+++ b/sphinx_gallery/tests/tinybuild/doc/conf.py
@@ -38,6 +38,7 @@ html_sidebars = {
 
 sphinx_gallery_conf = {
     "doc_module": ("sphinx_gallery",),
+    "prefer_full_module": {r"sphinx_gallery\._dummy"},
     "reference_url": {
         "sphinx_gallery": None,
         "scipy": "http://docs.scipy.org/doc/scipy/wrong_url",  # bad one

--- a/sphinx_gallery/tests/tinybuild/doc/index.rst
+++ b/sphinx_gallery/tests/tinybuild/doc/index.rst
@@ -17,6 +17,8 @@ every module. Examples `here <auto_examples/index.html>`_.
    :template: module.rst
 
    backreferences
+   _dummy
+   _dummy.nested
    docs_resolv
    downloads
    gen_gallery

--- a/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_numpy_matplotlib.py
@@ -20,6 +20,7 @@ from matplotlib.colors import is_color_like
 from matplotlib.figure import Figure
 
 import sphinx_gallery.backreferences
+import sphinx_gallery._dummy.nested
 from sphinx_gallery.py_source_parser import Block
 
 t = np.arange(N) / float(N)
@@ -47,6 +48,10 @@ sphinx_gallery.backreferences.identify_names(
     sphinx_gallery.backreferences._make_ref_regex(),
 )
 # 583: methods don't link properly
-dc = sphinx_gallery.backreferences.DummyClass()
+dc = sphinx_gallery._dummy.DummyClass()
 dc.run()
 print(dc.prop)
+# 1364: nested methods don't link properly
+ndc = sphinx_gallery._dummy.nested.NestedDummyClass()
+ndc.run()
+print(ndc.prop)


### PR DESCRIPTION
This fixes several cases of missing backreferences in Matplotlib's `mpl_toolkits` namespace, which need the full module name for referencing into Sphinx.

For example, [`Axes3D.plot`](https://matplotlib.org/stable/api/_as_gen/mpl_toolkits.mplot3d.axes3d.Axes3D.plot.html) only has one back reference:
![image](https://github.com/user-attachments/assets/8640693d-b73e-4d22-bff8-7ad060929ddc)

but with this change we have all these:
![image](https://github.com/user-attachments/assets/6712270f-7eca-4d75-9d49-b49ad6cdd303)
