### PR TITLE
Fix subsection header sanitization when `nested_sections=False`

### DIFF
--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -817,8 +817,12 @@ def generate_gallery_rst(app):
 
             has_subsection_header = False
             if subsection_index_content:
-                # Filter tags to prevent tag duplication across the documentation
-                indexst += _filter_tags(subsection_index_content)
+                if gallery_conf["nested_sections"]:
+                    # Filter tags to prevent tag duplication as subsection headers
+                    # are included in both root index and subsection index files
+                    indexst += _filter_tags(subsection_index_content)
+                else:
+                    indexst += subsection_index_content
                 has_subsection_header = True
 
             # Write subsection toctree containing all filenames, if req.

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -1103,3 +1103,27 @@ def test_create_jupyterlite_contents_with_modification(sphinx_app_wrapper):
             f"JupyterLite-specific change for {notebook_filename}"
             in first_cell["source"]
         )
+
+
+@pytest.mark.add_conf(
+    content="""
+sphinx_gallery_conf = {
+    'examples_dirs': 'src',
+    'gallery_dirs': 'ex',
+    'nested_sections': False,
+}"""
+)
+def test_nested_sections_false_sanitize(sphinx_app_wrapper):
+    """Check subsection headers not sanitized when `nested_sections=False`.
+
+    When `nested_sections=True`, we remove tags from subsection header in the
+    root index.rst file (but not in the subsection index.rst files), to prevent
+    tag duplication.
+    When `nested_sections=False`, we should not remove tags.
+    """
+    sphinx_app = sphinx_app_wrapper.build_sphinx_app()
+    index_fname = Path(sphinx_app.outdir, "..", "ex", "index.rst")
+    with open(index_fname, "r", encoding="utf-8") as fid:
+        rst = fid.read()
+
+    assert "my_added_first_sub_label" in rst

--- a/sphinx_gallery/tests/testconfs/src/first-subsection/GALLERY_HEADER.rst
+++ b/sphinx_gallery/tests/testconfs/src/first-subsection/GALLERY_HEADER.rst
@@ -1,2 +1,4 @@
+.. _my_added_first_sub_label:
+
 The First Subsection Test Gallery
 =================================


### PR DESCRIPTION
Fixes #1546

We should only remove tags (sanitize) subsection headers when `nested_sections=True` (as subsection headers are used twice, once in the root index.rst and once in the subsection index.rst).

When `nested_sections=False` we should not sanitize.

Had to do some digging in https://github.com/sphinx-gallery/sphinx-gallery/pull/904 to work out why we added the sanitize.

Again `nested_sections=False` was not tested at all in #904, we should have pushed for unit tests in #904 - our `sphinx_app_wrapper` is actually quite versatile.

Edit: note I checked that the test fails on main and passes with the changes