### PR TITLE
MNT Add test for `_bool_eval` and add configs to `_bool_eval` check

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -130,8 +130,8 @@ Build options
 Configuration options can be set at build time via the
 `Sphinx build -D <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-D>`_
 command line option. This overrides the value set in your ``conf.py`` file for that
-configuration. The value seting in your ``conf.py`` is effectively the 'default',
-as it takes lower precedence than the value passed via the ``-D`` build option.
+configuration. Values set in your ``conf.py`` are effectively the 'default',
+as it takes lower precedence than values passed via the ``-D`` build option.
 
 You can also use the ``-D`` option in your Makefile to create useful targets,
 for example:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -127,10 +127,22 @@ the rendered examples.
 Build options
 ^^^^^^^^^^^^^
 
-Some options can be set during the build execution step, e.g. using a Makefile:
+Configuration options can be set at build time via the
+`Sphinx build -D <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-D>`_
+command line option. This overrides the value set in your ``conf.py`` file for that
+configuration. The value seting in your ``conf.py`` is effectively the 'default',
+as it takes lower precedence than the value passed via the ``-D`` build option.
+
+You can also use the ``-D`` option in your Makefile to create useful targets,
+for example:
 
 - ``make html-noplot`` (:ref:`without_execution`)
 - ``make html_abort_on_example_error`` (:ref:`abort_on_first`)
+
+.. note::
+    If you wish to use the ``-D`` build option to pass an instantiated class, class or
+    function as a configuration value, you can do so by passing a fully qualified name
+    string to the object. See :ref:`importing_callables` for details.
 
 CSS changes
 ^^^^^^^^^^^
@@ -1233,7 +1245,7 @@ included in the prefix if it's required.
 .. tip::
 
     If building multiple versions of your documentation on a hosted service and
-    using prefix, consider using `sphinx build -D <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-D>`_
+    using prefix, consider using `Sphinx build -D <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-D>`_
     command line option to ensure links point to the correct version. For
     example:
 
@@ -1746,9 +1758,19 @@ Building without executing examples
 Sphinx-Gallery can parse all your examples and build the gallery
 without executing any of the scripts. This is just for speed
 visualization processes of the gallery and the size it takes your
-website to display, or any use you can imagine for it. To achieve this you
-need to pass the no plot option in the build process by modifying
-your ``Makefile`` with:
+website to display, or any use you can imagine for it.
+
+This can be done by setting the ``plot_gallery`` configuration in the
+``sphinx_gallery_conf`` dictionary inside your ``conf.py``::
+
+    sphinx_gallery_conf = {
+        ...
+        'plot_gallery': 'False',
+    }
+
+You can also change this via the
+`Sphinx build option -D <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-D>`_,
+which can be used to add a 'no-plot' target to your ``Makefile``:
 
 .. code-block:: Makefile
 
@@ -1760,17 +1782,9 @@ your ``Makefile`` with:
 Remember that for ``Makefile`` white space is significant and the indentation are tabs
 and not spaces.
 
-Alternatively, you can add the ``plot_gallery`` option to the
-``sphinx_gallery_conf`` dictionary inside your ``conf.py`` to have it as
-a default::
-
-    sphinx_gallery_conf = {
-        ...
-        'plot_gallery': 'False',
-    }
-
 The highest precedence is always given to the `-D` flag of the
-``sphinx-build`` command.
+``sphinx-build`` command, which effectively makes the value set in your ``conf.py``
+file the 'default'.
 
 .. note::
 
@@ -2176,9 +2190,18 @@ Abort build on first fail
 
 Sphinx-Gallery provides the early fail option. In
 this mode the gallery build process breaks as soon as an exception
-occurs in the execution of the examples scripts. To activate this
-behavior you need to pass a flag at the build process. It can be done
-by including in your ``Makefile``:
+occurs in the execution of the examples scripts. This can by activated via the
+``abort_on_example_error`` configuration, which can be set ``sphinx_gallery_conf``
+dictionary inside your ``conf.py`` configuration file::
+
+    sphinx_gallery_conf = {
+        ...
+        'abort_on_example_error': True,
+    }
+
+You can also change this via the
+`Sphinx build option -D <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-D>`_,
+which can be used to add a 'abort_on_example_error' target to your ``Makefile``:
 
 .. code-block:: makefile
 
@@ -2190,18 +2213,9 @@ by including in your ``Makefile``:
 Remember that for ``Makefile`` white space is significant and the indentation
 are tabs and not spaces.
 
-Alternatively, you can add the ``abort_on_example_error`` option to
-the ``sphinx_gallery_conf`` dictionary inside your ``conf.py``
-configuration file to have it as a default::
-
-    sphinx_gallery_conf = {
-        ...
-        'abort_on_example_error': True,
-    }
-
-
-The highest precedence is always given to the `-D` flag of
-the ``sphinx-build`` command.
+The highest precedence is always given to the `-D` flag of the
+``sphinx-build`` command, which effectively makes the value set in your ``conf.py``
+file the 'default'.
 
 .. _dont_fail_exit:
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -365,8 +365,15 @@ def _fill_gallery_conf_defaults(sphinx_gallery_conf, app=None, check_keys=True):
     # XXX anything that can only be a bool (rather than str) should probably be
     # evaluated this way as it allows setting via -D on the command line
     for key in (
+        "download_all_examples",
+        "inspect_global_variables",
+        "line_numbers",
+        "nested_sections",
+        "only_warn_on_example_error",
         "promote_jupyter_magic",
+        "remove_config_comments",
         "run_stale_examples",
+        "show_signature",
     ):
         gallery_conf[key] = _bool_eval(gallery_conf[key])
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -96,11 +96,8 @@ DEFAULT_GALLERY_CONF = {
     "reference_url": {},
     "capture_repr": ("_repr_html_", "__repr__"),
     "ignore_repr_types": r"",
-    # Build options
-    # -------------
-    # 'plot_gallery' also accepts strings that evaluate to a bool, e.g. "True",
-    # "False", "1", "0" so that they can be easily set via command line
-    # switches of sphinx-build
+    # 'plot_gallery' should accept strings that evaluate to a bool, to allow
+    # setting via `sphinx-build -D` on command line
     "plot_gallery": "True",
     "download_all_examples": True,
     "abort_on_example_error": False,
@@ -148,7 +145,11 @@ logger = sphinx.util.logging.getLogger("sphinx-gallery")
 
 
 def _bool_eval(x):
-    """Evaluate bool only configs, to allow setting via -D on the command line."""
+    """Evaluate bool only configs, allows setting via `sphinx-build -D` on command line.
+
+    Ensures that strings that evaluate to a bool, e.g. "True", "False", "1", "0",
+    work as expected.
+    """
     if isinstance(x, str):
         try:
             x = eval(x)
@@ -362,8 +363,8 @@ def _fill_gallery_conf_defaults(sphinx_gallery_conf, app=None, check_keys=True):
     _check_extra_config_keys(gallery_conf, sphinx_gallery_conf, check_keys)
 
     gallery_conf.update(sphinx_gallery_conf)
-    # XXX anything that can only be a bool (rather than str) should probably be
-    # evaluated this way as it allows setting via -D on the command line
+    # Bool only (i.e. not string) configs are evaluated with
+    # `_bool_eval` to allow setting via `sphinx-build -D`
     for key in (
         "download_all_examples",
         "inspect_global_variables",

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -14,6 +14,7 @@ from sphinx.config import is_serializable
 from sphinx.errors import ConfigError, ExtensionError, SphinxWarning
 
 from sphinx_gallery.gen_gallery import (
+    _bool_eval,
     _fill_gallery_conf_defaults,
     fill_gallery_conf_defaults,
     write_api_entry_usage,
@@ -35,6 +36,15 @@ Description.
 '''
 
 """
+
+
+def test_bool_eval():
+    """Ensure `_bool_eval` evaluates strings correctly to bool."""
+    assert _bool_eval("True") == True
+    assert _bool_eval("False") == False
+    assert _bool_eval("True") == True
+    assert _bool_eval("True") == True
+    assert _bool_eval("0") == False
 
 
 def test_bad_config():


### PR DESCRIPTION
closes #1411

* Add test for `_bool_eval`
* Adds bool only configurations to `_bool_eval` check
* Improves build options section, as I *think* any configuration can be altered via `-D` build option, as long as it is one of the accepted types by `-D`. As we now accept callables as string path to object, I *think* these can now also be set via `-D`.

