### PR TITLE
MNT: Use names instead of indices for Block namedtuple

### DIFF
--- a/sphinx_gallery/tests/test_block_parser.py
+++ b/sphinx_gallery/tests/test_block_parser.py
@@ -101,8 +101,8 @@ def test_cxx_titles(comment, expected_docstring):
     file_conf, blocks, _ = parser._split_content(doc)
 
     assert len(blocks) == 2
-    assert blocks[0][0] == "text"
-    assert blocks[0][1] == expected_docstring
+    assert blocks[0].type == "text"
+    assert blocks[0].content == expected_docstring
 
 
 @pytest.mark.parametrize(
@@ -189,8 +189,8 @@ def test_rst_blocks(filetype, title, special, expected):
     file_conf, blocks, _ = parser._split_content(doc)
 
     assert len(blocks) == 4
-    assert blocks[2][0] == "text"
-    assert blocks[2][1] == expected
+    assert blocks[2].type == "text"
+    assert blocks[2].content == expected
 
 
 def test_cpp_file_to_rst():
@@ -226,14 +226,16 @@ int main(int argc, char** argv) {
     assert parser.language == "C++"
     assert file_conf == {"foobar": 14}
 
-    assert "First heading\n-------------\n\nThis is the start" in blocks[2][1]
+    assert "First heading\n-------------\n\nThis is the start" in blocks[2].content
 
-    assert "// This is just a comment" in blocks[3][1]
-    assert "secret" in blocks[3][1]
+    assert "// This is just a comment" in blocks[3].content
+    assert "secret" in blocks[3].content
 
-    assert "sphinx_gallery_foobar" in blocks[3][1]
-    assert "sphinx_gallery_foobar" not in parser.remove_config_comments(blocks[3][1])
+    assert "sphinx_gallery_foobar" in blocks[3].content
+    assert "sphinx_gallery_foobar" not in parser.remove_config_comments(
+        blocks[3].content
+    )
 
-    cleaned = parser.remove_ignore_blocks(blocks[3][1])
+    cleaned = parser.remove_ignore_blocks(blocks[3].content)
     assert "secret" not in cleaned
     assert "y == 4" in cleaned

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -75,8 +75,8 @@ def test_split_code_and_text_blocks():
     )
 
     assert file_conf == {}
-    assert blocks[0][0] == "text"
-    assert blocks[1][0] == "code"
+    assert blocks[0].type == "text"
+    assert blocks[1].type == "code"
 
 
 def test_bug_cases_of_notebook_syntax():
@@ -183,10 +183,10 @@ def test_rst_block_after_docstring(gallery_conf, tmpdir):
 
     assert file_conf == {}
     assert len(blocks) == 4
-    assert blocks[0][0] == "text"
-    assert blocks[1][0] == "text"
-    assert blocks[2][0] == "text"
-    assert blocks[3][0] == "text"
+    assert blocks[0].type == "text"
+    assert blocks[1].type == "text"
+    assert blocks[2].type == "text"
+    assert blocks[3].type == "text"
 
     script_vars = {"execute_script": ""}
     file_conf = {}
@@ -283,9 +283,9 @@ def test_rst_empty_code_block(gallery_conf, tmpdir):
 
     assert file_conf == {}
     assert len(blocks) == 3
-    assert blocks[0][0] == "text"
-    assert blocks[1][0] == "text"
-    assert blocks[2][0] == "code"
+    assert blocks[0].type == "text"
+    assert blocks[1].type == "text"
+    assert blocks[2].type == "code"
 
     gallery_conf["abort_on_example_error"] = True
     script_vars = dict(
@@ -335,8 +335,8 @@ b = 'foo'
         )
     file_conf, blocks = split_code_and_text_blocks(filename)
     assert len(blocks) == 2
-    assert blocks[0][0] == "text"
-    assert blocks[1][0] == "code"
+    assert blocks[0].type == "text"
+    assert blocks[1].type == "code"
     assert file_conf == {}
     script_vars = {
         "execute_script": True,


### PR DESCRIPTION
Small drive-by improvement as I'm digging through the code.