### PR TITLE
Fix typo in note about Binder/JupyterLite

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1452,7 +1452,7 @@ EXAMPLE_HEADER = """
         :class: sphx-glr-download-link-note
 
         :ref:`Go to the end <sphx_glr_download_{1}>`
-        to download the full example code.{2}
+        to download the full example code{2}
 
 .. rst-class:: sphx-glr-example-title
 
@@ -1569,9 +1569,10 @@ def save_rst_example(
     jupyterlite_conf = gallery_conf["jupyterlite"]
     is_jupyterlite_enabled = jupyterlite_conf is not None
 
-    interactive_example_text = ""
     if is_binder_enabled or is_jupyterlite_enabled:
-        interactive_example_text += " or to run this example in your browser via "
+        interactive_example_text = " or to run this example in your browser via "
+    else:
+        interactive_example_text = "."
 
     if is_binder_enabled and is_jupyterlite_enabled:
         interactive_example_text += "JupyterLite or Binder."

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1574,11 +1574,11 @@ def save_rst_example(
         interactive_example_text += " or to run this example in your browser via "
 
     if is_binder_enabled and is_jupyterlite_enabled:
-        interactive_example_text += "JupyterLite or Binder"
+        interactive_example_text += "JupyterLite or Binder."
     elif is_binder_enabled:
-        interactive_example_text += "Binder"
+        interactive_example_text += "Binder."
     elif is_jupyterlite_enabled:
-        interactive_example_text += "JupyterLite"
+        interactive_example_text += "JupyterLite."
 
     example_rst = (
         EXAMPLE_HEADER.format(example_fname, ref_fname, interactive_example_text)


### PR DESCRIPTION
Closes #1489.

I modified the logic for how the sentence inside the note is constructed, specifically:
- The first part of the sentence, as defined in `EXAMPLE_HEADER`, now ends without a period
- Then, if Binder or JupyterLite is being used, the sentence is extended as before, and a period is added at the end of the extended sentence.
- If neither Binder o JypyterLite are used, just a period is added.

I tested my fix by running `make html` from inside `sphinx_gallery/tests/tinybuild/doc` and opening the examples in the generated gallery.

**Before (run in `master` branch):**

<img width="1626" height="300" alt="image" src="https://github.com/user-attachments/assets/fdb0fccb-2960-4b62-92cb-ec1dd2083b83" />

**After (run in my branch):**

<img width="1630" height="316" alt="image" src="https://github.com/user-attachments/assets/b809f797-1ae0-481b-a5c2-6dd65d2c4235" />


