### PR TITLE
FIX: Fix stability of stored compiled regex

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -159,9 +159,11 @@ def _update_gallery_conf_exclude_implicit_doc(gallery_conf):
 
     This is separate function for better testability.
     """
-    # prepare regex for exclusions from implicit documentation
+    # prepare regex for exclusions from implicit documentation, ensuring that what
+    # gets complied has a stable __repr__ (i.e., by sorting the exclude_implicit_doc
+    # set before joining)
     exclude_regex = (
-        re.compile("|".join(gallery_conf["exclude_implicit_doc"]))
+        re.compile("|".join(sorted(gallery_conf["exclude_implicit_doc"])))
         if gallery_conf["exclude_implicit_doc"]
         else False
     )

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1347,7 +1347,7 @@ def generate_file_rst(fname, target_dir, src_dir, gallery_conf):
         script_blocks, script_vars, gallery_conf, file_conf
     )
 
-    logger.debug("%s ran in : %.2g seconds\n", src_file, time_elapsed)
+    logger.debug("%s ran in : %.2g seconds", src_file, time_elapsed)
 
     # Create dummy images
     _make_dummy_images(executable, file_conf, script_vars)


### PR DESCRIPTION
I couldn't figure out why my MNE doc build was always rebuilding. It's because the `re.compile(<str>.join(<set>))` will not have a stable `repr` run-to-run because `set` does not have a stable order run-to-run. This PR fixes it. Not easy to add a test because it would require invoking `sphinx` twice, and even then would be a Heisenbug to detect. Hopefully https://github.com/sphinx-doc/sphinx/pull/12741 can move forward to make this more easy to detect.