### PR TITLE
WIP: Add support for matplotlib animation options

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -321,11 +321,9 @@ def _check_matplotlib_animations(gallery_conf, app):
                         ) from e
 
     gallery_conf["matplotlib_animations"] = {
-        "enabled": enabled, 
-        "format": fmt, 
-        "options": {
-            "set_rst_size":set_rst_size
-        }
+        "enabled": enabled,
+        "format": fmt,
+        "options": {"set_rst_size": set_rst_size},
     }
 
 

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -285,7 +285,7 @@ def _anim_rst(anim, image_path, gallery_conf):
     # relative_to doesn't work on windows
     # video_uri = video.relative_to(gallery_conf["src_dir"]).as_posix()
     video_uri = PurePosixPath(os.path.relpath(video, gallery_conf["src_dir"]))
-    if mpl_anim_opt["set_rst_size"]
+    if mpl_anim_opt["set_rst_size"]:
         html = _ANIMATION_VIDEO_RST.format(
             video=f"/{video_uri}",
             width=int(fig_size[0] * dpi),

--- a/sphinx_gallery/tests/tinybuild/doc/conf.py
+++ b/sphinx_gallery/tests/tinybuild/doc/conf.py
@@ -102,9 +102,9 @@ sphinx_gallery_conf = {
     "compress_images": ("images", "thumbnails"),
     "junit": op.join("sphinx-gallery", "junit-results.xml"),
     "matplotlib_animations": {
-        "enabled": True, 
-        "format": "mp4", 
-        "options": {"set_rst_size": False}
+        "enabled": True,
+        "format": "mp4",
+        "options": {"set_rst_size": False},
     },
     "pypandoc": True,
     "image_srcset": ["2x"],


### PR DESCRIPTION
Hi here is the PR (discussed in #1517 ) to allow toggling the `:height:` and `:width:` block for mp4 animations output.

The current state is partial as the `_check_matplotlib_animations` is not fully modified (no proper checking and backward compatibility yet). But the main change is the config is already set (and i'm looking for feedback on it).

TODO:

- [ ] Finish `_check_matplotlib_animations` and allow backward compatibility
- [ ] Test if there are side-effects
- [ ] Document that in the animation section
