### PR TITLE
Small typo on the configuration page of documentation

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -471,7 +471,7 @@ themselves. To do this, you'd either need to make some change (e.g., add/delete
 a newline) to your example or delete the ``.md5`` file to force Sphinx-Gallery
 to rebuild the example. Instead, you can use the configuration value::
 
-    sphinx_gallery_conf = = {
+    sphinx_gallery_conf = {
         ...
         'run_stale_examples': True,
     }


### PR DESCRIPTION
There seems to be a spurious equal sign in one of the code-blocks of the [stale-example rerunning section](https://sphinx-gallery.github.io/stable/configuration.html#rerunning-stale-examples) section of the documentation of the project.

Sorry for the very small PR, this should be a quick fix. And thank you for your project.