### PR TITLE
ENH: Use :doc: instead of :ref: to link to examples

### DIFF
--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -300,7 +300,7 @@ THUMBNAIL_TEMPLATE = """
   .. image:: /{thumbnail}
     :alt:
 
-  :ref:`sphx_glr_{ref_name}`
+  :doc:`{doc_name}`
 
 .. raw:: html
 
@@ -314,7 +314,7 @@ BACKREF_THUMBNAIL_TEMPLATE = (
     + """
 .. only:: not html
 
- * :ref:`sphx_glr_{ref_name}`
+ * :doc:`{doc_name}`
 """
 )
 
@@ -362,11 +362,11 @@ def _thumbnail_div(
     # Inside rst files forward slash defines paths
     thumb = thumb.replace(os.sep, "/")
 
-    ref_name = os.path.join(full_dir, fname).replace(os.sep, "_")
+    doc_name = "/" + (Path(full_dir) / fname).with_suffix("").as_posix()
 
     template = BACKREF_THUMBNAIL_TEMPLATE if is_backref else THUMBNAIL_TEMPLATE
     return template.format(
-        intro=escape(intro), thumbnail=thumb, title=title, ref_name=ref_name
+        intro=escape(intro), thumbnail=thumb, title=title, doc_name=doc_name
     )
 
 

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -22,7 +22,7 @@ REFERENCE = r"""
   .. image:: /fake_dir/images/thumb/sphx_glr_test_file_thumb.png
     :alt:
 
-  :ref:`sphx_glr_fake_dir_test_file.py`
+  :doc:`/fake_dir/test_file`
 
 .. raw:: html
 
@@ -79,7 +79,7 @@ def test_thumbnail_div(content, tooltip, is_backref):
         extra = """
 .. only:: not html
 
- * :ref:`sphx_glr_fake_dir_test_file.py`
+ * :doc:`/fake_dir/test_file`
 """
     else:
         extra = ""

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -1640,15 +1640,9 @@ def test_recommend_n_examples(sphinx_app):
     assert n_thumbnails == n_examples
 
     # Check the same 3 related examples are shown (can change when new examples added)
-    assert 'href="plot_webp.html#sphx-glr-auto-examples-plot-webp-py"' in related_html
-    assert (
-        'href="plot_command_line_args.html'
-        '#sphx-glr-auto-examples-plot-command-line-args-py"' in related_html
-    )
-    assert (
-        'href="plot_numpy_matplotlib.html'
-        '#sphx-glr-auto-examples-plot-numpy-matplotlib-py"' in related_html
-    )
+    assert 'href="plot_webp.html"' in related_html
+    assert 'href="plot_command_line_args.html"' in related_html
+    assert 'href="plot_numpy_matplotlib.html"' in related_html
 
 
 def test_sidebar_components_download_links(sphinx_app):

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -293,8 +293,8 @@ def _check_order(sphinx_app, key, expected_order=None):
     index_fname = Path(sphinx_app.outdir, "..", "ex", "index.rst")
     order = list()
     if key is None:
-        regex = r".*:ref:`sphx_glr_ex_(?:(?:first|second)-subsection_)?plot_(\d)\.py`"
-        locator = ":ref:"
+        regex = r".*:doc:`/ex/(?:(?:first|second)-subsection/)?plot_(\d)`"
+        locator = ":doc:"
     else:
         regex = rf".*:{key}=(\d):.*"
         locator = "sphx-glr-thumbcontainer"
@@ -816,7 +816,7 @@ def test_minigallery_multi_match(sphinx_app_wrapper):
     # Check thumbnail correct
     assert "_images/sphx_glr_plot_nested_thumb.png" in mg_html
     # Check href correct
-    assert "sphx-glr-ex-sub-folder-sub-sub-folder-plot-nested-py" in mg_html
+    assert 'href="ex/sub_folder/sub_sub_folder/plot_nested.html"' in mg_html
 
 
 def _get_minigallery_thumbnails(rst_fname):


### PR DESCRIPTION
The gallery overview page currently links to individual examples via `:ref:`.

Since every example is its own doc, linking via `:doc:` is actually simpler. This has the following advantages:

- The links in HTML becomes shorter. When :ref: generates a URL with an anchor, e.g. `/auto_examples/local_module.html#sphx-glr-auto-examples-local-module-py`, :doc: generates only the file part `/auto_examples/local_module.html`

  This also has a slightly different effect on the page position
  - https://sphinx-gallery.github.io/stable/auto_examples/plot_0_sin.html is at the top of the page
  - https://sphinx-gallery.github.io/stable/auto_examples/plot_0_sin.html#sphx-glr-auto-examples-plot-0-sin-py is slightly scrolled down to the heading
  
  IMHO it is better to start at the very top of the page.

- In preparatation of supporting user-defined ReST files as example inputs: we cannot rely that there's a suitable label available, so linking via :ref: would be cumbersome for pure-ReST inputs.