### PR TITLE
Fix `indexst` variable does not exist when own index gallery is first

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2541,10 +2541,12 @@ You can bypass Sphinx-Gallery automatically creating an  ``index.rst`` from a
 ``copyfile_regex`` includes ``index.rst``, and you have an ``index.rst`` in the
 gallery-source (i.e., a :ref:`examples_dirs <multiple_galleries_config>` directory),
 Sphinx-Gallery will use that instead and not make an index file for that gallery
-or any of its sub-galleries. If you do this, you are responsible for
+or any of its sub-galleries.
+If you pass your own ``index.rst`` file, you are responsible for
 adding your own Sphinx ``toctree`` in that index (or elsewhere in your Sphinx
 documentation) that includes any gallery items or other files in that
-directory.
+directory. You are also responsible for adding any necessary ``index.rst``
+files for that gallery's sub-galleries.
 
 .. _show_api_usage:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2537,10 +2537,11 @@ Manually passing ``index.rst``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can bypass Sphinx-Gallery automatically creating an  ``index.rst`` from a
-``GALLERY_HEADER.rst`` in a gallery directory or subdirectory. If your
+``GALLERY_HEADER.rst`` in a gallery directory or nested sub-gallery directory. If your
 ``copyfile_regex`` includes ``index.rst``, and you have an ``index.rst`` in the
-gallery-source instead of the 'GALLERY_HEADER' file, Sphinx-Gallery will use that instead of
-the index it automatically makes.  If you do this, you are responsible for
+gallery-source (i.e., a :ref:`examples_dirs <multiple_galleries_config>` directory),
+Sphinx-Gallery will use that instead and not make any index files for that gallery
+or any of its sub-galleries. If you do this, you are responsible for
 adding your own Sphinx ``toctree`` in that index (or elsewhere in your Sphinx
 documentation) that includes any gallery items or other files in that
 directory.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2540,7 +2540,7 @@ You can bypass Sphinx-Gallery automatically creating an  ``index.rst`` from a
 ``GALLERY_HEADER.rst`` in a gallery directory or nested sub-gallery directory. If your
 ``copyfile_regex`` includes ``index.rst``, and you have an ``index.rst`` in the
 gallery-source (i.e., a :ref:`examples_dirs <multiple_galleries_config>` directory),
-Sphinx-Gallery will use that instead and not make any index files for that gallery
+Sphinx-Gallery will use that instead and not make an index file for that gallery
 or any of its sub-galleries. If you do this, you are responsible for
 adding your own Sphinx ``toctree`` in that index (or elsewhere in your Sphinx
 documentation) that includes any gallery items or other files in that

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -534,7 +534,7 @@ def get_subsections(srcdir, examples_dir, gallery_conf, check_for_index=True):
         subfolders = [
             subfolder
             for subfolder in subfolders
-            # Returns `None` if `index.rst` or gallery header found
+            # Return is not `None` only when a gallery head file is found
             if _get_gallery_header(
                 os.path.join(examples_dir, subfolder), gallery_conf, raise_error=False
             )

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -534,11 +534,18 @@ def get_subsections(srcdir, examples_dir, gallery_conf, check_for_index=True):
         subfolders = [
             subfolder
             for subfolder in subfolders
-            # Returns `None` if no `index.rst` file and no gallery header found
+            # Returns `None` if `index.rst` or gallery header found
             if _get_gallery_header(
                 os.path.join(examples_dir, subfolder), gallery_conf, raise_error=False
             )
             is not None
+        ]
+    else:
+        # just make sure its a directory
+        subfolders = [
+            subfolder
+            for subfolder in subfolders
+            if os.path.isdir(os.path.join(examples_dir, subfolder))
         ]
 
     base_examples_dir_path = os.path.relpath(examples_dir, srcdir)
@@ -743,7 +750,7 @@ def generate_gallery_rst(app):
             is_subsection=False,
         )
 
-        # `this_context` is None when user provides own index.rst
+        # `this_content` is None when user provides own index.rst
         sg_root_index = this_content is not None
         costs += this_costs
         write_computation_times(gallery_conf, gallery_dir_abs_path, this_costs)

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -541,11 +541,14 @@ def get_subsections(srcdir, examples_dir, gallery_conf, check_for_index=True):
             is not None
         ]
     else:
-        # just make sure its a directory
+        # just make sure its a directory, that is not `__pycache__`
         subfolders = [
             subfolder
             for subfolder in subfolders
-            if os.path.isdir(os.path.join(examples_dir, subfolder))
+            if (
+                subfolder != "__pycache__"
+                and os.path.isdir(os.path.join(examples_dir, subfolder))
+            )
         ]
 
     base_examples_dir_path = os.path.relpath(examples_dir, srcdir)

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -534,18 +534,13 @@ def get_subsections(srcdir, examples_dir, gallery_conf, check_for_index=True):
         subfolders = [
             subfolder
             for subfolder in subfolders
+            # Returns `None` if no `index.rst` file and no gallery header found
             if _get_gallery_header(
                 os.path.join(examples_dir, subfolder), gallery_conf, raise_error=False
             )
             is not None
         ]
-    else:
-        # just make sure its a directory
-        subfolders = [
-            subfolder
-            for subfolder in subfolders
-            if os.path.isdir(os.path.join(examples_dir, subfolder))
-        ]
+
     base_examples_dir_path = os.path.relpath(examples_dir, srcdir)
     subfolders_with_path = [
         os.path.join(base_examples_dir_path, item) for item in subfolders

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -753,6 +753,8 @@ def generate_gallery_rst(app):
         costs += this_costs
         write_computation_times(gallery_conf, gallery_dir_abs_path, this_costs)
 
+        # `indexst` variable must exist, as passed to `_finish_index_rst`
+        indexst = ""
         # Create root gallery index.rst
         if sg_root_index:
             # :orphan: to suppress "not included in TOCTREE" sphinx warnings

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -504,7 +504,7 @@ def _fill_gallery_conf_defaults(sphinx_gallery_conf, app=None, check_keys=True):
     return gallery_conf
 
 
-def get_subsections(srcdir, examples_dir, gallery_conf, check_for_index=True):
+def get_subsections(srcdir, examples_dir, gallery_conf, check_for_header=True):
     """Return the list of subsections of a gallery.
 
     Parameters
@@ -515,8 +515,8 @@ def get_subsections(srcdir, examples_dir, gallery_conf, check_for_index=True):
         path to the examples directory relative to conf.py
     gallery_conf : Dict[str, Any]
         Sphinx-Gallery configuration dictionary.
-    check_for_index : bool
-        only return subfolders contain a GALLERY_HEADER file, default True
+    check_for_header : bool
+        only return subfolders that contain a GALLERY_HEADER file, default True
 
     Returns
     -------
@@ -530,7 +530,7 @@ def get_subsections(srcdir, examples_dir, gallery_conf, check_for_index=True):
         if isinstance(sortkey, list):
             sortkey = ExplicitOrder(sortkey)
     subfolders = [subfolder for subfolder in os.listdir(examples_dir)]
-    if check_for_index:
+    if check_for_header:
         subfolders = [
             subfolder
             for subfolder in subfolders
@@ -775,7 +775,7 @@ def generate_gallery_rst(app):
             app.builder.srcdir,
             examples_dir_abs_path,
             gallery_conf,
-            check_for_index=sg_root_index,
+            check_for_header=sg_root_index,
         )
         for subsection in subsecs:
             src_dir = os.path.join(examples_dir_abs_path, subsection)

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -438,6 +438,7 @@ def _get_gallery_header(dir_, gallery_conf, raise_error=True):
     """
     # First check if user supplies an index.rst and that index.rst is in the
     # copyfile regexp:
+    print(f'XXX DIR {os.listdir(dir_)}')
     if re.match(gallery_conf["copyfile_regex"], "index.rst"):
         fpth = os.path.join(dir_, "index.rst")
         if os.path.isfile(fpth):

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -433,15 +433,15 @@ def save_thumbnail(image_path_template, src_file, script_vars, file_conf, galler
 def _get_gallery_header(dir_, gallery_conf, raise_error=True):
     """Get gallery header from GALLERY_HEADER.[ext] or README.[ext] file.
 
-    Returns `False` if user supplied an index.rst. Returns `None` if neither a
-    `index.rst` nor a gallery header file found and `raise_error=False`.
+    Returns `None` if user supplied an index.rst or no gallery header file
+    found and `raise_error=False`.
     """
     # First check if user supplies an index.rst and that index.rst is in the
     # copyfile regexp:
     if re.match(gallery_conf["copyfile_regex"], "index.rst"):
         fpth = os.path.join(dir_, "index.rst")
         if os.path.isfile(fpth):
-            return False
+            return None
     # Next look for GALLERY_HEADER.[ext] (and for backward-compatibility README.[ext]
     extensions = [".txt"] + sorted(gallery_conf["source_suffix"])
     for ext in extensions:

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -438,7 +438,7 @@ def _get_gallery_header(dir_, gallery_conf, raise_error=True):
     """
     # First check if user supplies an index.rst and that index.rst is in the
     # copyfile regexp:
-    print(f'XXX DIR {os.listdir(dir_)}')
+    print(f"XXX DIR {os.listdir(dir_)}")
     if re.match(gallery_conf["copyfile_regex"], "index.rst"):
         fpth = os.path.join(dir_, "index.rst")
         if os.path.isfile(fpth):

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -433,16 +433,15 @@ def save_thumbnail(image_path_template, src_file, script_vars, file_conf, galler
 def _get_gallery_header(dir_, gallery_conf, raise_error=True):
     """Get gallery header from GALLERY_HEADER.[ext] or README.[ext] file.
 
-    Returns `None` if user supplied an index.rst or no gallery header file
-    found and `raise_error=False`.
+    Returns `False` if user supplied an index.rst. Returns `None` if neither a
+    `index.rst` nor a gallery header file found and `raise_error=False`.
     """
     # First check if user supplies an index.rst and that index.rst is in the
     # copyfile regexp:
-    print(f"XXX DIR {os.listdir(dir_)}")
     if re.match(gallery_conf["copyfile_regex"], "index.rst"):
         fpth = os.path.join(dir_, "index.rst")
         if os.path.isfile(fpth):
-            return None
+            return False
     # Next look for GALLERY_HEADER.[ext] (and for backward-compatibility README.[ext]
     extensions = [".txt"] + sorted(gallery_conf["source_suffix"])
     for ext in extensions:
@@ -542,7 +541,7 @@ def generate_dir_rst(
         List of example file names we generated ReST for.
     """
     index_content = ""
-    # `_get_gallery_header` returns `None` if user supplied `index.rst`
+    # `_get_gallery_header` returns `False` if user supplied `index.rst`
     header_fname = _get_gallery_header(src_dir, gallery_conf)
     user_index_rst = True
     if header_fname:

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -541,7 +541,7 @@ def generate_dir_rst(
         List of example file names we generated ReST for.
     """
     index_content = ""
-    # `_get_gallery_header` returns `False` if user supplied `index.rst`
+    # `_get_gallery_header` returns `None` if user supplied `index.rst`
     header_fname = _get_gallery_header(src_dir, gallery_conf)
     user_index_rst = True
     if header_fname:

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -16,6 +16,20 @@ from sphinx_gallery import docs_resolv, gen_gallery, gen_rst, py_source_parser
 from sphinx_gallery.scrapers import _import_matplotlib
 from sphinx_gallery.utils import _get_image
 
+INDEX_RST = """
+=============
+Own index.rst
+=============
+
+Own index.rst file.
+
+.. toctree::
+
+    plot_1
+    plot_2
+    plot_3
+"""
+
 NESTED_PY = """\"\"\"
 Header
 ======
@@ -218,17 +232,20 @@ def sphinx_app_wrapper(tmpdir, conf_file, rst_file, req_mpl, req_pil):
     # Copy files to 'examples/' as well because default `examples_dirs` is
     # '../examples' - for tests where we don't update config
     shutil.copytree((_fixturedir / "src"), (Path(tmpdir) / "examples"))
-    if rst_file:
-        with open((srcdir / "minigallery_test.rst"), "w") as rstfile:
-            rstfile.write(rst_file)
+    if rst_file == "own index.rst":
+        with open((srcdir / "src" / "index.rst"), "w") as file:
+            file.write(INDEX_RST)
+    elif rst_file:
+        with open((srcdir / "minigallery_test.rst"), "w") as file:
+            file.write(rst_file)
         # Add nested gallery
         if "sub_folder/sub_sub_folder" in rst_file:
             dir_path = srcdir / "src" / "sub_folder" / "sub_sub_folder"
             dir_path.mkdir(parents=True)
-            with open((dir_path / "plot_nested.py"), "w") as pyfile:
-                pyfile.write(NESTED_PY)
-            with open((dir_path / "GALLERY_HEADER.rst"), "w") as rstfile:
-                rstfile.write(GALLERY_HEADER)
+            with open((dir_path / "plot_nested.py"), "w") as file:
+                file.write(NESTED_PY)
+            with open((dir_path / "GALLERY_HEADER.rst"), "w") as file:
+                file.write(GALLERY_HEADER)
 
     base_config = f"""
 import os

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -410,6 +410,21 @@ def test_collect_gallery_files_ignore_pattern(tmpdir, gallery_conf):
 @pytest.mark.add_conf(
     content="""
 sphinx_gallery_conf = {
+    'examples_dirs': 'src',
+    'gallery_dirs': 'ex',
+    'copyfile_regex': r'.*\.rst',
+}"""
+)
+@pytest.mark.add_rst(file="own index.rst")
+def test_own_index_first(sphinx_app_wrapper):
+    """Test `generate_gallery_rst` works when own index gallery is first (and only)."""
+    # Issue #1382
+    sphinx_app_wrapper.build_sphinx_app()
+
+
+@pytest.mark.add_conf(
+    content="""
+sphinx_gallery_conf = {
     'backreferences_dir' : os.path.join('modules', 'gen'),
     'examples_dirs': 'src',
     'gallery_dirs': ['ex'],

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -408,7 +408,7 @@ def test_collect_gallery_files_ignore_pattern(tmpdir, gallery_conf):
 
 
 @pytest.mark.add_conf(
-    content="""
+    content=r"""
 sphinx_gallery_conf = {
     'examples_dirs': 'src',
     'gallery_dirs': 'ex',

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -651,6 +651,7 @@ def test_gen_dir_rst(gallery_conf, gallery_header):
     ],
 )
 def test_gen_dir_rst_invalid_header(gallery_conf, gallery_header):
+    """Check `_get_gallery_header` raises error for invalid header extension."""
     with open(os.path.join(gallery_conf["src_dir"], gallery_header), "wb") as fid:
         fid.write("Testing\n=======\n\nÓscar here.".encode())
     with pytest.raises(ExtensionError, match="does not have a GALLERY_HEADER"):


### PR DESCRIPTION
closes #1382

Bug introduced by refactor in https://github.com/sphinx-gallery/sphinx-gallery/pull/1332

When the first gallery in the example gallery loop, in `generate_gallery_rst`, is one with its own `index.rst` file, the `indexst` variable does not exist which is a problem because we pass it to `_finish_index_rst`. This variable is not used in `_finish_index_rst` when the gallery has its own index.rst file but `_finish_index_rst` does various other things so needs to be run always, even when the gallery has its own `index.rst`.

Adds test.

Will do a patch release once this is merged