### PR TITLE
Allow to disable writing computation times

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -65,6 +65,7 @@ file, inside a ``sphinx_gallery_conf`` dictionary.
 **Compute costs**
 
 - ``min_reported_time`` (:ref:`min_reported_time`)
+- ``write_computation_times`` (:ref:`write_computation_times`)
 - ``show_memory`` (:ref:`show_memory`)
 - ``junit`` (:ref:`junit_xml`)
 
@@ -2293,6 +2294,15 @@ The ``min_reported_time`` parameter can be set to a number of seconds. The
 duration of scripts that ran faster than that amount will not be logged nor
 embedded in the html output.
 
+.. _write_computation_times:
+
+Write computation times
+=======================
+
+Set to ``false`` if you want to omit computation times from the output.
+This helps with reproducible builds.
+If the ``SOURCE_DATE_EPOCH`` environment variable is set, it defaults to false.
+True otherwise.
 
 .. _show_memory:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2299,10 +2299,9 @@ embedded in the html output.
 Write computation times
 =======================
 
-Set to ``false`` if you want to omit computation times from the output.
+Set to ``False`` if you want to omit computation times from all gallery outputs.
 This helps with reproducible builds.
-If the ``SOURCE_DATE_EPOCH`` environment variable is set, it defaults to false.
-True otherwise.
+Default is ``True`` unless the ``SOURCE_DATE_EPOCH`` environment variable is set.
 
 .. _show_memory:
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -111,6 +111,7 @@ DEFAULT_GALLERY_CONF = {
     "expected_failing_examples": set(),
     "thumbnail_size": (400, 280),  # Default CSS does 0.4 scaling (160, 112)
     "min_reported_time": 0,
+    "write_computation_times": os.getenv("SOURCE_DATE_EPOCH") is None,
     "binder": {},
     "jupyterlite": {},
     "promote_jupyter_magic": False,
@@ -927,6 +928,8 @@ def write_computation_times(gallery_conf, target_dir, costs):
     costs: List[Dict]
         List of dicts of computation costs and paths, see gen_rst.py for details.
     """
+    if not gallery_conf["write_computation_times"]:
+        return
     total_time = sum(cost["t"] for cost in costs)
     if target_dir is None:  # all galleries together
         out_dir = gallery_conf["src_dir"]


### PR DESCRIPTION
Allow to disable writing computation times to allow for reproducible builds.

Default to not write durations. if SOURCE_DATE_EPOCH indicates that a reproducible build is wanted.

Helps with https://github.com/pygraphviz/pygraphviz/issues/541