### PR TITLE
Fix sphinx warning

### DIFF
--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -426,7 +426,10 @@ def _embed_code_links(app, gallery_conf, gallery_dir):
                         for key, value in inv.items():
                             # only python domain
                             if key.startswith("py") and want in value:
-                                link = value[want][2]
+                                try:
+                                    link = value[want].uri
+                                except AttributeError:  # sphinx < 8.2
+                                    link = value[want][2]
                                 type_ = key
                                 break
 


### PR DESCRIPTION
Closes #1466.

Sphinx switched from a tuple to a class in https://github.com/sphinx-doc/sphinx/pull/13248.