### PR TITLE
Update instructions for converting script to notebook

### DIFF
--- a/doc/utils.rst
+++ b/doc/utils.rst
@@ -11,7 +11,7 @@ and give the Python source file as argument:
 
 .. code-block:: console
 
-  $ python -m sphinx_gallery_py2jupyter python_script.py
+  $ sphinx_gallery_py2jupyter python_script.py
 
 
 Embedding Sphinx-Gallery inside your documentation script extensions


### PR DESCRIPTION
Running the command as specified gives:

```
/path/to/python: No module named sphinx_gallery_py2jupyter
```