### PR TITLE
Add commet on path for sphinx_gallery_thumbnail_path 

### DIFF
--- a/examples/plot_4b_provide_thumbnail.py
+++ b/examples/plot_4b_provide_thumbnail.py
@@ -7,6 +7,7 @@ thumbnail. This is done by specifying the keyword-value pair
 ``sphinx_gallery_thumbnail_path = 'fig path'`` as a comment somewhere below the
 docstring in the example file. In this example, we specify that we wish the
 figure ``demo.png`` in the folder ``_static`` to be used for the thumbnail.
+Note, the path to the image should be relative to the ``conf.py``.
 """
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
As noted in #1462, the path for rendering an image in a gallery (e.g., ``.. figure:: ../../_images/agrivoltaics_system.jpg``) differs from the path used for the thumbnail (e.g., ``# sphinx_gallery_thumbnail_path = '_images/agrivoltaics_system.jpg'``).

This PR adds a note, specifying that the ``sphinx_gallery_thumbnail_path `` should be relative to the ``conf.py`` file. This was also noted in this PR: https://github.com/sphinx-gallery/sphinx-gallery/pull/764/files

