### PR TITLE
FIX: Fix test_recommend_n_examples

### DIFF
--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -1631,15 +1631,24 @@ def test_recommend_n_examples(sphinx_app):
     with codecs.open(fname, "r", "utf-8") as fid:
         html = fid.read()
 
-    count = html.count('<div class="sphx-glr-thumbnail-title">')
-    n_examples = sphinx_app.config.sphinx_gallery_conf["recommender"]["n_examples"]
+    (related_html,) = re.findall(
+        '<p class="rubric">Related examples</p>(.*)</section>', html, re.DOTALL
+    )
 
-    assert '<p class="rubric">Related examples</p>' in html
-    assert count == n_examples
+    n_thumbnails = related_html.count('<div class="sphx-glr-thumbnail-title">')
+    n_examples = sphinx_app.config.sphinx_gallery_conf["recommender"]["n_examples"]
+    assert n_thumbnails == n_examples
+
     # Check the same 3 related examples are shown (can change when new examples added)
-    assert "sphx-glr-auto-examples-plot-defer-figures-py" in html
-    assert "sphx-glr-auto-examples-plot-webp-py" in html
-    assert "sphx-glr-auto-examples-plot-command-line-args-py" in html
+    assert 'href="plot_webp.html#sphx-glr-auto-examples-plot-webp-py"' in related_html
+    assert (
+        'href="plot_command_line_args.html'
+        '#sphx-glr-auto-examples-plot-command-line-args-py"' in related_html
+    )
+    assert (
+        'href="plot_numpy_matplotlib.html'
+        '#sphx-glr-auto-examples-plot-numpy-matplotlib-py"' in related_html
+    )
 
 
 def test_sidebar_components_download_links(sphinx_app):


### PR DESCRIPTION
One of the three related examples was not asserted with the correct string:

`assert "sphx-glr-auto-examples-plot-defer-figures-py" in html`

That string occurs in the HTML, but is not a related example.

I assume the test went incorrect at some point without somebody noticing, related to the comment in the code

>  Check the same 3 related examples are shown (can change when new examples added)


I've narrowed down the test by
- searching only in the "related" code section
- testing the presence of the full href=... strings
  Note: Here, I've also adjusted the order to the order in which they appear in the HTML. 

