### PR TITLE
Fix: Fix minigallery duplicates

### DIFF
--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -292,7 +292,7 @@ def identify_names(script_blocks, ref_regex, global_variables=None, node=""):
 THUMBNAIL_TEMPLATE = """
 .. raw:: html
 
-    <div class="sphx-glr-thumbcontainer" tooltip="{snippet}">
+    <div class="sphx-glr-thumbcontainer" tooltip="{intro}">
 
 .. only:: html
 
@@ -319,9 +319,33 @@ BACKREF_THUMBNAIL_TEMPLATE = (
 
 
 def _thumbnail_div(
-    target_dir, src_dir, fname, snippet, title, is_backref=False, check=True
+    target_dir, src_dir, fname, intro, title, is_backref=False, check=True
 ):
-    """Generate reST to place a thumbnail in a gallery."""
+    """Generate reST to place a thumbnail in a gallery.
+
+    Parameters
+    ----------
+    target_dir : str
+        Absolute path to output directory, where thumbnails are saved.
+    src_dir : str
+        Absolute path to build source directory.
+    fname : str
+        Filename of example file.
+    intro : str
+        Introductory docstring of example, to show in tooltip
+    title: str
+        Title of example.
+    is_backref : bool
+        Whether the thumbnail is for a backreference/recommendation file (in which
+        case reST added to prevent thumbnails showing in latex docs)
+    check : bool
+        Whether to check if the thumbnail image file exists.
+
+    Returns
+    -------
+    thumbnail : str
+        reST for a thumbnail.
+    """
     fname = Path(fname)
     thumb, _ = _find_image_ext(
         os.path.join(target_dir, "images", "thumb", f"sphx_glr_{fname.stem}_thumb.png")
@@ -341,12 +365,12 @@ def _thumbnail_div(
 
     template = BACKREF_THUMBNAIL_TEMPLATE if is_backref else THUMBNAIL_TEMPLATE
     return template.format(
-        snippet=escape(snippet), thumbnail=thumb, title=title, ref_name=ref_name
+        intro=escape(intro), thumbnail=thumb, title=title, ref_name=ref_name
     )
 
 
 def _write_backreferences(
-    backrefs, seen_backrefs, gallery_conf, target_dir, fname, snippet, title
+    backrefs, seen_backrefs, gallery_conf, target_dir, fname, intro, title
 ):
     """Write backreference file for one example including a thumbnail list of examples.
 
@@ -362,7 +386,7 @@ def _write_backreferences(
         Absolute path to directory where examples are saved.
     fname : str
         Filename of current example python file.
-    snippet : str
+    intro : str
         Introductory docstring of example.
     title: str
         Title of example.
@@ -394,7 +418,7 @@ def _write_backreferences(
                     target_dir,
                     gallery_conf["src_dir"],
                     fname,
-                    snippet,
+                    intro,
                     title,
                     is_backref=True,
                 )

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -414,7 +414,7 @@ def _write_backreferences(
         with open(include_path, mode, **_W_KW) as ex_file:
             if not seen:
                 # Be aware that if the number of lines of this heading changes,
-                #   the minigallery directive should be modified accordingly
+                # the minigallery directive should be modified accordingly
                 heading = f"Examples using ``{backref}``"
                 ex_file.write("\n\n" + heading + "\n")
                 ex_file.write("^" * len(heading) + "\n")
@@ -433,7 +433,9 @@ def _write_backreferences(
                 )
             )
             seen_backrefs.add(backref)
-            backrefs_example[backref].append((Path(target_dir, fname), intro, title))
+            backrefs_example[backref].append(
+                (str(Path(target_dir, fname)), intro, title)
+            )
     return backrefs_example
 
 

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -10,6 +10,7 @@ import inspect
 import os
 import re
 import sys
+from collections import defaultdict
 from html import escape
 from pathlib import Path
 
@@ -336,8 +337,8 @@ def _thumbnail_div(
     title: str
         Title of example.
     is_backref : bool
-        Whether the thumbnail is for a backreference/recommendation file (in which
-        case reST added to prevent thumbnails showing in latex docs)
+        Whether the thumbnail is for a html backreference/recommendation file. If not
+        a bullet list of the example is added for non-html documentation builds.
     check : bool
         Whether to check if the thumbnail image file exists.
 
@@ -390,10 +391,18 @@ def _write_backreferences(
         Introductory docstring of example.
     title: str
         Title of example.
+
+    Returns
+    -------
+    backrefs_example : dict[str, tuple]
+        Dictionary where value is the backreference object and value
+        is a NamedTuple containing all the information required for a reST
+        thumbnail div.
     """
     if gallery_conf["backreferences_dir"] is None:
         return
 
+    backrefs_example = defaultdict(list)
     for backref in backrefs:
         include_path = os.path.join(
             gallery_conf["src_dir"],
@@ -424,6 +433,8 @@ def _write_backreferences(
                 )
             )
             seen_backrefs.add(backref)
+            backrefs_example[backref].append((Path(target_dir, fname), intro, title))
+    return backrefs_example
 
 
 def _finalize_backreferences(seen_backrefs, gallery_conf):

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -166,12 +166,15 @@ class MiniGallery(Directive):
 
         file_paths = {}
         for arg in arg_list:
+            # Backreference arg input
             if paths := has_backrefs(arg):
                 # `PathInfo.arg` is not required for backreference paths
-                file_paths[Path(paths[0])] = PathInfo(paths[1], paths[2], None)
+                for path in paths:
+                    file_paths[Path(path[0])] = PathInfo(path[1], path[2], None)
+            # Glob path arg input
             elif paths := Path(src_dir).glob(arg):
                 # Glob paths require extra parsing to get the intro and title
-                # so we don't want to override a backreference path
+                # so we don't want to override a backreference arg input
                 for path in paths:
                     path_resolved = path.resolve()
                     if path_resolved in file_paths:

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -186,6 +186,7 @@ class MiniGallery(Directive):
             else:
                 target_dir = self._get_target_dir(config, src_dir, path, obj)
                 # Get thumbnail
+                # TODO: ideally we would not need to parse file (again) here
                 _, script_blocks = split_code_and_text_blocks(
                     str(path), return_node=False
                 )

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -195,7 +195,6 @@ class MiniGallery(Directive):
             file_paths.items(),
             key=((lambda x: sortkey(str(x[-1]))) if sortkey else None),
         ):
-            print(path)
             if path_info.intro is not None:
                 thumbnail = _thumbnail_div(
                     path.parent, src_dir, path.name, path_info.intro, path_info.title

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -18,7 +18,7 @@ import sphinx.util
 from sphinx.errors import ExtensionError
 from sphinx.search import js_index
 
-from .utils import _W_KW, _replace_md5, status_iterator
+from .utils import _W_KW, _read_json, status_iterator
 
 logger = sphinx.util.logging.getLogger("sphinx-gallery")
 
@@ -330,22 +330,6 @@ def _get_intersphinx_inventory(app):
     return intersphinx_inv
 
 
-# Whatever mechanism is used for writing here should be paired with reading in
-# _embed_code_links
-def _write_code_obj(target_file, example_code_obj):
-    codeobj_fname = target_file.with_name(target_file.stem + ".codeobj.json.new")
-    with open(codeobj_fname, "w", **_W_KW) as fid:
-        json.dump(
-            example_code_obj,
-            fid,
-            sort_keys=True,
-            ensure_ascii=False,
-            indent=1,
-            check_circular=False,
-        )
-    _replace_md5(codeobj_fname, check="json")
-
-
 def _embed_code_links(app, gallery_conf, gallery_dir):
     """Add resolvers for the packages for which we want to show links."""
     doc_resolvers = {}
@@ -400,8 +384,8 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
             continue
 
         # we have a json file with the objects to embed links for
-        with open(json_fname, "r", encoding="utf-8") as fid:
-            example_code_obj = json.load(fid)
+        example_code_obj = _read_json(json_fname)
+
         # generate replacement strings with the links
         str_repl = {}
         for name in sorted(example_code_obj):

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -1245,6 +1245,7 @@ def write_api_entry_usage(app, docname, source):
     unused_api_entries = list()
     used_api_entries = dict()
     backreferences_all = _read_json(Path(backreferences_dir, "backreferences_all.json"))
+    src_dir = gallery_conf["src_dir"]
     for entry in example_files:
         # don't include built-in methods etc.
         if re.match(gallery_conf["api_usage_ignore"], entry) is not None:
@@ -1254,7 +1255,11 @@ def write_api_entry_usage(app, docname, source):
         if backref_entry is None:
             unused_api_entries.append(entry)
         else:
-            used_api_entries[entry] = [br[0] for br in backref_entry]
+            used_api_entries[entry] = list()
+            for br in backref_entry:
+                example_path = Path(br[0]).relative_to(src_dir)
+                ref_name = str(example_path).replace(os.sep, "_")
+                used_api_entries[entry].append(f"sphx_glr_{ref_name}")
 
     for entry in sorted(unused_api_entries):
         source[0] += f"- :{get_entry_type(entry)}:`{entry}`\n"

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -509,7 +509,7 @@ def generate_dir_rst(
     seen_backrefs,
     is_subsection=True,
 ):
-    """Generate the gallery reStructuredText for an example directory.
+    """Generate output example reST files for one gallery (sub)directory.
 
     Parameters
     ----------

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -42,7 +42,6 @@ from .backreferences import (
     identify_names,
 )
 from .block_parser import BlockParser
-from .docs_resolv import _write_code_obj
 from .interactive_example import (
     _add_jupyterlite_badge_logo,
     gen_binder_rst,
@@ -60,12 +59,14 @@ from .scrapers import (
 from .utils import (
     _W_KW,
     _collect_gallery_files,
+    _combine_backreferences,
     _format_toctree,
     _replace_md5,
     get_md5sum,
     optipng,
     scale_image,
     status_iterator,
+    _write_json,
     zip_files,
 )
 
@@ -539,6 +540,10 @@ def generate_dir_rst(
          with keys "t", "mem", "src_file", and "target_dir".
     toctree_items: list,
         List of example file names we generated ReST for.
+    backrefs_dir : dict[str, tuple]
+        Dictionary where value is the backreference object and value
+        is a tuple containing: full path to example file, 
+        thumbnail div.
     """
     index_content = ""
     # `_get_gallery_header` returns `None` if user supplied `index.rst`
@@ -581,6 +586,8 @@ def generate_dir_rst(
         f"generating gallery for {build_target_dir}... ",
         length=len(sorted_listdir),
     )
+
+    backrefs_dir = {}
 
     parallel = list
     p_fun = generate_file_rst
@@ -625,7 +632,7 @@ def generate_dir_rst(
 
         # Write backreferences
         if "backrefs" in out_vars:
-            _write_backreferences(
+            backrefs_example = _write_backreferences(
                 out_vars["backrefs"],
                 seen_backrefs,
                 gallery_conf,
@@ -634,6 +641,7 @@ def generate_dir_rst(
                 intro,
                 title,
             )
+            _combine_backreferences(backrefs_dir, backrefs_example)
 
     # Close thumbnail parent div
     index_content += THUMBNAIL_PARENT_DIV_CLOSE
@@ -660,6 +668,7 @@ def generate_dir_rst(
         index_content,
         costs,
         toctree_filenames,
+        backrefs_dir,
     )
 
 
@@ -1253,7 +1262,7 @@ def _get_backreferences(gallery_conf, script_vars, script_blocks, node, target_f
     ref_regex = _make_ref_regex(gallery_conf["default_role"])
     example_code_obj = identify_names(script_blocks, ref_regex, global_variables, node)
     if example_code_obj:
-        _write_code_obj(target_file, example_code_obj)
+        _write_json(target_file, example_code_obj, ".codeobj")
     exclude_regex = gallery_conf["exclude_implicit_doc_regex"]
 
     def _normalize_name(cobj):

--- a/sphinx_gallery/utils.py
+++ b/sphinx_gallery/utils.py
@@ -12,6 +12,7 @@ import os
 import re
 import subprocess
 import zipfile
+from collections import defaultdict
 from functools import partial
 from pathlib import Path
 from shutil import copyfile, move
@@ -349,3 +350,36 @@ def custom_minigallery_sort_order_sorter(file):
         "plot_1.py",
     ]
     return ORDER.index(Path(file).name)
+
+
+# Should be matched with `_read_json`
+def _write_json(target_file, to_save, name=""):
+    """Write dictionary to JSON file."""
+    # this part is awkward but ??
+    codeobj_fname = target_file.with_name(target_file.stem + f"{name}.json.new")
+    with open(codeobj_fname, "w", **_W_KW) as fid:
+        json.dump(
+            to_save,
+            fid,
+            sort_keys=True,
+            ensure_ascii=False,
+            indent=1,
+            check_circular=False,
+        )
+    _replace_md5(codeobj_fname, check="json")
+
+
+def _read_json(json_fname):
+    """Read JSON dictionary from file."""
+    with open(json_fname, "r", encoding="utf-8") as fid:
+        json_dict = json.load(fid)
+    return json_dict
+
+
+def _combine_backreferences(dict_a, dict_b):
+    """Combine backreferences dictionaries, joining lists when keys are the same."""
+    # `dict_b` is None when `backreferences_dir` config not set
+    if isinstance(dict_b, dict):
+        for key, value in dict_b.items():
+            dict_a.setdefault(key, []).extend(value)
+    return dict_a


### PR DESCRIPTION
closes #1259
closes #1414 

* `.examples` files are still generated as before, no changes there
* create a dict of backreferences (storing title and intro as well for thumbnail creation) and write to json
* Update API usage and minigallery directive to use the backreferences dict file
   * this should fix the minigallery duplicate problem 