### PR TITLE
Remove "# noqa: E501" from end of text blocks

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -1528,7 +1528,14 @@ def rst_blocks(
             block_separator = (
                 "\n\n" if not script_block.content.endswith("\n") else "\n"
             )
-            example_rst += script_block.content + block_separator
+            # Remove "# noqa: E501" at the end of any lines (issue #1403)
+            text_content = re.sub(
+                r"^(.*)( +# noqa: ?E501 *)$",
+                r"\1",  # replace with first capturing group
+                script_block.content,
+                flags=re.MULTILINE,
+            )
+            example_rst += text_content + block_separator
 
     return example_rst
 

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -1301,6 +1301,16 @@ def test_alt_text_thumbnail(sphinx_app):
     assert ":alt:" in rst
 
 
+def test_noqa_removal(sphinx_app):
+    """Test that "noqa: E501" is removed from end of text blocks."""
+    src_dir = sphinx_app.srcdir
+
+    example_rst = op.join(src_dir, "auto_examples", "plot_matplotlib_alt.rst")
+    with codecs.open(example_rst, "r", "utf-8") as fid:
+        rst = fid.read()
+    assert "# noqa: E501" not in rst
+
+
 def test_backreference_labels(sphinx_app):
     """Tests that backreference labels work."""
     src_dir = sphinx_app.srcdir

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -240,9 +240,7 @@ def test_rst_block_noqa_removal(gallery_conf, tmpdir):
     file_conf, blocks = split_code_and_text_blocks(filename)
 
     script_vars = {"execute_script": ""}
-    output_blocks, _ = sg.execute_script(
-        blocks, script_vars, gallery_conf, file_conf
-    )
+    output_blocks, _ = sg.execute_script(blocks, script_vars, gallery_conf, file_conf)
 
     example_rst = sg.rst_blocks(blocks, output_blocks, file_conf, gallery_conf)
     want_rst = """\

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -216,6 +216,55 @@ Paragraph 3
     assert example_rst == want_rst
 
 
+def test_rst_block_noqa_removal(gallery_conf, tmpdir):
+    """Check "# noqa: E501" removed from end of text blocks (issue #1403)."""
+    filename = str(tmpdir.join("temp.py"))
+    with open(filename, "w") as f:
+        f.write(
+            "\n".join(
+                [
+                    '"Docstring"',
+                    "####################",
+                    "# Paragraph 1",
+                    "# has a noqa at the end. # noqa: E501",
+                    "",
+                    "#%%",
+                    "# Paragraph 2 also has a noqa # noqa:E501",
+                    "",
+                    "# %%",
+                    "# Paragraph 3",
+                    "",
+                ]
+            )
+        )
+    file_conf, blocks = split_code_and_text_blocks(filename)
+
+    script_vars = {"execute_script": ""}
+    output_blocks, _ = sg.execute_script(
+        blocks, script_vars, gallery_conf, file_conf
+    )
+
+    example_rst = sg.rst_blocks(blocks, output_blocks, file_conf, gallery_conf)
+    want_rst = """\
+Docstring
+
+.. GENERATED FROM PYTHON SOURCE LINES 3-5
+
+Paragraph 1
+has a noqa at the end.
+
+.. GENERATED FROM PYTHON SOURCE LINES 7-8
+
+Paragraph 2 also has a noqa
+
+.. GENERATED FROM PYTHON SOURCE LINES 10-11
+
+Paragraph 3
+
+"""
+    assert example_rst == want_rst
+
+
 def test_rst_empty_code_block(gallery_conf, tmpdir):
     """Test that we can "execute" a code block containing only comments."""
     gallery_conf.update(image_scrapers=())

--- a/sphinx_gallery/tests/tinybuild/examples/plot_matplotlib_alt.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_matplotlib_alt.py
@@ -1,10 +1,11 @@
 """
-======================
+===================
 Matplotlib alt text
-======================
+===================
 
 This example tests that the alt text is generated correctly for matplotlib
 figures.
+It also checks that "noqa: E501" is removed from the end of text blocks. # noqa: E501
 """
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
closes #1403

Removes (only) "# noqa: E501" from the end of text blocks:

* it seems that this specific lint qa is the problem, e.g., per #1403 and https://github.com/scikit-learn/scikit-learn/pull/32241#discussion_r2366715332
* a regex to try and remove all 'noqa ...' comments may be a bit brittle

If we get more issues/reports of other qa's being a problem, we can re-open but I thought we could go with YAGNI for now. WDYT @larsoner ?