### PR TITLE
MNT: Add min scikit-learn doc build to CI

### DIFF
--- a/.circleci/build_docs_skl.sh
+++ b/.circleci/build_docs_skl.sh
@@ -35,5 +35,5 @@ pip install sphinx numpydoc matplotlib Pillow pandas \
 # Checkout scikit-learn main branch, to build docs from repo
 git clone git@github.com:scikit-learn/scikit-learn.git
 cd scikit-learn/doc
-export EXAMPLES_PATTERN="plot_grid_search_text_feature_extraction|plot_display_object_visualizations"
+export EXAMPLES_PATTERN="plot_grid_search_text_feature_extraction|plot_display_object_visualization"
 make html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
       - run:
           command: ./.circleci/build_docs_skl.sh
       - store_artifacts:
-          path: scikit-learn/doc/_build/html/
+          path: scikit-learn/doc/_build/html/stable
           destination: docs_skl
 
   deploy_dev:


### PR DESCRIPTION
Towards https://github.com/sphinx-gallery/sphinx-gallery/issues/1513

Builds a minimal version of the scikit-learn docs, with 2 examples:

* https://scikit-learn.org/dev/auto_examples/model_selection/plot_grid_search_text_feature_extraction.html
   * uses plotly
* https://scikit-learn.org/dev/auto_examples/miscellaneous/plot_display_object_visualization.html
   * standard mpl outputs and one of the only examples with a per-example config
  
Copied #1514