### PR TITLE
Doc: mention color css property to hide links

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1045,6 +1045,7 @@ following css prevents any module except for matplotlib from being decorated:
 
     a[class^="sphx-glr-backref-module-"] {
         text-decoration: none;
+        color: inherit;
     }
     a[class^="sphx-glr-backref-module-matplotlib"] {
         text-decoration: underline;


### PR DESCRIPTION
Setting "colors: inherit" in the css helps to hide the links from code cells (#1409) in my case, so it can be useful to mention