### PR TITLE
allow git archives to have dynamic versioning

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -40,5 +40,6 @@ recursive-exclude */gen_modules *
 exclude gen_modules
 exclude .DS_store
 exclude .github_changelog_generator
+exclude .git_archival.txt
 exclude .git-blame-ignore-revs
 exclude .pre-commit-config.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "setuptools.build_meta"
 requires = [
   "setuptools",
-  "setuptools-scm",
+  "setuptools-scm>=7",
 ]
 
 [project]


### PR DESCRIPTION
If I did things correctly, this should allow folks to specify `"sphinx_gallery @ https://github.com/sphinx-gallery/sphinx-gallery/archive/refs/heads/master.zip"` in their pyproject.toml files if they want to, without hitting this setuptools-scm error:

> LookupError: setuptools-scm was unable to detect version for C:\redacted\AppData\Local\Temp\pip-install-4gllzf0a\sphinx-gallery_9dfdfde8181949b8b49cd2ce9bf8d7cb.
>
> Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.

refs:

- [the issue where it came up](https://github.com/mne-tools/mne-bids/issues/1424#issuecomment-3180713566)
- [the explanation of how to fix](https://github.com/mne-tools/mne-bids/pull/1428#issuecomment-3180922554)
- [the relevant part of the setuptools-scm docs](https://setuptools-scm.readthedocs.io/en/latest/usage/#setting-up-git-archival-support)
- [the corresponding section of the scientific python packaging guide](https://learn.scientific-python.org/development/guides/packaging-classic/#versioning-mediumhigh-priority) (midway through that section; search for `.git_archival.txt`)

Tested by running  `pip install "sphinx_gallery @ https://github.com/drammock/sphinx-gallery/archive/refs/heads/archival.zip"` (i.e. from this branch) and it worked without error.

Alternatives:

1. Without this PR, folks can instead use `git+https://...` format, but that requires the user to have git installed; most end users do, but not all.
2. I think (?) this problem is specific to setuptools-scm; if you switched to hatchling + hatch-vcs it might go away.