### PR TITLE
Fix minigallery duplicates and add tests and update documenation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.3
+    rev: v0.9.4
     hooks:
       - id: ruff-format
         exclude: plot_syntaxerror
@@ -8,7 +8,7 @@ repos:
         args: ["--select=I", "--fix"]
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.2
+    rev: v0.9.3
     hooks:
       - id: ruff-format
         exclude: plot_syntaxerror
@@ -8,7 +8,7 @@ repos:
         args: ["--select=I", "--fix"]
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.0
     hooks:
       - id: codespell
         additional_dependencies:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -701,14 +701,18 @@ Add mini-galleries
 ==================
 
 Sphinx-Gallery provides the :class:`sphinx_gallery.directives.MiniGallery`
-directive so that you can easily add a reduced version of the Gallery to
-your Sphinx documentation ``.rst`` files. The minigallery directive therefore
-supports passing a list (space separated) of any of the following:
+directive so that you can easily add a gallery of specific examples,
+a 'mini-gallery', to your reST. This directive works in both reST text blocks in
+examples and ``.rst`` files.
 
-* fully qualified name of object (see :ref:`references_to_examples`) - this
+The minigallery directive supports passing a list, as a space separated directive
+argument or in the body of the directive. There are two ways to specify examples
+to include in the mini-gallery:
+
+* via fully qualified names of object (see :ref:`references_to_examples`) - this
   adds all examples where the object was used in the code or referenced in
   the example text
-* pathlike strings to example Python files, including glob-style
+* via pathlike strings to example Python files, including glob-style
   (see :ref:`file_based_minigalleries`)
 
 To use object names, you must enable backreference generation, see
@@ -717,6 +721,48 @@ If backreference generation is not enabled, object entries to the
 :class:`~sphinx_gallery.directives.MiniGallery` directive will be ignored
 and all entries will be treated as pathlike strings or glob-style pathlike strings.
 See :ref:`file_based_minigalleries` for details.
+
+For example, the reST below will add a mini-gallery that includes all
+examples that use or reference the specific function ``numpy.exp``, the example
+``examples/plot_sin_.py``, and all example files matching the string
+``/examples/plot_4*``:
+
+.. code-block:: rst
+
+    .. minigallery:: numpy.exp ../examples/plot_0_sin.py ../examples/plot_4*
+
+All relevant examples will be merged into a single mini-gallery. The
+mini-gallery will only be shown if the files exist or the items are actually
+used or referred to in an example. Sphinx-Gallery will prevent duplication, ensuring
+that examples 'passed' more than once (e.g., one example uses a passed object **and**
+matches a passed file string) will only appear once in the mini-gallery.
+
+You can also sort the examples in your mini-galleries. See :ref:`minigallery_order`
+for details.
+
+The mini-gallery directive also supports the following options:
+
+* ``add-heading`` - adds a heading to the mini-gallery.
+    * The default heading for a mini-gallery with a single passed argument is:
+      "Examples using *{full qualified object name}*".
+    * The default heading for a mini-gallery with multiple passed arguments is:
+      "Examples of one of multiple objects".
+* ``heading-level`` - specify the heading level. Accepts a single character
+  (e.g., ``-``).
+
+For example, the following reST adds the heading "My examples", with heading
+level ``-``. It also shows how to pass inputs in the body of the directive (instead of
+as directive arguments).
+
+.. code-block:: rst
+
+    .. minigallery::
+        :add-heading: My examples
+        :heading-level: -
+
+        numpy.exp
+        ../examples/plot_0_sin.py
+        ../examples/plot_4*
 
 .. _references_to_examples:
 
@@ -755,36 +801,50 @@ refer to :obj:`numpy.exp`, which looks like this:
 .. minigallery:: numpy.exp
     :add-heading:
 
-For such behavior to be available, you have to activate it in
-your Sphinx-Gallery configuration ``conf.py`` file with::
+For such behavior to be available, set the following Sphinx-Gallery configurations
+in your ``conf.py`` file:
+
+**Required**
+
+* ``backreferences_dir`` - directory where object granular galleries are stored.
+  This should be a string or ``pathlib.Path`` object that is **relative** to the
+  ``conf.py`` file, or ``None``. It is ``None`` by default, which means that
+  backrefererences are not generated.
+* ``doc_module`` - the modules for which you want object level galleries
+  to be created, as a tuple of string module names.
+
+**Optional**
+
+* ``exclude_implicit_doc`` - Regexes to match objects to exclude from implicit
+  backreferences, as set of string regexes. The default option is an empty set,
+  which will exclude nothing.
+
+For example::
 
     sphinx_gallery_conf = {
         ...
         # directory where function/class granular galleries are stored
         'backreferences_dir'  : 'gen_modules/backreferences',
 
-        # Modules for which function/class level galleries are created. In
-        # this case sphinx_gallery and numpy in a tuple of strings.
+        # here we want to create backreferences for sphinx_gallery and numpy
         'doc_module'          : ('sphinx_gallery', 'numpy'),
 
         # Regexes to match objects to exclude from implicit backreferences.
-        # The default option is an empty set, i.e. exclude nothing.
-        # To exclude everything, use: '.*'
         'exclude_implicit_doc': {r'pyplot\.show'},
     }
 
 The path you specify in ``backreferences_dir`` (here we choose
-``gen_modules/backreferences``) will be populated with
-ReStructuredText files, with names ending with '.examples'.
-Each .rst file will contain a reduced version of the
-gallery specific to every function/class that is used across all the examples
-and belonging to the modules listed in ``doc_module``.
-Note that backreference files will be generated for all objects. Objects that
-are not used in any example will have an empty file to prevent inclusion
-errors during autodoc parsing.
+``gen_modules/backreferences``) will be populated with a file called
+"backreferences_all.json". This contains a mapping of all of all objects
+belonging to the modules listed in ``doc_module`` and not excluded in
+``exclude_implicit_doc``, to the examples where it was used or referenced.
+Objects not used or referenced in any example are not included.
 
-``backreferences_dir`` should be a string or ``pathlib.Path`` object that is
-**relative** to the ``conf.py`` file, or ``None``. It is ``None`` by default.
+For backwards compatibility ``backreferences_dir`` will also be populated with
+reST files for each object, named '<object>.examples'.
+Each .rst file will contain a reduced version of the
+gallery, containing examples where that "object" that is used.
+No file will be generated for objects not used or referenced in any example.
 
 Sometimes, there are functions that are being used in practically every example
 for the given module, for instance the ``pyplot.show`` or ``pyplot.subplots``
@@ -810,66 +870,9 @@ do not have functions in common, for example a set of tutorials. The
 mini-gallery directive therefore also supports passing in:
 
 * pathlike strings to sphinx gallery example files (relative to ``conf.py``)
-* glob-style pathlike strings to Sphinx-Gallery example files (relative to ``conf.py``)
-
-For example, the rst below will add a mini-gallery that includes all
-examples that use the specific function ``numpy.exp``, the example
-``examples/plot_sin_.py``, and all files matching the string
-``/examples/plot_4*``:
-
-.. code-block:: rst
-
-    .. minigallery::
-        :add-heading:
-
-        numpy.exp
-        ../examples/plot_0_sin.py
-        ../examples/plot_4*
-
-Listing multiple items merges all the examples into a single mini-gallery. The
-mini-gallery will only be shown if the files exist or the items are actually
-used or referred to in an example. Sphinx-Gallery will ensure that examples
-that are 'passed' more than once (e.g., uses a passed object and matches a passed file
-string) will only appear once in the mini-gallery.
-
-.. minigallery::
-    :add-heading:
-
-    numpy.exp
-    ../examples/plot_0_sin.py
-    ../examples/plot_4*
-
-You can also provide the list of items in the body of the directive:
-
-.. code-block:: rst
-
-    .. minigallery::
-        :add-heading:
-
-        numpy.exp
-        ../examples/plot_0_sin.py
-        ../examples/plot_4*
-
-The ``add-heading`` option adds a heading for the mini-gallery. If no string
-argument is provided, when only a single item is listed the default heading is:
-
-    "Examples using *{full qualified object name}*"
-
-Specifying a custom heading message is recommended for a gallery with multiple
-items because otherwise the default message is:
-
-    "Examples of one of multiple objects".
-
-The example mini-gallery shown above uses the default heading level ``^``. This
-can be changed using the ``heading-level`` option, which accepts a single
-character (e.g., ``-``).
-
-You can also pass inputs to the minigallery directive as a space separated
-list of arguments:
-
-.. code-block:: rst
-
-    .. minigallery:: numpy.exp ../examples/plot_0_sin.py ../examples/plot_4*
+* glob-style pathlike strings to Sphinx-Gallery example files (relative to ``conf.py``).
+  For example, passing ``/examples/plot_4*`` will include all example files
+  matching the above pattern.
 
 .. _minigallery_order:
 
@@ -881,18 +884,18 @@ thumbnails corresponding to the input file strings or object names.
 You can specify minigallery thumbnails order via the ``minigallery_sort_order``
 configuration, which gets passed to the :py:func:`sorted` ``key`` parameter when
 sorting all minigalleries.
-Sorting is done on the full paths to the gallery examples (e.g.,
-``path/to/plot_example.py``) and backreference files (e.g.,
-``path/to/numpy.exp.examples``), corresponding to the inputs.
+
+Sorting is done on the full paths to all the gallery examples (e.g.,
+``path/to/plot_example.py``) that correspond to the inputs.
 
 See :ref:`own_sort_keys` for details on writing a custom sort key.
 
-As an example, to put backreference thumbnails at the end, we could define the function
-below in ``doc/sphinxext.py`` (note that backreference filenames do not start with
-"plot\_" and ``False`` gets sorted ahead of ``True`` as 0 is less than 1)::
+For example, to put all example thumbnails starting with "plot_numpy_" at the start,
+we could define the function below in ``doc/sphinxext.py`` (note ``False`` gets sorted
+ahead of ``True`` as 0 is less than 1)::
 
     def function_sorter(x)
-        return (not os.path.basename(x).startswith("plot_"), x)::
+        return (not Path(x).name.starts_with("plot_numpy_"), x)::
 
 We can then set the configuration to be (ensuring the function is
 :ref:`importable <importing_callables>`)::
@@ -906,13 +909,7 @@ We can then set the configuration to be (ensuring the function is
 Sphinx-Gallery would resolve ``"sphinxext.function_sorter"`` to the
 ``function_sorter`` object.
 
-Sorting the set of thumbnails generated from
-:ref:`API backreferences <references_to_examples>` (i.e. the thumbnails linked
-to a qualified object name input) is not supported, but the sorting function can
-be used to position the entire set of backreference thumbnails since minigallery sort
-gets passed the ``{input}.example`` backreference filename. Thumbnails may be duplicated
-if they correspond to multiple object names or an object name and file/glob
-input.
+Note that you can only define one sorting key for all minigalleries.
 
 Auto-documenting your API with links to examples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2631,24 +2628,24 @@ Manually passing files
 ======================
 
 By default, Sphinx-Gallery creates all the files that are written in the
-sphinx-build directory, either by generating rst and images from a ``*.py``
+sphinx-build directory, either by generating reST and images from a ``*.py``
 in the gallery-source, or from  creating ``index.rst`` from
 ``GALLERY_HEADER.rst`` (or ``README.[rst/txt]`` for backward-compatibility)
 in the gallery-source.  However, sometimes it is desirable to pass files
 from the gallery-source to the sphinx-build.  For example, you may want
 to pass an image that a gallery refers to, but does not generate itself.
-You may also want to pass raw rst from the gallery-source to the
+You may also want to pass raw reST from the gallery-source to the
 sphinx-build, because that material fits in thematically with your gallery,
-but is easier to write as rst.  To accommodate this, you may set
+but is easier to write as reST.  To accommodate this, you may set
 ``copyfile_regex`` in ``sphinx_gallery_conf``.  The following copies
-across rst files. ::
+across reST files. ::
 
     sphinx_gallery_conf = {
         ...
        'copyfile_regex': r'.*\.rst',
     }
 
-Note that if you copy across rst files, for instance, it is your
+Note that if you copy across reST files, for instance, it is your
 responsibility to ensure that they are in a sphinx ``toctree`` somewhere
 in your document.  You can, of course, add a ``toctree`` to your
 ``GALLERY_HEADER.rst``.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -901,9 +901,9 @@ We can then set the configuration to be (ensuring the function is
 :ref:`importable <importing_callables>`)::
 
     sphinx_gallery_conf = {
-    #...,
-    "minigallery_sort_order": "sphinxext.function_sorter",
-    #...
+        #...,
+        "minigallery_sort_order": "sphinxext.function_sorter",
+        #...
     }
 
 Sphinx-Gallery would resolve ``"sphinxext.function_sorter"`` to the

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -742,11 +742,12 @@ relevant to that object. This can be useful in API documentation.
 **Implicit backreferences** are useful for auto-documenting objects
 that are used and classes that are explicitly instantiated, in the code. Any examples
 where an object is used in the code are added *implicitly* as backreferences.
+
 **Explicit backreferences** are for objects that are *explicitly* referred to
 in an example's text. They are useful for classes that are
 typically implicitly returned in the code rather than explicitly instantiated (e.g.,
 :class:`matplotlib.axes.Axes` which is most often instantiated only indirectly
-within function calls)..
+within function calls).
 
 For example, we can embed a small gallery of all examples that use or
 refer to :obj:`numpy.exp`, which looks like this:
@@ -811,7 +812,7 @@ mini-gallery directive therefore also supports passing in:
 * pathlike strings to sphinx gallery example files (relative to ``conf.py``)
 * glob-style pathlike strings to Sphinx-Gallery example files (relative to ``conf.py``)
 
-For example, the rst below adds the reduced version of the Gallery for all
+For example, the rst below will add a mini-gallery that includes all
 examples that use the specific function ``numpy.exp``, the example
 ``examples/plot_sin_.py``, and all files matching the string
 ``/examples/plot_4*``:
@@ -827,9 +828,9 @@ examples that use the specific function ``numpy.exp``, the example
 
 Listing multiple items merges all the examples into a single mini-gallery. The
 mini-gallery will only be shown if the files exist or the items are actually
-used or referred to in an example. Thumbnails may also be duplicated
-if they correspond to multiple object names or an object name and file/glob
-input.
+used or referred to in an example. Sphinx-Gallery will ensure that examples
+that are 'passed' more than once (e.g., uses a passed object and matches a passed file
+string) will only appear once in the mini-gallery.
 
 .. minigallery::
     :add-heading:

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -438,9 +438,7 @@ def _write_backreferences(
                 )
             )
             seen_backrefs.add(backref)
-            backrefs_example[backref].append(
-                (fname, src_dir, target_dir, intro, title)
-            )
+            backrefs_example[backref].append((fname, src_dir, target_dir, intro, title))
     return dict(backrefs_example)
 
 

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -371,7 +371,7 @@ def _thumbnail_div(
 
 
 def _write_backreferences(
-    backrefs, seen_backrefs, gallery_conf, target_dir, fname, intro, title
+    backrefs, seen_backrefs, gallery_conf, src_dir, target_dir, fname, intro, title
 ):
     """Write and return backreferences for one example.
 
@@ -386,6 +386,8 @@ def _write_backreferences(
         Back references already encountered when parsing this example.
     gallery_conf : Dict[str, Any]
         Gallery configurations.
+    src_dir : str
+        Stuff.
     target_dir : str
         Absolute path to directory where examples are saved.
     fname : str
@@ -399,7 +401,8 @@ def _write_backreferences(
     -------
     backrefs_example : dict[str, tuple]
         Dictionary where value is the backreference object and value
-        is a tuple containing: full path to example file, intro, title.
+        is a tuple containing: example filename, full path to example source directory,
+        full path to example target directory, intro, title.
     """
     if gallery_conf["backreferences_dir"] is None:
         return
@@ -436,7 +439,7 @@ def _write_backreferences(
             )
             seen_backrefs.add(backref)
             backrefs_example[backref].append(
-                (str(Path(target_dir, fname)), intro, title)
+                (fname, src_dir, target_dir, intro, title)
             )
     return dict(backrefs_example)
 

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -56,7 +56,7 @@ class MiniGallery(Directive):
     }
 
     def _get_target_dir(self, config, src_dir, path, obj):
-        """Get thumbnail target directory, errors when ambiguous/not in example dir."""
+        """Get thumbnail target directory, errors when not in example dir."""
         examples_dirs = config.sphinx_gallery_conf["examples_dirs"]
         if not isinstance(examples_dirs, list):
             examples_dirs = [examples_dirs]

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -204,7 +204,11 @@ class MiniGallery(Directive):
         ):
             if path_info.intro is not None:
                 thumbnail = _thumbnail_div(
-                    path_info.target_dir, src_dir, path.name, path_info.intro, path_info.title
+                    path_info.target_dir,
+                    src_dir,
+                    path.name,
+                    path_info.intro,
+                    path_info.title,
                 )
             else:
                 target_dir = self._get_target_dir(config, src_dir, path, path_info.arg)

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+from collections import namedtuple
 from pathlib import Path, PurePosixPath
 
 from docutils import nodes, statemachine
@@ -17,6 +18,7 @@ from .backreferences import (
 )
 from .gen_rst import extract_intro_and_title
 from .py_source_parser import split_code_and_text_blocks
+from .utils import _read_json
 
 logger = getLogger("sphinx-gallery")
 
@@ -125,13 +127,13 @@ class MiniGallery(Directive):
         # Retrieve source directory
         src_dir = config.sphinx_gallery_conf["src_dir"]
 
-        # Parse the argument into the individual objects
-        obj_list = []
+        # Parse the argument into the individual args
+        arg_list = []
 
         if self.arguments:
-            obj_list.extend([c.strip() for c in self.arguments[0].split()])
+            arg_list.extend([c.strip() for c in self.arguments[0].split()])
         if self.content:
-            obj_list.extend([c.strip() for c in self.content])
+            arg_list.extend([c.strip() for c in self.content])
 
         lines = []
 
@@ -139,53 +141,75 @@ class MiniGallery(Directive):
         if "add-heading" in self.options:
             heading = self.options["add-heading"]
             if heading == "":
-                if len(obj_list) == 1:
-                    heading = f"Examples using ``{obj_list[0]}``"
+                if len(arg_list) == 1:
+                    heading = f"Examples using ``{arg_list[0]}``"
                 else:
                     heading = "Examples using one of multiple objects"
             lines.append(heading)
             heading_level = self.options.get("heading-level", "^")
             lines.append(heading_level * len(heading))
 
-        def has_backrefs(obj):
-            path = Path(src_dir, backreferences_dir, f"{obj}.examples")
-            return path if (path.is_file() and (path.stat().st_size > 0)) else False
+        ExampleInfo = namedtuple("ExampleInfo", ["intro", "title", "arg"])
+        backreferences_all = None
+        if backreferences_dir:
+            backreferences_all = _read_json(
+                Path(src_dir, backreferences_dir, "backreferences_all.json")
+            )
 
-        file_paths = []
-        for obj in obj_list:
-            if backreferences_dir and (path := has_backrefs(obj)):
-                file_paths.append((obj, path.resolve()))
-            elif paths := Path(src_dir).glob(obj):
-                file_paths.extend([(obj, p.resolve()) for p in paths])
+        def has_backrefs(arg):
+            if backreferences_all is None:
+                return False
+            examples = backreferences_all.get(arg, None)
+            if examples:
+                return examples
+            return False
+
+        # Full paths to example files are dict keys, preventing duplicates
+        file_paths = {}
+        for arg in arg_list:
+            # Backreference arg input
+            if paths := has_backrefs(arg):
+                # Note `ExampleInfo.arg` not required for backreference paths
+                for path in paths:
+                    file_paths[Path(path[0])] = ExampleInfo(
+                        intro=path[1], title=path[2], arg=None
+                    )
+            # Glob path arg input
+            elif paths := Path(src_dir).glob(arg):
+                # Glob paths require extra parsing to get the intro and title
+                # so we don't want to override a duplicate backreference arg input
+                for path in paths:
+                    path_resolved = path.resolve()
+                    if path_resolved in file_paths:
+                        continue
+                    else:
+                        file_paths[path_resolved] = ExampleInfo(None, None, arg)
 
         if len(file_paths) == 0:
             return []
 
         lines.append(THUMBNAIL_PARENT_DIV)
 
-        # sort on the str(file_path) but keep (obj, path) pair
+        # sort on the file path
         if config.sphinx_gallery_conf["minigallery_sort_order"] is None:
             sortkey = None
         else:
             (sortkey,) = _get_callables(
                 config.sphinx_gallery_conf, "minigallery_sort_order"
             )
-        for obj, path in sorted(
-            set(file_paths),
-            key=((lambda x: sortkey(str(x[-1]))) if sortkey else None),
+        for path, path_info in sorted(
+            file_paths.items(),
+            # `x[0]` to sort on key only
+            key=((lambda x: sortkey(str(x[0]))) if sortkey else None),
         ):
-            if path.suffix == ".examples":
-                # Insert the backreferences file(s) using the `include` directive.
-                # / is the src_dir for include
-                lines.append(
-                    f"""\
-.. include:: /{path.relative_to(src_dir).as_posix()}
-    :start-after: thumbnail-parent-div-open
-    :end-before: thumbnail-parent-div-close"""
+            if path_info.intro is not None:
+                thumbnail = _thumbnail_div(
+                    path.parent, src_dir, path.name, path_info.intro, path_info.title
                 )
             else:
-                target_dir = self._get_target_dir(config, src_dir, path, obj)
+                target_dir = self._get_target_dir(config, src_dir, path, path_info.arg)
                 # Get thumbnail
+                # TODO: ideally we would not need to parse file (again) here
                 _, script_blocks = split_code_and_text_blocks(
                     str(path), return_node=False
                 )
@@ -194,7 +218,7 @@ class MiniGallery(Directive):
                 )
 
                 thumbnail = _thumbnail_div(target_dir, src_dir, path.name, intro, title)
-                lines.append(thumbnail)
+            lines.append(thumbnail)
 
         lines.append(THUMBNAIL_PARENT_DIV_CLOSE)
         text = "\n".join(lines)

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -149,7 +149,7 @@ class MiniGallery(Directive):
             heading_level = self.options.get("heading-level", "^")
             lines.append(heading_level * len(heading))
 
-        ExampleInfo = namedtuple("ExampleInfo", ["intro", "title", "arg"])
+        ExampleInfo = namedtuple("ExampleInfo", ["target_dir", "intro", "title", "arg"])
         backreferences_all = None
         if backreferences_dir:
             backreferences_all = _read_json(
@@ -168,11 +168,11 @@ class MiniGallery(Directive):
         file_paths = {}
         for arg in arg_list:
             # Backreference arg input
-            if paths := has_backrefs(arg):
+            if examples := has_backrefs(arg):
                 # Note `ExampleInfo.arg` not required for backreference paths
-                for path in paths:
-                    file_paths[Path(path[0])] = ExampleInfo(
-                        intro=path[1], title=path[2], arg=None
+                for path in examples:
+                    file_paths[Path(path[1], path[0]).resolve()] = ExampleInfo(
+                        target_dir=path[2], intro=path[3], title=path[4], arg=None
                     )
             # Glob path arg input
             elif paths := Path(src_dir).glob(arg):
@@ -183,7 +183,7 @@ class MiniGallery(Directive):
                     if path_resolved in file_paths:
                         continue
                     else:
-                        file_paths[path_resolved] = ExampleInfo(None, None, arg)
+                        file_paths[path_resolved] = ExampleInfo(None, None, None, arg)
 
         if len(file_paths) == 0:
             return []
@@ -204,7 +204,7 @@ class MiniGallery(Directive):
         ):
             if path_info.intro is not None:
                 thumbnail = _thumbnail_div(
-                    path.parent, src_dir, path.name, path_info.intro, path_info.title
+                    path_info.target_dir, src_dir, path.name, path_info.intro, path_info.title
                 )
             else:
                 target_dir = self._get_target_dir(config, src_dir, path, path_info.arg)

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -18,7 +18,7 @@ import sphinx.util
 from sphinx.errors import ExtensionError
 from sphinx.search import js_index
 
-from .utils import _W_KW, _replace_md5, status_iterator
+from .utils import _W_KW, _read_json, status_iterator
 
 logger = sphinx.util.logging.getLogger("sphinx-gallery")
 
@@ -330,22 +330,6 @@ def _get_intersphinx_inventory(app):
     return intersphinx_inv
 
 
-# Whatever mechanism is used for writing here should be paired with reading in
-# _embed_code_links
-def _write_code_obj(target_file, example_code_obj):
-    codeobj_fname = target_file.with_name(target_file.stem + ".codeobj.json.new")
-    with open(codeobj_fname, "w", **_W_KW) as fid:
-        json.dump(
-            example_code_obj,
-            fid,
-            sort_keys=True,
-            ensure_ascii=False,
-            indent=1,
-            check_circular=False,
-        )
-    _replace_md5(codeobj_fname, check="json")
-
-
 def _embed_code_links(app, gallery_conf, gallery_dir):
     """Add resolvers for the packages for which we want to show links."""
     doc_resolvers = {}
@@ -400,8 +384,8 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
             continue
 
         # we have a json file with the objects to embed links for
-        with open(json_fname, "r", encoding="utf-8") as fid:
-            example_code_obj = json.load(fid)
+        example_code_obj = _read_json(json_fname)
+
         # generate replacement strings with the links
         str_repl = {}
         for name in sorted(example_code_obj):

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -1420,26 +1420,6 @@ def write_junit_xml(gallery_conf, target_dir, costs):
         fid.write(output)
 
 
-def touch_empty_backreferences(app, what, name, obj, options, lines):
-    """Generate empty back-reference example files.
-
-    This avoids inclusion errors/warnings if there are no gallery
-    examples for a class / module that is being parsed by autodoc.
-    """
-    if not bool(app.config.sphinx_gallery_conf["backreferences_dir"]):
-        return
-
-    examples_path = os.path.join(
-        app.srcdir,
-        app.config.sphinx_gallery_conf["backreferences_dir"],
-        f"{name}.examples",
-    )
-
-    if not os.path.exists(examples_path):
-        # touch file
-        open(examples_path, "w").close()
-
-
 def _expected_failing_examples(gallery_conf):
     return {
         os.path.normpath(os.path.join(gallery_conf["src_dir"], path))

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -1261,7 +1261,8 @@ def write_api_entry_usage(app, docname, source):
         else:
             used_api_entries[entry] = list()
             for br in backref_entry:
-                example_path = Path(br[0]).relative_to(src_dir)
+                # br[2] = abs path to target directory
+                example_path = Path(br[2], br[0]).relative_to(src_dir)
                 ref_name = str(example_path).replace(os.sep, "_")
                 used_api_entries[entry].append(f"sphx_glr_{ref_name}")
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -1420,6 +1420,26 @@ def write_junit_xml(gallery_conf, target_dir, costs):
         fid.write(output)
 
 
+def touch_empty_backreferences(app, what, name, obj, options, lines):
+    """Generate empty back-reference example files.
+
+    This avoids inclusion errors/warnings if there are no gallery
+    examples for a class / module that is being parsed by autodoc.
+    """
+    if not bool(app.config.sphinx_gallery_conf["backreferences_dir"]):
+        return
+
+    examples_path = os.path.join(
+        app.srcdir,
+        app.config.sphinx_gallery_conf["backreferences_dir"],
+        f"{name}.examples",
+    )
+
+    if not os.path.exists(examples_path):
+        # touch file
+        open(examples_path, "w").close()
+
+
 def _expected_failing_examples(gallery_conf):
     return {
         os.path.normpath(os.path.join(gallery_conf["src_dir"], path))
@@ -1672,6 +1692,7 @@ def setup(app):
     app.connect("config-inited", post_configure_jupyterlite_sphinx, priority=900)
 
     if "sphinx.ext.autodoc" in app.extensions:
+        app.connect("autodoc-process-docstring", touch_empty_backreferences)
         app.connect("autodoc-process-docstring", write_api_entries)
         app.connect("source-read", write_api_entry_usage)
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -49,11 +49,14 @@ from .scrapers import _import_matplotlib
 from .sorting import ExplicitOrder
 from .utils import (
     _collect_gallery_files,
+    _combine_backreferences,
     _format_toctree,
     _has_graphviz,
     _has_optipng,
     _has_pypandoc,
+    _read_json,
     _replace_md5,
+    _write_json,
 )
 
 _KNOWN_CSS = (
@@ -737,6 +740,8 @@ def generate_gallery_rst(app):
     examples_dirs = [ex_dir for ex_dir, _ in workdirs]
     _collect_gallery_files(examples_dirs, gallery_conf, check_filenames=True)
 
+    backrefs_all = {}
+
     for examples_dir, gallery_dir in workdirs:
         examples_dir_abs_path = os.path.join(app.builder.srcdir, examples_dir)
         gallery_dir_abs_path = os.path.join(app.builder.srcdir, gallery_dir)
@@ -748,6 +753,7 @@ def generate_gallery_rst(app):
             this_content,
             this_costs,
             this_toctree_items,
+            backrefs_root,
         ) = generate_dir_rst(
             examples_dir_abs_path,
             gallery_dir_abs_path,
@@ -755,6 +761,8 @@ def generate_gallery_rst(app):
             seen_backrefs,
             is_subsection=False,
         )
+
+        _combine_backreferences(backrefs_all, backrefs_root)
 
         # `this_content` is None when user provides own index.rst
         sg_root_index = this_content is not None
@@ -794,7 +802,10 @@ def generate_gallery_rst(app):
                 subsection_index_content,
                 subsection_costs,
                 subsection_toctree_filenames,
+                backrefs_subsec,
             ) = generate_dir_rst(src_dir, target_dir, gallery_conf, seen_backrefs)
+
+            _combine_backreferences(backrefs_all, backrefs_subsec)
 
             has_subsection_header = False
             if subsection_index_content:
@@ -834,6 +845,17 @@ def generate_gallery_rst(app):
     # Per project - items below run once only (for all galleries)
     # Write a single global sg_execution_times
     write_computation_times(gallery_conf, None, costs)
+
+    # Write backreferences_all to file
+    if gallery_conf["backreferences_dir"]:
+        _write_json(
+            Path(
+                gallery_conf["src_dir"],
+                gallery_conf["backreferences_dir"],
+                "backreferences_all",
+            ),
+            backrefs_all,
+        )
 
     if gallery_conf["show_api_usage"] is not False:
         _init_api_usage(app.builder.srcdir)
@@ -1226,24 +1248,22 @@ def write_api_entry_usage(app, docname, source):
     # find used and unused API entries
     unused_api_entries = list()
     used_api_entries = dict()
+    backreferences_all = _read_json(Path(backreferences_dir, "backreferences_all.json"))
+    src_dir = gallery_conf["src_dir"]
     for entry in example_files:
         # don't include built-in methods etc.
         if re.match(gallery_conf["api_usage_ignore"], entry) is not None:
             continue
         # check if backreferences empty
-        example_fname = os.path.join(backreferences_dir, f"{entry}.examples.new")
-        if not os.path.isfile(example_fname):  # use without new
-            example_fname = os.path.splitext(example_fname)[0]
-        assert os.path.isfile(example_fname)
-        if os.path.getsize(example_fname) == 0:
+        backref_entry = backreferences_all.get(entry, None)
+        if backref_entry is None:
             unused_api_entries.append(entry)
         else:
             used_api_entries[entry] = list()
-            with open(example_fname, encoding="utf-8") as fid2:
-                for line in fid2:
-                    if line.startswith("  :ref:"):
-                        example_name = line.split("`")[1]
-                        used_api_entries[entry].append(example_name)
+            for br in backref_entry:
+                example_path = Path(br[0]).relative_to(src_dir)
+                ref_name = str(example_path).replace(os.sep, "_")
+                used_api_entries[entry].append(f"sphx_glr_{ref_name}")
 
     for entry in sorted(unused_api_entries):
         source[0] += f"- :{get_entry_type(entry)}:`{entry}`\n"

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -1691,7 +1691,6 @@ def setup(app):
     app.connect("config-inited", post_configure_jupyterlite_sphinx, priority=900)
 
     if "sphinx.ext.autodoc" in app.extensions:
-        app.connect("autodoc-process-docstring", touch_empty_backreferences)
         app.connect("autodoc-process-docstring", write_api_entries)
         app.connect("source-read", write_api_entry_usage)
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -542,7 +542,8 @@ def generate_dir_rst(
         List of example file names we generated ReST for.
     backrefs_dir : dict[str, tuple]
         Dictionary where value is the backreference object and value
-        is a tuple containing: full path to example file, intro, title.
+        is a tuple containing: example filename, full path to example source directory,
+        full path to example target directory, intro, title.
 
     """
     index_content = ""
@@ -632,11 +633,11 @@ def generate_dir_rst(
 
         # Write backreferences
         if "backrefs" in out_vars:
-            print('XXXXX backrefs!')
             backrefs_example = _write_backreferences(
                 out_vars["backrefs"],
                 seen_backrefs,
                 gallery_conf,
+                src_dir,
                 target_dir,
                 fname,
                 intro,

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -632,6 +632,7 @@ def generate_dir_rst(
 
         # Write backreferences
         if "backrefs" in out_vars:
+            print('XXXXX backrefs!')
             backrefs_example = _write_backreferences(
                 out_vars["backrefs"],
                 seen_backrefs,

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -1354,7 +1354,10 @@ def minigallery_tree(sphinx_app):
     ],
 )
 def test_minigallery_directive(minigallery_tree, test, heading, sortkey):
-    """Tests the functionality of the minigallery directive."""
+    """Tests the functionality of the minigallery directive.
+
+    Use `print(f"{test}: {lxml.html.tostring(text)}")` for checking.
+    """
     assert test in minigallery_tree
 
     text = minigallery_tree[test]
@@ -1373,6 +1376,8 @@ def test_minigallery_directive(minigallery_tree, test, heading, sortkey):
 
     if test in ["Test 1-F-R", "Test 1-S"]:
         img = text.xpath('descendant::img[starts-with(@src, "_images/sphx_glr")]')
+        # These examples are from subdir: examples_with_rst, examples_rst_index
+        # thus we look for "rst"
         href = text.xpath('descendant::a[contains(@href, "rst")]')
 
         assert img and href
@@ -1400,7 +1405,24 @@ def test_minigallery_directive(minigallery_tree, test, heading, sortkey):
             else:
                 assert not (img or href)
 
-    print(f"{test}: {lxml.html.tostring(text)}")
+
+def test_minigallery_duplicates(minigallery_tree):
+    """Ensure minigallery removes duplicate examples.
+
+    "Test duplicates" in `minigallery.rst` should result in only 2 examples:
+    - plot_second_future_imports - object (`ExplicitOrder`) AND 2 file inputs
+    - plot_numpy_matplotlib - object (`Block`) and 1 file input
+    """
+    assert "Test duplicates" in minigallery_tree
+
+    text = minigallery_tree["Test duplicates"]
+
+    imgs = text.xpath('descendant::img[starts-with(@src, "_images/sphx_glr")]')
+    expected_examples = {
+        "_images/sphx_glr_plot_second_future_imports_thumb.png",
+        "_images/sphx_glr_plot_numpy_matplotlib_thumb.png",
+    }
+    assert {img.values()[-1] for img in imgs} == expected_examples
 
 
 def test_matplotlib_warning_filter(sphinx_app):

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -852,6 +852,8 @@ def test_rebuild(tmpdir_factory, sphinx_app):
     generated_backrefs_0 = sorted(
         op.join(old_src_dir, "gen_modules", "backreferences", f)
         for f in os.listdir(op.join(old_src_dir, "gen_modules", "backreferences"))
+        # Exclude backreferences_all.json` which is changed when any example is run
+        if "backreferences_all.json" not in f
     )
     generated_rst_0 = sorted(
         op.join(old_src_dir, "auto_examples", f)
@@ -944,6 +946,8 @@ def test_rebuild(tmpdir_factory, sphinx_app):
     generated_backrefs_1 = sorted(
         op.join(new_app.srcdir, "gen_modules", "backreferences", f)
         for f in os.listdir(op.join(new_app.srcdir, "gen_modules", "backreferences"))
+        # Exclude backreferences_all.json` which is changed when any example is run
+        if "backreferences_all.json" not in f
     )
     generated_rst_1 = sorted(
         op.join(new_app.srcdir, "auto_examples", f)
@@ -1117,6 +1121,8 @@ def _rerun(
     generated_backrefs_1 = sorted(
         op.join(new_app.srcdir, "gen_modules", "backreferences", f)
         for f in os.listdir(op.join(new_app.srcdir, "gen_modules", "backreferences"))
+        # Exclude backreferences_all.json` which is changed when any example is run
+        if "backreferences_all.json" not in f
     )
     generated_rst_1 = sorted(
         op.join(new_app.srcdir, "auto_examples", f)

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -891,13 +891,13 @@ sphinx_gallery_conf = {
 Header
 ======
 
-.. minigallery:: numpy.max src/plot_1.py
+.. minigallery:: sphinx_gallery.py_source_parser.Block src/plot_1.py
 """
 )
 def test_minigallery_duplicate_object_path_input(sphinx_app_wrapper):
     """Check object and path input de-deplication works in minigallery directive.
 
-    `numpy.max` is used in `src/plot_1.py`.
+    `Block` is used in `src/plot_1.py`.
     """
     sphinx_app = sphinx_app_wrapper.build_sphinx_app()
 

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -891,7 +891,7 @@ sphinx_gallery_conf = {
 Header
 ======
 
-.. minigallery:: numpy.max, src/plot_1.py
+.. minigallery:: numpy.max src/plot_1.py
 """
 )
 def test_minigallery_duplicate_object_path_input(sphinx_app_wrapper):

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -905,6 +905,7 @@ def test_minigallery_duplicate_object_path_input(sphinx_app_wrapper):
     file_numbers = _get_minigallery_thumbnails(rst_fname)
     assert file_numbers == ["1"]
 
+
 def test_write_computation_times_noop(sphinx_app_wrapper):
     app = sphinx_app_wrapper.create_sphinx_app()
     write_computation_times(app.config.sphinx_gallery_conf, None, [])

--- a/sphinx_gallery/tests/test_utils.py
+++ b/sphinx_gallery/tests/test_utils.py
@@ -1,0 +1,38 @@
+"""Test utility functions."""
+
+from pathlib import Path
+
+from sphinx_gallery.utils import _combine_backreferences, _read_json, _write_json
+
+
+def test_combine_backreferences():
+    """Check `_combine_backreferences` works as expected."""
+    backrefs_a = {
+        "a": [1, 2],
+        "b": [11, 12],
+    }
+    assert _combine_backreferences({}, backrefs_a) == backrefs_a
+
+    backrefs_b = {
+        "a": [3, 4],
+        "c": [21, 22],
+    }
+    assert _combine_backreferences(backrefs_a, backrefs_b) == {
+        "a": [1, 2, 3, 4],
+        "b": [11, 12],
+        "c": [21, 22],
+    }
+
+
+def test_read_write_json(tmpdir):
+    """Check `_read_json` and `_write_json` work as expected."""
+    path = Path(tmpdir, "test")
+    data = {
+        "object1": ("path/file.py", "first intro", "first title"),
+        "object2": ("path2/file2.py", "second intro", "second title"),
+    }
+    _write_json(path, data, "test_dict")
+    # Writing converts tuples to lists
+    assert _read_json(Path(path).with_name(path.stem + "test_dict.json")) == {
+        key: list(value) for key, value in data.items()
+    }

--- a/sphinx_gallery/tests/testconfs/src/plot_1.py
+++ b/sphinx_gallery/tests/testconfs/src/plot_1.py
@@ -6,9 +6,9 @@ B test
 :filename=1:title=2:lines=3:filesize=2:
 """
 
-import numpy as np
+from sphinx_gallery.py_source_parser import Block
 
-np.max([1, 2, 3])
+Block("text", "Text block", 1)
 
 # %%
 #

--- a/sphinx_gallery/tests/testconfs/src/plot_1.py
+++ b/sphinx_gallery/tests/testconfs/src/plot_1.py
@@ -6,9 +6,9 @@ B test
 :filename=1:title=2:lines=3:filesize=2:
 """
 
-print("foo")
-print("bar")
-print("again")
+import numpy as np
+
+np.max([1, 2, 3])
 
 # %%
 #

--- a/sphinx_gallery/tests/tinybuild/doc/minigallery.rst
+++ b/sphinx_gallery/tests/tinybuild/doc/minigallery.rst
@@ -68,3 +68,13 @@ Test 3-N
    ../examples/*matplotlib*.py
    sphinx_gallery.sorting.ExplicitOrder
    sphinx_gallery.sorting.FileNameSortKey
+
+Test duplicates
+
+.. minigallery::
+
+    sphinx_gallery.sorting.ExplicitOrder
+    ../examples/plot_second_future_imports.py
+    ../examples/plot_second_future_import*
+    sphinx_gallery.py_source_parser.Block
+    ../examples/plot_numpy_matplotib.py

--- a/sphinx_gallery/utils.py
+++ b/sphinx_gallery/utils.py
@@ -12,6 +12,7 @@ import os
 import re
 import subprocess
 import zipfile
+from collections import defaultdict
 from functools import partial
 from pathlib import Path
 from shutil import copyfile, move
@@ -349,3 +350,35 @@ def custom_minigallery_sort_order_sorter(file):
         "plot_1.py",
     ]
     return ORDER.index(Path(file).name)
+
+
+# Should be matched with `_read_json`
+def _write_json(target_file, to_save, name=""):
+    """Write dictionary to JSON file."""
+    codeobj_fname = target_file.with_name(target_file.stem + f"{name}.json.new")
+    with open(codeobj_fname, "w", **_W_KW) as fid:
+        json.dump(
+            to_save,
+            fid,
+            sort_keys=True,
+            ensure_ascii=False,
+            indent=1,
+            check_circular=False,
+        )
+    _replace_md5(codeobj_fname, check="json")
+
+
+def _read_json(json_fname):
+    """Read JSON dictionary from file."""
+    with open(json_fname, "r", encoding="utf-8") as fid:
+        json_dict = json.load(fid)
+    return json_dict
+
+
+def _combine_backreferences(dict_a, dict_b):
+    """Combine backreferences dictionaries, joining lists when keys are the same."""
+    # `dict_b` is None when `backreferences_dir` config not set
+    if isinstance(dict_b, dict):
+        for key, value in dict_b.items():
+            dict_a.setdefault(key, []).extend(value)
+    return dict_a

--- a/sphinx_gallery/utils.py
+++ b/sphinx_gallery/utils.py
@@ -355,7 +355,7 @@ def custom_minigallery_sort_order_sorter(file):
 # Should be matched with `_read_json`
 def _write_json(target_file, to_save, name=""):
     """Write dictionary to JSON file."""
-    codeobj_fname = target_file.with_name(target_file.stem + f"{name}.json.new")
+    codeobj_fname = Path(target_file).with_name(target_file.stem + f"{name}.json.new")
     with open(codeobj_fname, "w", **_W_KW) as fid:
         json.dump(
             to_save,


### PR DESCRIPTION
Follow up to #1430. A few things happening in this PR (sorry!)

**Fixes duplicates between object and file inputs**

In #1430 the dict key used for objects was `Path(target_dir, filename)`, whereas the dict key used for file inputs was `Path(src_dir, filename)`. Thus, files selected via both object and file path would be duplicated.

There were two ways I could have fixed this:

* Change key for file inputs to use `target_dir` - we would have needed to get the `target_dir` anyway to get the thumbnail and it may have been better to raise an error earlier if input path is not in an `examples_dir` (done in `_get_target_dir`) BUT we probably want to sort on `Path(src_dir, filename)` as it's probably easier for users vs `Path(target_dir, filename)`
* Change key for object inputs to use `src_dir` meaning I write BOTH `target_dir` and `src_dir` to `backreferences_all.json` - probably 'safest' as we know `src_dir` and `target_dir` and do not have to do any complex ambiguity checking (as we do in `_get_target_dir`) but probably a bit much more expensive?

I went with the latter option.

**Tests**

* Adds unit tests in `test_gen_gallery.py` - I've had to amend `sphinx_gallery/tests/testconfs/src/plot_1.py` to use a SG function, so I can test an object backreference input
* Add a check in `test_full.py` via `minigallery.rst`
* Add unit tests for the utility functions i added (`_combine_backreferences`, `_read_json`, `_write_json`)

**Docs**

* Moved general minigallery info under the main header, so users don't have to go under "Create mini-galleries using file paths" to find it
* Amended to say duplicates are removed
* Mention new `backreferences_all.json` file and updated to say '.examples' files to be for backward compatibility only
* Improved section on enabling backreferences (personal nitpick changes)
* Update what will be passed to minigallery sortkey functions