### PR TITLE
BUG: make _anim_rst windows compatible

### DIFF
--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -273,7 +273,9 @@ def _anim_rst(anim, image_path, gallery_conf):
     dpi = rcParams["savefig.dpi"]
     if dpi == "figure":
         dpi = fig.dpi
-    video_uri = video.relative_to(gallery_conf["src_dir"]).as_posix()
+    # relative_to doesn't work on windows
+    # video_uri = video.relative_to(gallery_conf["src_dir"]).as_posix()
+    video_uri = PurePosixPath(os.path.relpath(video, gallery_conf["src_dir"]))
     html = _ANIMATION_VIDEO_RST.format(
         video=f"/{video_uri}",
         width=int(fig_size[0] * dpi),


### PR DESCRIPTION
Changes to using os.path.relpath cause on windows `Path.relative_to` yields the following build errors: 

```python-traceback
    File "C:\Users\story\miniconda3\envs\mpl-dev\Lib\site-packages\sphinx_gallery\scrapers.py", line 276, in _anim_rst
        video_uri = video.relative_to(gallery_conf["src_dir"]).as_posix()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "C:\Users\story\miniconda3\envs\mpl-dev\Lib\pathlib.py", line 682, in relative_to
        raise ValueError(f"{str(self)!r} is not in the subpath of {str(other)!r}")
    ValueError: 'C:\\Users\\story\\Projects\\matplotlib\\doc\\gallery\\animation\\images\\sphx_glr_simple_scatter_009.mp4' is not in the subpath of 'C:/Users/story/Projects/matplotlib/doc'
```