### PR TITLE
Fix incorrect paths for JupyterLite Notebook interface URLs, unpin `jupyterlite-sphinx`, and update JupyterLite integration docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
                 "sphinx!=7.3.2,!=7.3.3,!=7.3.4,!=7.3.5,!=7.3.6" pytest \
                 traits memory_profiler "ipython!=8.7.0" plotly graphviz \
                 "pyvista>=0.44.0" "docutils>=0.18" imageio pydata-sphinx-theme \
-                "jupyterlite-sphinx>=0.8.0,<0.9.0" "jupyterlite-pyodide-kernel<0.1.0" \
+                "jupyterlite-sphinx>=0.17.1" "jupyterlite-pyodide-kernel" \
                 libarchive-c "sphinxcontrib-video>=0.2.1rc0" intersphinx_registry
             pip uninstall -yq vtk  # pyvista installs vtk above
             pip install --upgrade --only-binary ":all" --extra-index-url https://wheels.vtk.org vtk-osmesa

--- a/.github/install.sh
+++ b/.github/install.sh
@@ -13,7 +13,7 @@ if [ "$DISTRIB" == "mamba" ]; then
     if [ "$PLATFORM" != "Linux" ]; then
         conda remove -y memory_profiler
     fi
-    PIP_DEPENDENCIES="jupyterlite-sphinx>=0.8.0,<0.9.0 jupyterlite-pyodide-kernel<0.1.0 libarchive-c numpy"
+    PIP_DEPENDENCIES="jupyterlite-sphinx>=0.17.1 jupyterlite-pyodide-kernel libarchive-c numpy"
 elif [ "$DISTRIB" == "minimal" ]; then
     PIP_DEPENDENCIES=""
 elif [ "$DISTRIB" == "pip" ]; then

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1521,21 +1521,21 @@ Sphinx-Gallery automatically generates Jupyter notebooks for any examples built
 with the gallery. `JupyterLite <https://jupyterlite.readthedocs.io>`__ makes it
 possible to run an example in your browser. The functionality is quite similar
 to Binder in the sense that you will get a Jupyter environment where you can
-run the example interactively as a notebook. The main difference with Binder
+run the example interactively as a notebook. The main differences from Binder
 are:
 
 - with JupyterLite, the example actually runs in your browser, there is no need
   for a separate machine in the cloud to run your Python code. That means that
   starting a Jupyter server is generally quicker, no need to wait for the
   Binder image to be built
-- with JupyterLite the first imports take time. At the time of writing
-  (February 2023) ``import scipy`` can take ~15-30s. Some innocuously looking
+- with JupyterLite, the first imports take time. At the time of writing
+  (December 2024) ``import scipy`` can take ~15-30s. Some innocuously looking
   Python code may just not work and break in an unexpected fashion. The Jupyter
   kernel is based on Pyodide, see `here
   <https://pyodide.org/en/latest/usage/wasm-constraints.html>`__ for some
   Pyodide limitations.
-- with JupyterLite environments are not as flexible as Binder, for example you
-  can not use a docker image but only the default `Pyodide
+- JupyterLite environments are not as flexible as Binder. For example, you
+  can not use a Docker image, but only the default `Pyodide
   <https://pyodide.org/en/stable/index.html>`__ environment. That means that
   some non pure-Python packages may not be available, see list of `available
   packages in Pyodide
@@ -1549,8 +1549,12 @@ are:
 
 In order to enable JupyterLite links with Sphinx-Gallery, you need to install
 the `jupyterlite-sphinx <https://jupyterlite-sphinx.readthedocs.io>`_ package.
-For `jupyterlite-sphinx>=0.8` (released 15 March 2023) you also need to install
-`jupyterlite-pyodide-kernel`.
+Versions of `jupyterlite-sphinx` and `sphinx-gallery` should be compatible, but
+we recommend `jupyterlite-sphinx>=0.17.1`.`
+For `jupyterlite-sphinx>=0.8` you also need to install
+`jupyterlite-pyodide-kernel`. The latest released version is recommended, but
+recent versions should work as well, and it depends on the version of Pyodide
+that you are using or planning to use.
 
 You then need to add `jupyterlite_sphinx` to your Sphinx extensions in
 ``conf.py``::
@@ -1566,7 +1570,7 @@ You can configure JupyterLite integration by setting
     sphinx_gallery_conf = {
       ...
       'jupyterlite': {
-         'use_jupyter_lab': <bool>, # Whether JupyterLite links should start Jupyter Lab instead of the Retrolab Notebook interface.
+         'use_jupyter_lab': <bool>, # Whether JupyterLite links should start Jupyter Lab instead of the Notebook interface.
          'notebook_modification_function': <str>, # fully qualified name of a function that implements JupyterLite-specific modifications of notebooks
          'jupyterlite_contents': <str>, # where to copy the example notebooks (relative to Sphinx source directory)
          }

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1605,8 +1605,8 @@ jupyterlite_contents (type: string, default: ``jupyterlite_contents``)
   contents.
 
 You can set variables in ``conf.py`` to configure ``jupyterlite-sphinx``, see
-the `jupyterlite-sphinx doc
-<https://jupyterlite-sphinx.readthedocs.io/en/latest/configuration.html>`__ for
+the `jupyterlite-sphinx documentation
+<https://jupyterlite-sphinx.readthedocs.io/en/stable/configuration.html>`__ for
 more details.
 
 If a Sphinx-Gallery configuration for JupyterLite is discovered, the following

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1549,8 +1549,8 @@ are:
 
 In order to enable JupyterLite links with Sphinx-Gallery, you need to install
 the `jupyterlite-sphinx <https://jupyterlite-sphinx.readthedocs.io>`_ package.
-Versions of ``jupyterlite-sphinx`` and Sphinx-Gallery should be compatible, but
-we recommend ``jupyterlite-sphinx>=0.17.1``.
+Recent versions of ``jupyterlite-sphinx`` and Sphinx-Gallery should be compatible,
+with each other, but we recommend ``jupyterlite-sphinx>=0.17.1``.
 For ``jupyterlite-sphinx>=0.8`` you also need to install
 ``jupyterlite-pyodide-kernel``. The latest released version is recommended, but
 recent versions should work as well, this depends on the version of Pyodide

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1549,11 +1549,11 @@ are:
 
 In order to enable JupyterLite links with Sphinx-Gallery, you need to install
 the `jupyterlite-sphinx <https://jupyterlite-sphinx.readthedocs.io>`_ package.
-Versions of `jupyterlite-sphinx` and `sphinx-gallery` should be compatible, but
-we recommend `jupyterlite-sphinx>=0.17.1`.`
-For `jupyterlite-sphinx>=0.8` you also need to install
-`jupyterlite-pyodide-kernel`. The latest released version is recommended, but
-recent versions should work as well, and it depends on the version of Pyodide
+Versions of ``jupyterlite-sphinx`` and Sphinx-Gallery should be compatible, but
+we recommend ``jupyterlite-sphinx>=0.17.1``.
+For ``jupyterlite-sphinx>=0.8`` you also need to install
+``jupyterlite-pyodide-kernel``. The latest released version is recommended, but
+recent versions should work as well, this depends on the version of Pyodide
 that you are using or planning to use.
 
 You then need to add `jupyterlite_sphinx` to your Sphinx extensions in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ optional-dependencies.dev = [
   "intersphinx-registry",
   "ipython",
   "joblib",
-  "jupyterlite-sphinx",
+  "jupyterlite-sphinx>=0.17.1",
   "lxml",
   "matplotlib",
   "numpy",

--- a/sphinx_gallery/interactive_example.py
+++ b/sphinx_gallery/interactive_example.py
@@ -417,7 +417,7 @@ def gen_jupyterlite_rst(fpath, gallery_conf):
     if gallery_conf["jupyterlite"]["use_jupyter_lab"]:
         lite_root_url += "/lab"
     else:
-        lite_root_url += "/retro/notebooks"
+        lite_root_url += "/notebooks"
 
     lite_url = f"{lite_root_url}/index.html?path={notebook_location}"
 

--- a/sphinx_gallery/interactive_example.py
+++ b/sphinx_gallery/interactive_example.py
@@ -297,7 +297,7 @@ def pre_configure_jupyterlite_sphinx(app, config):
         return
 
     # Do not use notebooks as sources for the documentation. See
-    # https://jupyterlite-sphinx.readthedocs.io/en/latest/configuration.html#disable-the-ipynb-docs-source-binding
+    # https://jupyterlite-sphinx.readthedocs.io/en/stable/configuration.html#disable-the-ipynb-docs-source-binding
     # for more details
     config.jupyterlite_bind_ipynb_suffix = False
 

--- a/sphinx_gallery/tests/test_interactive_example.py
+++ b/sphinx_gallery/tests/test_interactive_example.py
@@ -216,7 +216,7 @@ def test_gen_jupyterlite_rst(use_jupyter_lab, example_file, tmpdir):
     if use_jupyter_lab:
         jupyter_part = "lab"
     else:
-        jupyter_part = "retro/notebooks"
+        jupyter_part = "notebooks"
 
     target_rst = target_rst_template.format(
         root_url=root_url, jupyter_part=jupyter_part, notebook_path=notebook_path


### PR DESCRIPTION
## Description

I noticed that while JupyterLite dropped the "retro" string in the URL for the Notebook interface at some point in time, `sphinx-gallery` still seems to have it – and I recently hit this on https://github.com/scikit-image/scikit-image/pull/7644 where I wanted to use it for the gallery notebooks. This PR fixes it, so that the buttons inserted by `sphinx-gallery` now open the correct link:

`http://127.0.0.1:8000/lite/notebooks/index.html?path=my_notebook.ipynb`,

instead of the broken one below

`http://127.0.0.1:8000/lite/retro/notebooks/index.html?path=my_notebook.ipynb`

It appears that this was not caught in other projects, such as `scikit-learn`, because the "Lab" interface is used there, for which the URL is correct here.

I also tried to add a minimal test to ensure that this breakage does not happen again, by creating a minimal web server as a pytest fixture, but realised that it would require a JupyterLite site to be built during the test suite – which is quite overkill.

## Additional context

N/A