### PR TITLE
ENH: Improve _sanitize_rst

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -284,8 +284,12 @@ def _sanitize_rst(string):
     # ``whatever thing`` --> whatever thing
     p = r"(\s|^)`"
     string = re.sub(p + r"`([^`]+)`" + e, r"\1\2\3", string)
+    # `~mymodule.MyClass` --> MyClass
+    string = re.sub(p + r"~([^`]+)" + e, _regroup, string)
+
     # `whatever thing` --> whatever thing
-    string = re.sub(p + r"([^`]+)" + e, r"\1\2\3", string)
+    # `.MyClass` --> MyClass
+    string = re.sub(p + r"\.?([^`]+)" + e, r"\1\2\3", string)
 
     # **string** --> string
     string = re.sub(r"\*\*([^\*]*)\*\*", r"\1", string)

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -51,6 +51,11 @@ REFERENCE = r"""
             "this and that; and these things and those things",
             False,
         ),
+        (
+            "See `.MyClass` and `~.MyClass.close`",
+            "See MyClass and close",
+            False,
+        ),
     ],
 )
 def test_thumbnail_div(content, tooltip, is_backref):


### PR DESCRIPTION
When using the sphinx config `default_role = 'obj'`, one can leave out the prefixes :meth: and similar and directly reference code objects using backticks. In there, one can use the sphinx prefix modifiers `.` and `~`.

Examples from Matplotlib where these show up:

![image](https://github.com/user-attachments/assets/8d7787a4-1b4a-43d9-b4a4-a25fe89f0967) ![image](https://github.com/user-attachments/assets/ac09434d-c790-489c-aac7-482fe544d394)

This PR enhances `_sanitize_rst` to remove the prefix modifiers:

- `.MyClass` --> MyClass
- `~.MyClass.close` --> close


