### PR TITLE
TST: Prefer Path over os.path in all test code

### DIFF
--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -2,11 +2,8 @@
 # License: 3-clause BSD
 """Test the SG pipeline used with Sphinx and tinybuild."""
 
-import codecs
-import glob
 import json
 import os
-import os.path as op
 import re
 import shutil
 import sys
@@ -121,22 +118,20 @@ def test_timings(sphinx_app):
     src_dir = sphinx_app.srcdir
 
     # local folder
-    timings_rst = op.join(src_dir, "auto_examples", "sg_execution_times.rst")
-    assert op.isfile(timings_rst)
-    with codecs.open(timings_rst, "r", "utf-8") as fid:
-        content = fid.read()
+    timings_rst = Path(src_dir, "auto_examples", "sg_execution_times.rst")
+    assert timings_rst.is_file()
+    content = timings_rst.read_text(encoding="utf-8")
     assert ":ref:`sphx_glr_auto_examples_plot_numpy_matplotlib.py`" in content
     parenthetical = "(``plot_numpy_matplotlib.py``)"
     assert parenthetical in content
     # HTML output
-    timings_html = op.join(out_dir, "auto_examples", "sg_execution_times.html")
-    assert op.isfile(timings_html)
-    with codecs.open(timings_html, "r", "utf-8") as fid:
-        content = fid.read()
+    timings_html = Path(out_dir, "auto_examples", "sg_execution_times.html")
+    assert timings_html.is_file()
+    content = timings_html.read_text(encoding="utf-8")
     assert 'href="plot_numpy_matplotlib.html' in content
     # printed
     status = sphinx_app._status.getvalue()
-    fname = op.join("..", "examples", "plot_numpy_matplotlib.py")
+    fname = Path("..", "examples", "plot_numpy_matplotlib.py")
     assert f"- {fname}: " in status
 
 
@@ -145,13 +140,12 @@ def test_api_usage(sphinx_app):
     out_dir = sphinx_app.outdir
     src_dir = sphinx_app.srcdir
     # the rst file was empty but is removed in post-processing
-    api_rst = op.join(src_dir, "sg_api_usage.rst")
-    assert not op.isfile(api_rst)
+    api_rst = Path(src_dir, "sg_api_usage.rst")
+    assert not api_rst.is_file()
     # HTML output
-    api_html = op.join(out_dir, "sg_api_usage.html")
-    assert op.isfile(api_html)
-    with codecs.open(api_html, "r", "utf-8") as fid:
-        content = fid.read()
+    api_html = Path(out_dir, "sg_api_usage.html")
+    assert api_html.is_file()
+    content = api_html.read_text(encoding="utf-8")
     has_graphviz = _has_graphviz()
     # spot check references
     assert (
@@ -172,7 +166,7 @@ def test_api_usage(sphinx_app):
         assert 'alt="sphinx_gallery usage graph"' not in content
     # printed
     status = sphinx_app._status.getvalue()
-    fname = op.join("..", "examples", "plot_numpy_matplotlib.py")
+    fname = Path("..", "examples", "plot_numpy_matplotlib.py")
     assert f"- {fname}: " in status
 
 
@@ -193,8 +187,7 @@ def test_junit(sphinx_app, tmp_path):
     out_dir = sphinx_app.outdir
     junit_file = Path(out_dir) / "sphinx-gallery" / "junit-results.xml"
     assert junit_file.is_file()
-    with open(junit_file, "rb") as fid:
-        contents = fid.read()
+    contents = junit_file.read_bytes()
     suite = lxml.etree.fromstring(contents)
     want = dict(
         errors="0",
@@ -288,12 +281,10 @@ def test_junit(sphinx_app, tmp_path):
 def test_run_sphinx(sphinx_app):
     """Test basic outputs."""
     out_dir = Path(sphinx_app.outdir)
-    out_files = os.listdir(out_dir)
-    assert "index.html" in out_files
-    assert "auto_examples" in out_files
-    assert "auto_examples_with_rst" in out_files
-    assert "auto_examples_rst_index" in out_files
-    assert "auto_examples_README_header" in out_files
+    assert (out_dir / "index.html").is_file()
+    assert (out_dir / "auto_examples_with_rst").is_dir()
+    assert (out_dir / "auto_examples_rst_index").is_dir()
+    assert (out_dir / "auto_examples_README_header").is_dir()
     generated_examples_dir = out_dir / "auto_examples"
     assert generated_examples_dir.is_dir()
     # make sure that indices are properly being passed forward...
@@ -326,8 +317,8 @@ def test_thumbnail_path(sphinx_app, tmp_path):
     from PIL import Image
 
     # Make sure our thumbnail matches what it should be
-    fname_orig = op.join(sphinx_app.srcdir, "_static_nonstandard", "demo.png")
-    fname_thumb = op.join(
+    fname_orig = str(Path(sphinx_app.srcdir, "_static_nonstandard", "demo.png"))
+    fname_thumb = Path(
         sphinx_app.outdir, "_images", "sphx_glr_plot_second_future_imports_thumb.png"
     )
     fname_new = str(tmp_path / "new.png")
@@ -348,10 +339,10 @@ def test_negative_thumbnail_config(sphinx_app, tmp_path):
     from PIL import Image
 
     # Make sure our thumbnail is the 2nd (last) image
-    fname_orig = op.join(
-        sphinx_app.outdir, "_images", "sphx_glr_plot_matplotlib_alt_002.png"
+    fname_orig = str(
+        Path(sphinx_app.outdir, "_images", "sphx_glr_plot_matplotlib_alt_002.png")
     )
-    fname_thumb = op.join(
+    fname_thumb = Path(
         sphinx_app.outdir, "_images", "sphx_glr_plot_matplotlib_alt_thumb.png"
     )
     fname_new = str(tmp_path / "new.png")
@@ -372,8 +363,8 @@ def test_thumbnail_expected_failing_examples(sphinx_app, tmp_path):
     from PIL import Image
 
     # Get the "BROKEN" stamp for the default failing example thumbnail
-    stamp_fname = op.join(
-        sphinx_app.srcdir, "_static_nonstandard", "broken_example.png"
+    stamp_fname = str(
+        Path(sphinx_app.srcdir, "_static_nonstandard", "broken_example.png")
     )
     stamp_fname_scaled = str(tmp_path / "new.png")
     scale_image(
@@ -386,7 +377,7 @@ def test_thumbnail_expected_failing_examples(sphinx_app, tmp_path):
 
     # Get thumbnail from example with failing example thumbnail behaviour
     # (i.e. thumbnail should be "BROKEN" stamp)
-    thumb_fname = op.join(
+    thumb_fname = Path(
         sphinx_app.outdir, "_images", "sphx_glr_plot_failing_example_thumb.png"
     )
     thumbnail = np.asarray(Image.open(thumb_fname))
@@ -396,7 +387,7 @@ def test_thumbnail_expected_failing_examples(sphinx_app, tmp_path):
 
     # Get thumbnail from example with default thumbnail behaviour
     # (i.e. thumbnail should be the plot from the example, not the "BROKEN" stamp)
-    thumb_fname = op.join(
+    thumb_fname = Path(
         sphinx_app.outdir,
         "_images",
         "sphx_glr_plot_failing_example_thumbnail_thumb.png",
@@ -409,19 +400,17 @@ def test_thumbnail_expected_failing_examples(sphinx_app, tmp_path):
 
 def test_multi_image(sphinx_app):
     """Test `sphinx_gallery_multi_image(_block)` variables."""
-    generated_examples_dir = op.join(sphinx_app.outdir, "auto_examples")
+    generated_examples_dir = Path(sphinx_app.outdir, "auto_examples")
 
     # Check file-wide `sphinx_gallery_multi_image="single"` produces no multi-img
-    html_fname = op.join(generated_examples_dir, "plot_multi_image_separate.html")
-    with codecs.open(html_fname, "r", "utf-8") as fid:
-        html = fid.read()
+    html_fname = generated_examples_dir / "plot_multi_image_separate.html"
+    html = html_fname.read_text(encoding="utf-8")
     assert "sphx-glr-single-img" in html
     assert "sphx-glr-multi-img" not in html
 
     # Check block-specific `sphinx_gallery_multi_image_block` produces mixed img classes
-    html_fname = op.join(generated_examples_dir, "plot_multi_image_block_separate.html")
-    with codecs.open(html_fname, "r", "utf-8") as fid:
-        html = fid.read()
+    html_fname = generated_examples_dir / "plot_multi_image_block_separate.html"
+    html = html_fname.read_text(encoding="utf-8")
     # find start of each code block
     matches = re.finditer('<div class="highlight-Python notranslate">', html)
     starts = [match.start() for match in matches] + [-1]
@@ -438,18 +427,17 @@ def test_multi_image(sphinx_app):
 
 
 def test_command_line_args_img(sphinx_app):
-    generated_examples_dir = op.join(sphinx_app.outdir, "auto_examples")
+    generated_examples_dir = Path(sphinx_app.outdir, "auto_examples")
     thumb_fname = "../_images/sphx_glr_plot_command_line_args_thumb.png"
-    file_fname = op.join(generated_examples_dir, thumb_fname)
-    assert op.isfile(file_fname), file_fname
+    file_fname = generated_examples_dir / thumb_fname
+    assert file_fname.is_file(), file_fname
 
 
 def test_image_formats(sphinx_app):
     """Test Image format support."""
-    generated_examples_dir = op.join(sphinx_app.outdir, "auto_examples")
-    generated_examples_index = op.join(generated_examples_dir, "index.html")
-    with codecs.open(generated_examples_index, "r", "utf-8") as fid:
-        html = fid.read()
+    generated_examples_dir = Path(sphinx_app.outdir, "auto_examples")
+    generated_examples_index = generated_examples_dir / "index.html"
+    html = generated_examples_index.read_text(encoding="utf-8")
     thumb_fnames = [
         "../_images/sphx_glr_plot_svg_thumb.svg",
         "../_images/sphx_glr_plot_numpy_matplotlib_thumb.png",
@@ -457,8 +445,8 @@ def test_image_formats(sphinx_app):
         "../_images/sphx_glr_plot_webp_thumb.webp",
     ]
     for thumb_fname in thumb_fnames:
-        file_fname = op.join(generated_examples_dir, thumb_fname)
-        assert op.isfile(file_fname), file_fname
+        file_fname = generated_examples_dir / thumb_fname
+        assert file_fname.is_file(), file_fname
         want_html = f'src="{thumb_fname}"'
         assert want_html in html
     # the original GIF does not get copied because it's not used in the
@@ -470,29 +458,27 @@ def test_image_formats(sphinx_app):
         ("plot_animation", "mp4", [2]),
         ("plot_webp", "webp", [1]),
     ):
-        html_fname = op.join(generated_examples_dir, f"{ex}.html")
-        with codecs.open(html_fname, "r", "utf-8") as fid:
-            html = fid.read()
+        html_fname = generated_examples_dir / f"{ex}.html"
+        html = html_fname.read_text(encoding="utf-8")
         for num in nums:
             img_fname0 = f"../_images/sphx_glr_{ex}_{num:03}.{ext}"
-            file_fname = op.join(generated_examples_dir, img_fname0)
-            assert op.isfile(file_fname), file_fname
+            file_fname = generated_examples_dir / img_fname0
+            assert file_fname.is_file(), file_fname
             want_html = f'src="{img_fname0}"'
             assert want_html in html
             img_fname2 = f"../_images/sphx_glr_{ex}_{num:03}_2_00x.{ext}"
-            file_fname2 = op.join(generated_examples_dir, img_fname2)
+            file_fname2 = generated_examples_dir / img_fname2
             want_html = f'srcset="{img_fname0}, {img_fname2} 2.00x"'
             if ext in ("png", "jpg", "svg", "webp"):
                 # check 2.00x (tests directive)
-                assert op.isfile(file_fname2), file_fname2
+                assert file_fname2.is_file(), file_fname2
                 assert want_html in html
 
 
 def test_repr_html_classes(sphinx_app):
     """Test appropriate _repr_html_ classes."""
-    example_file = op.join(sphinx_app.outdir, "auto_examples", "plot_repr.html")
-    with codecs.open(example_file, "r", "utf-8") as fid:
-        lines = fid.read()
+    example_file = Path(sphinx_app.outdir, "auto_examples", "plot_repr.html")
+    lines = example_file.read_text(encoding="utf-8")
     assert 'div class="output_subarea output_html rendered_html output_result"' in lines
     assert "gallery-rendered-html.css" in lines
 
@@ -501,13 +487,11 @@ def test_embed_links_and_styles(sphinx_app):
     """Test that links and styles are embedded properly in doc."""
     out_dir = sphinx_app.outdir
     src_dir = sphinx_app.srcdir
-    examples_dir = op.join(out_dir, "auto_examples")
-    assert op.isdir(examples_dir)
-    example_files = os.listdir(examples_dir)
-    assert "plot_numpy_matplotlib.html" in example_files
-    example_file = op.join(examples_dir, "plot_numpy_matplotlib.html")
-    with codecs.open(example_file, "r", "utf-8") as fid:
-        lines = fid.read()
+    examples_dir = Path(out_dir, "auto_examples")
+    assert examples_dir.is_dir()
+    assert (examples_dir / "plot_numpy_matplotlib.html").is_file()
+    example_file = examples_dir / "plot_numpy_matplotlib.html"
+    lines = example_file.read_text(encoding="utf-8")
     # ensure we've linked properly
     assert "#module-matplotlib.colors" in lines
     assert "matplotlib.colors.is_color_like" in lines
@@ -635,10 +619,9 @@ def test_embed_links_and_styles(sphinx_app):
         )  # noqa:E501
 
     # highlight language
-    fname = op.join(src_dir, "auto_examples", "plot_numpy_matplotlib.rst")
-    assert op.isfile(fname)
-    with codecs.open(fname, "r", "utf-8") as fid:
-        rst = fid.read()
+    fname = Path(src_dir, "auto_examples", "plot_numpy_matplotlib.rst")
+    assert fname.is_file()
+    rst = fname.read_text(encoding="utf-8")
     assert ".. code-block:: Python\n" in rst
 
     # warnings
@@ -649,30 +632,27 @@ def test_embed_links_and_styles(sphinx_app):
     assert re.match(want_warn, lines, re.DOTALL) is not None
     sys.stdout.write(lines)
 
-    lines = (Path(examples_dir) / "plot_pickle.html").read_text("utf-8")
+    lines = (examples_dir / "plot_pickle.html").read_text("utf-8")
     assert "joblib.Parallel.html" in lines
 
 
 def test_backreferences(sphinx_app):
     """Test backreferences."""
-    out_dir = sphinx_app.outdir
-    mod_file = op.join(out_dir, "gen_modules", "sphinx_gallery.sorting.html")
-    with codecs.open(mod_file, "r", "utf-8") as fid:
-        lines = fid.read()
+    out_dir = Path(sphinx_app.outdir)
+    mod_file = out_dir / "gen_modules" / "sphinx_gallery.sorting.html"
+    lines = mod_file.read_text(encoding="utf-8")
     assert "ExplicitOrder" in lines  # in API doc
     assert "plot_second_future_imports.html" in lines  # backref via code use
     assert "FileNameSortKey" in lines  # in API doc
     assert "plot_numpy_matplotlib.html" in lines  # backref via :class: in str
-    mod_file = op.join(out_dir, "gen_modules", "sphinx_gallery.backreferences.html")
-    with codecs.open(mod_file, "r", "utf-8") as fid:
-        lines = fid.read()
+    mod_file = out_dir / "gen_modules" / "sphinx_gallery.backreferences.html"
+    lines = mod_file.read_text(encoding="utf-8")
     assert "NameFinder" in lines  # in API doc
     assert "plot_future_imports.html" in lines  # backref via doc block
     # rendered file
-    html = op.join(out_dir, "auto_examples", "plot_second_future_imports.html")
-    assert op.isfile(html)
-    with codecs.open(html, "r", "utf-8") as fid:
-        html = fid.read()
+    html_file = out_dir / "auto_examples" / "plot_second_future_imports.html"
+    assert html_file.is_file()
+    html = html_file.read_text(encoding="utf-8")
     assert "sphinx_gallery.sorting.html#sphinx_gallery.sorting.ExplicitOrder" in html  # noqa: E501
     assert "sphinx_gallery.scrapers.html#sphinx_gallery.scrapers.clean_modules" in html  # noqa: E501
     assert "figure_rst.html" not in html  # excluded
@@ -680,26 +660,21 @@ def test_backreferences(sphinx_app):
 
 def test_backreferences_dirhtml(sphinx_dirhtml_app):
     """Test backreferences in dirhtml doc."""
-    out_dir = sphinx_dirhtml_app.outdir
-    mod_file = op.join(out_dir, "gen_modules", "sphinx_gallery.sorting", "index.html")
-    with codecs.open(mod_file, "r", "utf-8") as fid:
-        lines = fid.read()
+    out_dir = Path(sphinx_dirhtml_app.outdir)
+    mod_file = out_dir / "gen_modules" / "sphinx_gallery.sorting" / "index.html"
+    lines = mod_file.read_text(encoding="utf-8")
     assert "ExplicitOrder" in lines  # in API doc
     assert "plot_second_future_imports/" in lines  # backref via code use
     assert "FileNameSortKey" in lines  # in API doc
     assert "plot_numpy_matplotlib/" in lines  # backref via :class: in str
-    mod_file = op.join(
-        out_dir, "gen_modules", "sphinx_gallery.backreferences", "index.html"
-    )
-    with codecs.open(mod_file, "r", "utf-8") as fid:
-        lines = fid.read()
+    mod_file = out_dir / "gen_modules" / "sphinx_gallery.backreferences" / "index.html"
+    lines = mod_file.read_text(encoding="utf-8")
     assert "NameFinder" in lines  # in API doc
     assert "plot_future_imports/" in lines  # backref via doc block
     # rendered file
-    html = op.join(out_dir, "auto_examples", "plot_second_future_imports", "index.html")
-    assert op.isfile(html)
-    with codecs.open(html, "r", "utf-8") as fid:
-        html = fid.read()
+    html_file = out_dir / "auto_examples" / "plot_second_future_imports" / "index.html"
+    assert html_file.is_file()
+    html = html_file.read_text(encoding="utf-8")
     assert "sphinx_gallery.sorting/#sphinx_gallery.sorting.ExplicitOrder" in html  # noqa: E501
     assert "sphinx_gallery.scrapers/#sphinx_gallery.scrapers.clean_modules" in html  # noqa: E501
     assert "figure_rst.html" not in html  # excluded
@@ -723,9 +698,8 @@ def test_backreferences_dirhtml(sphinx_dirhtml_app):
 def test_backreferences_examples_rst(sphinx_app, rst_file, example_used_in):
     """Test linking to mini-galleries using backreferences_dir."""
     backref_dir = sphinx_app.srcdir
-    examples_rst = op.join(backref_dir, "gen_modules", "backreferences", rst_file)
-    with codecs.open(examples_rst, "r", "utf-8") as fid:
-        lines = fid.read()
+    examples_rst = Path(backref_dir, "gen_modules", "backreferences", rst_file)
+    lines = examples_rst.read_text(encoding="utf-8")
     assert example_used_in in lines
     # check the .. raw:: html div count
     n_open = lines.count("<div")
@@ -735,11 +709,10 @@ def test_backreferences_examples_rst(sphinx_app, rst_file, example_used_in):
 
 def test_backreferences_examples_html(sphinx_app):
     """Test linking to mini-galleries using backreferences_dir."""
-    backref_file = op.join(
+    backref_file = Path(
         sphinx_app.outdir, "gen_modules", "sphinx_gallery.backreferences.html"
     )
-    with codecs.open(backref_file, "r", "utf-8") as fid:
-        lines = fid.read()
+    lines = backref_file.read_text(encoding="utf-8")
     # Class properties not properly checked on older Sphinx (e.g. 3)
     # so let's use the "id" instead
     regex = re.compile(r'<dt[ \S]*id="sphinx_gallery.backreferences.[ \S]*>')
@@ -764,11 +737,8 @@ def test_backreferences_examples_html(sphinx_app):
     n_close = lines.count("</div")
     assert n_open == n_close  # should always be equal
 
-    backref_file = op.join(
-        sphinx_app.outdir, "gen_modules", "sphinx_gallery._dummy.html"
-    )
-    with codecs.open(backref_file, "r", "utf-8") as fid:
-        lines = fid.read()
+    backref_file = Path(sphinx_app.outdir, "gen_modules", "sphinx_gallery._dummy.html")
+    lines = backref_file.read_text(encoding="utf-8")
     # Class properties not properly checked on older Sphinx (e.g. 3)
     # so let's use the "id" instead
     regex = re.compile(r'<dt[ \S]*id="sphinx_gallery._dummy.[ \S]*>')
@@ -790,11 +760,10 @@ def test_backreferences_examples_html(sphinx_app):
     n_close = lines.count("</div")
     assert n_open == n_close  # should always be equal
 
-    backref_file = op.join(
+    backref_file = Path(
         sphinx_app.outdir, "gen_modules", "sphinx_gallery._dummy.nested.html"
     )
-    with codecs.open(backref_file, "r", "utf-8") as fid:
-        lines = fid.read()
+    lines = backref_file.read_text(encoding="utf-8")
     # Class properties not properly checked on older Sphinx (e.g. 3)
     # so let's use the "id" instead
     regex = re.compile(r'<dt[ \S]*id="sphinx_gallery._dummy.nested.[ \S]*>')
@@ -819,9 +788,8 @@ def test_backreferences_examples_html(sphinx_app):
 
 def test_logging_std_nested(sphinx_app):
     """Test that nested stdout/stderr uses within a given script work."""
-    log_rst = op.join(sphinx_app.srcdir, "auto_examples", "plot_log.rst")
-    with codecs.open(log_rst, "r", "utf-8") as fid:
-        lines = fid.read()
+    log_rst = Path(sphinx_app.srcdir, "auto_examples", "plot_log.rst")
+    lines = log_rst.read_text(encoding="utf-8")
     assert ".. code-block:: none\n\n    is in the same cell" in lines
     assert ".. code-block:: none\n\n    is not in the same cell" in lines
 
@@ -902,9 +870,9 @@ def test_rebuild(tmp_path_factory, sphinx_app):
     assert len(copied_py_0) > 0
     assert len(copied_ipy_0) > 0
     assert len(sphinx_app.config.sphinx_gallery_conf["stale_examples"]) == 0
-    assert op.isfile(
-        op.join(sphinx_app.outdir, "_images", "sphx_glr_plot_numpy_matplotlib_001.png")
-    )
+    assert Path(
+        sphinx_app.outdir, "_images", "sphx_glr_plot_numpy_matplotlib_001.png"
+    ).is_file()
 
     #
     # run a second time, no files should be updated
@@ -913,8 +881,8 @@ def test_rebuild(tmp_path_factory, sphinx_app):
     src_dir = sphinx_app.srcdir
     del sphinx_app  # don't accidentally use it below
     conf_dir = src_dir
-    out_dir = op.join(src_dir, "_build", "html")
-    toctrees_dir = op.join(src_dir, "_build", "toctrees")
+    out_dir = Path(src_dir, "_build", "html")
+    toctrees_dir = Path(src_dir, "_build", "toctrees")
     time.sleep(0.1)
     with docutils_namespace():
         new_app = Sphinx(
@@ -954,9 +922,9 @@ def test_rebuild(tmp_path_factory, sphinx_app):
     assert re.match(want, status, re.MULTILINE | re.DOTALL) is not None
     n_stale = len(new_app.config.sphinx_gallery_conf["stale_examples"])
     assert n_stale == N_GOOD
-    assert op.isfile(
-        op.join(new_app.outdir, "_images", "sphx_glr_plot_numpy_matplotlib_001.png")
-    )
+    assert Path(
+        new_app.outdir, "_images", "sphx_glr_plot_numpy_matplotlib_001.png"
+    ).is_file()
 
     generated_modules_1 = sorted(
         f for f in Path(new_app.srcdir, "gen_modules").iterdir() if f.is_file()
@@ -1056,10 +1024,9 @@ def _rerun(
     time.sleep(0.1)
     confoverrides = dict()
     if how == "modify":
-        fname = op.join(src_dir, "../examples", "plot_numpy_matplotlib.py")
-        with codecs.open(fname, "r", "utf-8") as fid:
-            lines = fid.readlines()
-        with codecs.open(fname, "w", "utf-8") as fid:
+        fname = Path(src_dir, "../examples", "plot_numpy_matplotlib.py")
+        lines = fname.read_text(encoding="utf-8").splitlines(keepends=True)
+        with fname.open("w", encoding="utf-8") as fid:
             for line in lines:
                 # Make a tiny change that won't affect the recommender
                 if "FYI this" in line:
@@ -1128,9 +1095,9 @@ def _rerun(
     assert re.match(want, status, flags) is not None
     got_stale = len(new_app.config.sphinx_gallery_conf["stale_examples"])
     assert got_stale == n_stale
-    assert op.isfile(
-        op.join(new_app.outdir, "_images", "sphx_glr_plot_numpy_matplotlib_001.png")
-    )
+    assert Path(
+        new_app.outdir, "_images", "sphx_glr_plot_numpy_matplotlib_001.png"
+    ).is_file()
 
     generated_modules_1 = sorted(
         f for f in Path(new_app.srcdir, "gen_modules").iterdir() if f.is_file()
@@ -1216,7 +1183,7 @@ def _rerun(
 def test_error_messages(sphinx_app, name, want):
     """Test that informative error messages are added."""
     src_dir = Path(sphinx_app.srcdir)
-    rst = (src_dir / "auto_examples" / (name + ".rst")).read_text("utf-8")
+    rst = (src_dir / "auto_examples" / f"{name}.rst").read_text("utf-8")
     assert re.match(want, rst, re.DOTALL) is not None, f"{name} should have had: {want}"
 
 
@@ -1238,9 +1205,8 @@ def test_error_messages(sphinx_app, name, want):
 def test_error_messages_dirhtml(sphinx_dirhtml_app, name, want):
     """Test that informative error messages are added."""
     src_dir = sphinx_dirhtml_app.srcdir
-    example_rst = op.join(src_dir, "auto_examples", name + ".rst")
-    with codecs.open(example_rst, "r", "utf-8") as fid:
-        rst = fid.read()
+    example_rst = Path(src_dir, "auto_examples", f"{name}.rst")
+    rst = example_rst.read_text(encoding="utf-8")
     rst = rst.replace("\n", " ")
     assert re.match(want, rst) is not None
 
@@ -1250,23 +1216,20 @@ def test_alt_text_image(sphinx_app):
     out_dir = sphinx_app.outdir
     src_dir = sphinx_app.srcdir
     # alt text is fig titles, rst
-    example_rst = op.join(src_dir, "auto_examples", "plot_matplotlib_alt.rst")
-    with codecs.open(example_rst, "r", "utf-8") as fid:
-        rst = fid.read()
+    example_rst = Path(src_dir, "auto_examples", "plot_matplotlib_alt.rst")
+    rst = example_rst.read_text(encoding="utf-8")
     # suptitle and axes titles
     assert ":alt: This is a sup title, subplot 1, subplot 2" in rst
     # multiple titles
     assert ":alt: Left Title, Center Title, Right Title" in rst
 
     # no fig title - alt text is file name, rst
-    example_rst = op.join(src_dir, "auto_examples", "plot_numpy_matplotlib.rst")
-    with codecs.open(example_rst, "r", "utf-8") as fid:
-        rst = fid.read()
+    example_rst = Path(src_dir, "auto_examples", "plot_numpy_matplotlib.rst")
+    rst = example_rst.read_text(encoding="utf-8")
     assert ":alt: plot numpy matplotlib" in rst
     # html
-    example_html = op.join(out_dir, "auto_examples", "plot_numpy_matplotlib.html")
-    with codecs.open(example_html, "r", "utf-8") as fid:
-        html = fid.read()
+    example_html = Path(out_dir, "auto_examples", "plot_numpy_matplotlib.html")
+    html = example_html.read_text(encoding="utf-8")
     assert 'alt="plot numpy matplotlib"' in html
 
 
@@ -1275,19 +1238,16 @@ def test_alt_text_thumbnail(sphinx_app):
     out_dir = sphinx_app.outdir
     src_dir = sphinx_app.srcdir
     # check gallery index thumbnail, html
-    generated_examples_index = op.join(out_dir, "auto_examples", "index.html")
-    with codecs.open(generated_examples_index, "r", "utf-8") as fid:
-        html = fid.read()
+    generated_examples_index = Path(out_dir, "auto_examples", "index.html")
+    html = generated_examples_index.read_text(encoding="utf-8")
     assert 'alt=""' in html
     # check backreferences thumbnail, html
-    backref_html = op.join(out_dir, "gen_modules", "sphinx_gallery.backreferences.html")
-    with codecs.open(backref_html, "r", "utf-8") as fid:
-        html = fid.read()
+    backref_html = Path(out_dir, "gen_modules", "sphinx_gallery.backreferences.html")
+    html = backref_html.read_text(encoding="utf-8")
     assert 'alt=""' in html
     # check gallery index thumbnail, rst
-    generated_examples_index = op.join(src_dir, "auto_examples", "index.rst")
-    with codecs.open(generated_examples_index, "r", "utf-8") as fid:
-        rst = fid.read()
+    generated_examples_index = Path(src_dir, "auto_examples", "index.rst")
+    rst = generated_examples_index.read_text(encoding="utf-8")
     assert ":alt:" in rst
 
 
@@ -1295,9 +1255,8 @@ def test_noqa_removal(sphinx_app):
     """Test that "noqa: E501" is removed from end of text blocks."""
     src_dir = sphinx_app.srcdir
 
-    example_rst = op.join(src_dir, "auto_examples", "plot_matplotlib_alt.rst")
-    with codecs.open(example_rst, "r", "utf-8") as fid:
-        rst = fid.read()
+    example_rst = Path(src_dir, "auto_examples", "plot_matplotlib_alt.rst")
+    rst = example_rst.read_text(encoding="utf-8")
     assert "# noqa: E501" not in rst
 
 
@@ -1306,15 +1265,13 @@ def test_backreference_labels(sphinx_app):
     src_dir = sphinx_app.srcdir
     out_dir = sphinx_app.outdir
     # Test backreference label
-    backref_rst = op.join(src_dir, "gen_modules", "sphinx_gallery.backreferences.rst")
-    with codecs.open(backref_rst, "r", "utf-8") as fid:
-        rst = fid.read()
+    backref_rst = Path(src_dir, "gen_modules", "sphinx_gallery.backreferences.rst")
+    rst = backref_rst.read_text(encoding="utf-8")
     label = ".. _sphx_glr_backref_sphinx_gallery.backreferences.identify_names:"  # noqa: E501
     assert label in rst
     # Test html link
-    index_html = op.join(out_dir, "index.html")
-    with codecs.open(index_html, "r", "utf-8") as fid:
-        html = fid.read()
+    index_html = Path(out_dir, "index.html")
+    html = index_html.read_text(encoding="utf-8")
     link = 'href="gen_modules/sphinx_gallery.backreferences.html#sphx-glr-backref-sphinx-gallery-backreferences-identify-names">'  # noqa: E501
     assert link in html
 
@@ -1322,9 +1279,8 @@ def test_backreference_labels(sphinx_app):
 @pytest.fixture(scope="module")
 def minigallery_tree(sphinx_app):
     out_dir = sphinx_app.outdir
-    minigallery_html = op.join(out_dir, "minigallery.html")
-    with codecs.open(minigallery_html, "r", "utf-8") as fid:
-        tree = lxml.html.fromstring(fid.read())
+    minigallery_html = Path(out_dir, "minigallery.html")
+    tree = lxml.html.fromstring(minigallery_html.read_text(encoding="utf-8"))
 
     names = tree.xpath('//p[starts-with(text(), "Test")]')
     divs = tree.find_class("sphx-glr-thumbnails")
@@ -1455,9 +1411,8 @@ def test_minigallery_duplicates(minigallery_tree):
 def test_matplotlib_warning_filter(sphinx_app):
     """Test Matplotlib agg warning is removed."""
     out_dir = sphinx_app.outdir
-    example_html = op.join(out_dir, "auto_examples", "plot_matplotlib_alt.html")
-    with codecs.open(example_html, "r", "utf-8") as fid:
-        html = fid.read()
+    example_html = Path(out_dir, "auto_examples", "plot_matplotlib_alt.html")
+    html = example_html.read_text(encoding="utf-8")
     warning = (
         "Matplotlib is currently using agg, which is a"
         " non-GUI backend, so cannot show the figure."
@@ -1470,9 +1425,8 @@ def test_matplotlib_warning_filter(sphinx_app):
 def test_jupyter_notebook_pandoc(sphinx_app):
     """Test using pypandoc."""
     src_dir = sphinx_app.srcdir
-    fname = op.join(src_dir, "auto_examples", "plot_numpy_matplotlib.ipynb")
-    with codecs.open(fname, "r", "utf-8") as fid:
-        md = fid.read()
+    fname = Path(src_dir, "auto_examples", "plot_numpy_matplotlib.ipynb")
+    md = fname.read_text(encoding="utf-8")
 
     md_sg = r"Use :mod:`sphinx_gallery` to link to other packages, like\n:mod:`numpy`, :mod:`matplotlib.colors`, and :mod:`matplotlib.pyplot`."  # noqa
     md_pandoc = r"Use `sphinx_gallery`{.interpreted-text role=\"mod\"} to link to other\npackages, like `numpy`{.interpreted-text role=\"mod\"},\n`matplotlib.colors`{.interpreted-text role=\"mod\"}, and\n`matplotlib.pyplot`{.interpreted-text role=\"mod\"}."  # noqa
@@ -1486,19 +1440,17 @@ def test_jupyter_notebook_pandoc(sphinx_app):
 def test_md5_hash(sphinx_app):
     """Test MD5 hashing."""
     src_dir = sphinx_app.srcdir
-    fname = op.join(src_dir, "auto_examples", "plot_log.py.md5")
+    fname = Path(src_dir, "auto_examples", "plot_log.py.md5")
     expected_md5 = "0edc2de97f96f3b55f8b4a21994931a8"
-    with open(fname) as md5_file:
-        actual_md5 = md5_file.read()
+    actual_md5 = fname.read_text()
 
     assert actual_md5 == expected_md5
 
 
 def test_interactive_example_logo_exists(sphinx_app):
     """Test that the binder logo path is correct."""
-    root = op.join(sphinx_app.outdir, "auto_examples")
-    with codecs.open(op.join(root, "plot_svg.html"), "r", "utf-8") as fid:
-        html = fid.read()
+    root = Path(sphinx_app.outdir, "auto_examples")
+    html = (root / "plot_svg.html").read_text(encoding="utf-8")
     img_strs = "\n" + "\n".join(re.findall("<img [^>]+>", html, re.DOTALL))
     path = re.match(
         r'.*<img alt="Launch binder" src="([^"]+)" (width|style)=[^/>]+\/>.*',
@@ -1507,9 +1459,9 @@ def test_interactive_example_logo_exists(sphinx_app):
     )
     assert path is not None, img_strs
     path = path.groups()[0]
-    img_fname = op.abspath(op.join(root, path))
-    assert "binder_badge_logo" in img_fname  # can have numbers appended
-    assert op.isfile(img_fname)
+    img_fname = (root / path).absolute()
+    assert "binder_badge_logo" in str(img_fname)  # can have numbers appended
+    assert img_fname.is_file()
     assert (
         "https://mybinder.org/v2/gh/sphinx-gallery/sphinx-gallery.github.io/master?urlpath=lab/tree/notebooks/auto_examples/plot_svg.ipynb"
         in html
@@ -1522,16 +1474,15 @@ def test_interactive_example_logo_exists(sphinx_app):
     )
     assert path is not None
     path = path.groups()[0]
-    img_fname = op.abspath(op.join(root, path))
-    assert "jupyterlite_badge_logo" in img_fname  # can have numbers appended
-    assert op.isfile(img_fname)
+    img_fname = (root / path).absolute()
+    assert "jupyterlite_badge_logo" in str(img_fname)  # can have numbers appended
+    assert img_fname.is_file()
 
 
 def test_download_and_interactive_note(sphinx_app):
     """Test text saying go to the end to download code or run the example."""
-    root = op.join(sphinx_app.outdir, "auto_examples")
-    with codecs.open(op.join(root, "plot_svg.html"), "r", "utf-8") as fid:
-        html = fid.read()
+    root = Path(sphinx_app.outdir, "auto_examples")
+    html = (root / "plot_svg.html").read_text(encoding="utf-8")
 
     pattern = (
         r"to download the full example.+" r"in your browser via JupyterLite or Binder"
@@ -1541,10 +1492,9 @@ def test_download_and_interactive_note(sphinx_app):
 
 def test_defer_figures(sphinx_app):
     """Test the deferring of figures."""
-    root = op.join(sphinx_app.outdir, "auto_examples")
-    fname = op.join(root, "plot_defer_figures.html")
-    with codecs.open(fname, "r", "utf-8") as fid:
-        html = fid.read()
+    root = Path(sphinx_app.outdir, "auto_examples")
+    fname = root / "plot_defer_figures.html"
+    html = fname.read_text(encoding="utf-8")
 
     # The example has two code blocks with plotting commands, but the first
     # block has the flag ``sphinx_gallery_defer_figures``.  Thus, there should
@@ -1555,27 +1505,21 @@ def test_defer_figures(sphinx_app):
 
 def test_no_dummy_image(sphinx_app):
     """Test sphinx_gallery_dummy_images NOT created when executable is True."""
-    img1 = op.join(
+    img1 = Path(
         sphinx_app.srcdir, "auto_examples", "images", "sphx_glr_plot_repr_001.png"
     )
-    img2 = op.join(
+    img2 = Path(
         sphinx_app.srcdir, "auto_examples", "images", "sphx_glr_plot_repr_002.png"
     )
-    assert not op.isfile(img1)
-    assert not op.isfile(img2)
+    assert not img1.is_file()
+    assert not img2.is_file()
 
 
 def test_jupyterlite_modifications(sphinx_app):
     src_dir = sphinx_app.srcdir
-    jupyterlite_notebook_pattern = op.join(
-        src_dir, "jupyterlite_contents", "**", "*.ipynb"
-    )
-    jupyterlite_notebook_filenames = glob.glob(
-        jupyterlite_notebook_pattern, recursive=True
-    )
 
-    for notebook_filename in jupyterlite_notebook_filenames:
-        with open(notebook_filename) as f:
+    for notebook_filename in Path(src_dir, "jupyterlite_contents").rglob("*.ipynb"):
+        with notebook_filename.open() as f:
             notebook_content = json.load(f)
 
         first_cell = notebook_content["cells"][0]
@@ -1616,10 +1560,9 @@ def test_julia_rst(sphinx_app):
 def test_recommend_n_examples(sphinx_app):
     """Test correct thumbnails are displayed for an example."""
     pytest.importorskip("numpy")
-    root = op.join(sphinx_app.outdir, "auto_examples")
-    fname = op.join(root, "plot_defer_figures.html")
-    with codecs.open(fname, "r", "utf-8") as fid:
-        html = fid.read()
+    root = Path(sphinx_app.outdir, "auto_examples")
+    fname = Path(root, "plot_defer_figures.html")
+    html = fname.read_text(encoding="utf-8")
 
     (related_html,) = re.findall(
         '<p class="rubric">Related examples</p>(.*)</section>', html, re.DOTALL
@@ -1637,9 +1580,8 @@ def test_recommend_n_examples(sphinx_app):
 
 def test_sidebar_components_download_links(sphinx_app):
     """Test that the `sg_download_links.html` component works as expected."""
-    example_file = op.join(sphinx_app.outdir, "auto_examples", "plot_repr.html")
-    with codecs.open(example_file, "r", "utf-8") as fid:
-        tree = lxml.html.fromstring(fid.read())
+    example_file = Path(sphinx_app.outdir, "auto_examples", "plot_repr.html")
+    tree = lxml.html.fromstring(example_file.read_text(encoding="utf-8"))
 
     for class_name, desc in [
         ("sphx-glr-download-python", "Download source code"),
@@ -1653,16 +1595,15 @@ def test_sidebar_components_download_links(sphinx_app):
             .attrib["href"]
         )
         sidebar_div = tree.find_class(f"{class_name}-sidebar")[0]
-        assert sidebar_div.attrib["title"] == os.path.basename(orig_href)
+        assert sidebar_div.attrib["title"] == Path(orig_href).name
         assert sidebar_div.getchildren()[0].attrib["href"] == orig_href
         assert sidebar_div.getchildren()[0].text_content().strip() == desc
 
 
 def test_sidebar_components_launcher_links(sphinx_app):
     """Test that the `sg_launcher_links.html` component works as expected."""
-    example_file = op.join(sphinx_app.outdir, "auto_examples", "plot_repr.html")
-    with codecs.open(example_file, "r", "utf-8") as fid:
-        tree = lxml.html.fromstring(fid.read())
+    example_file = Path(sphinx_app.outdir, "auto_examples", "plot_repr.html")
+    tree = lxml.html.fromstring(example_file.read_text(encoding="utf-8"))
 
     for class_name in ["binder-badge", "lite-badge"]:
         orig_anchor = tree.find_class(class_name)[0].getchildren()[0]

--- a/sphinx_gallery/tests/test_full_noexec.py
+++ b/sphinx_gallery/tests/test_full_noexec.py
@@ -1,9 +1,9 @@
 # License: 3-clause BSD
 """Test the SG pipeline using Sphinx and tinybuild."""
 
-import os.path as op
 import shutil
 from io import StringIO
+from pathlib import Path
 
 import pytest
 from sphinx.application import Sphinx
@@ -13,7 +13,7 @@ from sphinx.util.docutils import docutils_namespace
 @pytest.fixture(scope="module")
 def sphinx_app(tmp_path_factory, req_mpl, req_pil):
     temp_dir = tmp_path_factory.getbasetemp() / "root_nonexec"
-    src_dir = op.join(op.dirname(__file__), "tinybuild")
+    src_dir = Path(__file__).parent / "tinybuild"
 
     def ignore(src, names):
         return ("_build", "gen_modules", "auto_examples")
@@ -49,11 +49,11 @@ def sphinx_app(tmp_path_factory, req_mpl, req_pil):
 
 def test_dummy_image(sphinx_app):
     """Test that sphinx_gallery_dummy_images are created."""
-    img1 = op.join(
+    img1 = Path(
         sphinx_app.srcdir, "auto_examples", "images", "sphx_glr_plot_repr_001.png"
     )
-    img2 = op.join(
+    img2 = Path(
         sphinx_app.srcdir, "auto_examples", "images", "sphx_glr_plot_repr_002.png"
     )
-    assert op.isfile(img1)
-    assert op.isfile(img2)
+    assert img1.is_file()
+    assert img2.is_file()

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -230,8 +230,8 @@ def test_config_backreferences(sphinx_app_wrapper):
     sphinx_app = sphinx_app_wrapper.create_sphinx_app()
     cfg = sphinx_app.config
     assert cfg.project == "Sphinx-Gallery <Tests>"
-    assert cfg.sphinx_gallery_conf["backreferences_dir"] == os.path.join(
-        "gen_modules", "backreferences"
+    assert cfg.sphinx_gallery_conf["backreferences_dir"] == str(
+        Path("gen_modules", "backreferences")
     )
     build_warn = sphinx_app._warning.getvalue()
     assert build_warn == ""

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -3,7 +3,6 @@
 """Testing the rst files generator."""
 
 import ast
-import codecs
 import codeop
 import importlib
 import io
@@ -451,12 +450,8 @@ def test_fail_example(gallery_conf, failing_code, want, log_collector, req_pil):
     gallery_conf.update(image_scrapers=(), reset_modules=())
     gallery_conf.update(filename_pattern="raise.py")
 
-    with codecs.open(
-        os.path.join(gallery_conf["examples_dir"], "raise.py"),
-        mode="w",
-        encoding="utf-8",
-    ) as f:
-        f.write("\n".join(failing_code))
+    path = Path(gallery_conf["examples_dir"], "raise.py")
+    path.write_text("\n".join(failing_code), encoding="utf-8")
 
     sg.generate_file_rst(
         "raise.py",
@@ -474,15 +469,10 @@ def test_fail_example(gallery_conf, failing_code, want, log_collector, req_pil):
     assert "_check_input" not in msg
 
     # read rst file and check if it contains traceback output
-
-    with codecs.open(
-        os.path.join(gallery_conf["gallery_dir"], "raise.rst"),
-        mode="r",
-        encoding="utf-8",
-    ) as f:
-        ex_failing_blocks = f.read().count("pytb")
-        assert ex_failing_blocks != 0, "Did not run into errors in bad code"
-        assert ex_failing_blocks <= 1, "Did not stop executing script after error"
+    path = Path(gallery_conf["gallery_dir"], "raise.rst")
+    ex_failing_blocks = path.read_text(encoding="utf-8").count("pytb")
+    assert ex_failing_blocks != 0, "Did not run into errors in bad code"
+    assert ex_failing_blocks <= 1, "Did not stop executing script after error"
 
 
 def _generate_rst(gallery_conf, fname, content):
@@ -507,14 +497,9 @@ def _generate_rst(gallery_conf, fname, content):
     rst : str
         The generated reST code.
     """
-    with codecs.open(
-        os.path.join(gallery_conf["examples_dir"], fname), mode="w", encoding="utf-8"
-    ) as f:
-        f.write("\n".join(content))
-    with codecs.open(
-        os.path.join(gallery_conf["examples_dir"], "README.txt"), "w", "utf8"
-    ):
-        pass
+    path = Path(gallery_conf["examples_dir"], fname)
+    path.write_text("\n".join(content), encoding="utf-8")
+    Path(gallery_conf["examples_dir"], "README.txt").write_text("")
 
     # generate rst file
     generate_dir_rst(
@@ -525,12 +510,8 @@ def _generate_rst(gallery_conf, fname, content):
         is_subsection=False,
     )
     # read rst file and check if it contains code output
-    rst_fname = os.path.splitext(fname)[0] + ".rst"
-    with codecs.open(
-        os.path.join(gallery_conf["gallery_dir"], rst_fname), mode="r", encoding="utf-8"
-    ) as f:
-        rst = f.read()
-    return rst
+    rst_fname = Path(gallery_conf["gallery_dir"], fname).with_suffix(".rst")
+    return rst_fname.read_text(encoding="utf-8")
 
 
 ALPHA_CONTENT = '''
@@ -676,8 +657,8 @@ def test_exclude_implicit(gallery_conf, exclusion, expected, monkeypatch, req_pi
 )
 def test_gen_dir_rst(gallery_conf, gallery_header):
     """Test gen_dir_rst."""
-    with open(os.path.join(gallery_conf["src_dir"], gallery_header), "wb") as fid:
-        fid.write("Testing\n=======\n\nÓscar here.".encode())
+    header_path = Path(gallery_conf["src_dir"], gallery_header)
+    header_path.write_bytes("Testing\n=======\n\nÓscar here.".encode())
     out = generate_dir_rst(
         gallery_conf["src_dir"], gallery_conf["gallery_dir"], gallery_conf, []
     )
@@ -693,8 +674,8 @@ def test_gen_dir_rst(gallery_conf, gallery_header):
 )
 def test_gen_dir_rst_invalid_header(gallery_conf, gallery_header):
     """Check `_get_gallery_header` raises error for invalid header extension."""
-    with open(os.path.join(gallery_conf["src_dir"], gallery_header), "wb") as fid:
-        fid.write("Testing\n=======\n\nÓscar here.".encode())
+    header_path = Path(gallery_conf["src_dir"], gallery_header)
+    header_path.write_bytes("Testing\n=======\n\nÓscar here.".encode())
     with pytest.raises(ExtensionError, match="does not have a GALLERY_HEADER"):
         generate_dir_rst(
             gallery_conf["src_dir"], gallery_conf["gallery_dir"], gallery_conf, []
@@ -718,11 +699,8 @@ def test_pattern_matching(gallery_conf, log_collector, req_pil):
     fnames = ["plot_0.py", "plot_1.py", "plot_2.py"]
     for fname in fnames:
         rst = _generate_rst(gallery_conf, fname, CONTENT)
-        rst_fname = os.path.splitext(fname)[0] + ".rst"
-        if re.search(
-            gallery_conf["filename_pattern"],
-            os.path.join(gallery_conf["gallery_dir"], rst_fname),
-        ):
+        rst_fname = Path(gallery_conf["gallery_dir"], fname).with_suffix(".rst")
+        if re.search(gallery_conf["filename_pattern"], str(rst_fname)):
             assert code_output in rst
             assert warn_output in rst
         else:
@@ -774,7 +752,7 @@ def test_zip_python(gallery_conf):
     """Test generated zipfiles are not corrupt and have expected name and contents."""
     gallery_conf.update(examples_dir=os.path.join(gallery_conf["src_dir"], "examples"))
     shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "tinybuild", "examples"),
+        Path(__file__).parent / "tinybuild" / "examples",
         gallery_conf["examples_dir"],
     )
     examples = downloads.list_downloadable_sources(gallery_conf["examples_dir"])
@@ -792,7 +770,7 @@ def test_zip_mixed_source(gallery_conf):
     """Test generated zipfiles are not corrupt and have expected name and contents."""
     gallery_conf.update(examples_dir=os.path.join(gallery_conf["src_dir"], "examples"))
     shutil.copytree(
-        os.path.join(os.path.dirname(__file__), "tinybuild", "examples"),
+        Path(__file__).parent / "tinybuild" / "examples",
         gallery_conf["examples_dir"],
     )
     examples = downloads.list_downloadable_sources(
@@ -822,12 +800,10 @@ def test_rst_example(gallery_conf):
     gallery_conf.update(binder=binder_conf)
     gallery_conf["min_reported_time"] = -1
 
-    example_file = os.path.join(gallery_conf["gallery_dir"], "plot.py")
+    example_file = Path(gallery_conf["gallery_dir"], "plot.py")
     sg.save_rst_example("example_rst", example_file, 0, 0, gallery_conf)
 
-    test_file = re.sub(r"\.py$", ".rst", example_file)
-    with codecs.open(test_file) as f:
-        rst = f.read()
+    rst = example_file.with_suffix(".rst").read_text()
 
     assert "lab/tree/notebooks/plot.ipynb" in rst
 

--- a/sphinx_gallery/tests/test_interactive_example.py
+++ b/sphinx_gallery/tests/test_interactive_example.py
@@ -239,7 +239,7 @@ def test_check_jupyterlite_conf():
     app.extensions = ["jupyterlite_sphinx"]
     assert check_jupyterlite_conf(None, app) is None
     assert check_jupyterlite_conf({}, app) == {
-        "jupyterlite_contents": os.path.join("srcdir", "jupyterlite_contents"),
+        "jupyterlite_contents": str(Path("srcdir", "jupyterlite_contents")),
         "use_jupyter_lab": True,
         "notebook_modification_function": None,
     }
@@ -249,7 +249,7 @@ def test_check_jupyterlite_conf():
         "use_jupyter_lab": False,
     }
     expected = {
-        "jupyterlite_contents": os.path.join("srcdir", "this_is_the_contents_dir"),
+        "jupyterlite_contents": str(Path("srcdir", "this_is_the_contents_dir")),
         "use_jupyter_lab": False,
         "notebook_modification_function": None,
     }
@@ -261,7 +261,7 @@ def test_check_jupyterlite_conf():
     conf = {"notebook_modification_function": notebook_modification_function}
 
     expected = {
-        "jupyterlite_contents": os.path.join("srcdir", "jupyterlite_contents"),
+        "jupyterlite_contents": str(Path("srcdir", "jupyterlite_contents")),
         "use_jupyter_lab": True,
         "notebook_modification_function": notebook_modification_function,
     }

--- a/sphinx_gallery/tests/test_load_style.py
+++ b/sphinx_gallery/tests/test_load_style.py
@@ -1,6 +1,6 @@
 """Testing sphinx_gallery.load_style extension."""
 
-import os
+from pathlib import Path
 
 import pytest
 
@@ -13,10 +13,9 @@ def test_load_style(sphinx_app_wrapper):
     assert cfg.project == "Sphinx-Gallery <Tests>"
     build_warn = sphinx_app._warning.getvalue()
     assert build_warn == ""
-    index_html = os.path.join(sphinx_app_wrapper.outdir, "index.html")
-    assert os.path.isfile(index_html)
-    with open(index_html) as fid:
-        content = fid.read()
+    index_html = Path(sphinx_app_wrapper.outdir, "index.html")
+    assert index_html.is_file()
+    content = index_html.read_text()
     assert (
         'link rel="stylesheet" type="text/css" href="_static/sg_gallery.css' in content
     )

--- a/sphinx_gallery/tests/test_notebook.py
+++ b/sphinx_gallery/tests/test_notebook.py
@@ -279,7 +279,7 @@ def test_notebook_images_prefix(gallery_conf, rst_path, md_path, prefix_enabled)
     if prefix_enabled:
         gallery_conf = gallery_conf.copy()
         gallery_conf["notebook_images"] = "https://example.com/"
-    target_dir = os.path.join(gallery_conf["src_dir"], gallery_conf["gallery_dirs"])
+    target_dir = Path(gallery_conf["src_dir"], gallery_conf["gallery_dirs"])
 
     rst = textwrap.dedent(
         """\
@@ -290,7 +290,7 @@ def test_notebook_images_prefix(gallery_conf, rst_path, md_path, prefix_enabled)
        :class: image
     """
     ).format(rst_path)
-    markdown = rst2md(rst, gallery_conf, target_dir, {})
+    markdown = rst2md(rst, gallery_conf, str(target_dir), {})
 
     assert f'src="{md_path}"' in markdown
     assert 'alt="My Image"' in markdown
@@ -302,32 +302,31 @@ def test_notebook_images_prefix(gallery_conf, rst_path, md_path, prefix_enabled)
 def test_notebook_images_data_uri(gallery_conf):
     gallery_conf = gallery_conf.copy()
     gallery_conf["notebook_images"] = True
-    target_dir = os.path.join(gallery_conf["src_dir"], gallery_conf["gallery_dirs"])
+    target_dir = Path(gallery_conf["src_dir"], gallery_conf["gallery_dirs"])
 
-    test_image = os.path.join(
-        os.path.dirname(__file__), "tinybuild", "doc", "_static_nonstandard", "demo.png"
+    test_image = (
+        Path(__file__).parent / "tinybuild" / "doc" / "_static_nonstandard" / "demo.png"
     )
     # For windows we need to copy this to tmpdir because if tmpdir and this
     # file are on different drives there is no relpath between them
-    dest_dir = os.path.join(gallery_conf["src_dir"], "_static_nonstandard")
-    os.mkdir(dest_dir)
-    dest_image = os.path.join(dest_dir, "demo.png")
+    dest_dir = Path(gallery_conf["src_dir"], "_static_nonstandard")
+    dest_dir.mkdir()
+    dest_image = dest_dir / "demo.png"
     shutil.copyfile(test_image, dest_image)
     # Make into "absolute" path from source directory
-    test_image_rel = os.path.relpath(dest_image, gallery_conf["src_dir"])
-    test_image_abs = "/" + test_image_rel.replace(os.sep, "/")
+    test_image_rel = dest_image.relative_to(gallery_conf["src_dir"])
+    test_image_abs = "/" + test_image_rel.as_posix()
     rst = textwrap.dedent(
         """\
     .. image:: {}
        :width: 100px
     """
     ).format(test_image_abs)
-    markdown = rst2md(rst, gallery_conf, target_dir, {})
+    markdown = rst2md(rst, gallery_conf, str(target_dir), {})
 
     assert "data" in markdown
     assert 'src="data:image/png;base64,' in markdown
-    with open(test_image, "rb") as test_file:
-        data = base64.b64encode(test_file.read())
+    data = base64.b64encode(test_image.read_bytes())
     assert data.decode("ascii") in markdown
 
     rst = textwrap.dedent(
@@ -337,7 +336,7 @@ def test_notebook_images_data_uri(gallery_conf):
     """
     )
     with pytest.raises(ExtensionError):
-        rst2md(rst, gallery_conf, target_dir, {})
+        rst2md(rst, gallery_conf, str(target_dir), {})
 
 
 def test_jupyter_notebook(gallery_conf):

--- a/sphinx_gallery/tests/test_recommender.py
+++ b/sphinx_gallery/tests/test_recommender.py
@@ -2,9 +2,7 @@
 # License: 3-clause BSD
 """Test the example recommender plugin."""
 
-import codecs
-import os
-import re
+from pathlib import Path
 
 import pytest
 
@@ -41,45 +39,36 @@ def test_recommendation_files(gallery_conf):
         "fox_eats_dog_food.py": "The quick brown fox ate the lazy dog's food",
         "dog_jumps_fox.py": "The quick dog jumped over the lazy fox",
     }
+    gallery_dir = Path(gallery_conf["gallery_dir"])
 
     for file_name, content in file_dict.items():
-        file_path = os.path.join(gallery_conf["gallery_dir"], file_name)
-        with open(file_path, "w") as f:
-            f.write(content)
+        file_path = gallery_dir / file_name
+        file_path.write_text(content)
         sg.save_rst_example("example_rst", file_path, 0, 0, gallery_conf)
 
-        test_file = re.sub(r"\.py$", ".rst", file_path)
-        recommendation_file = re.sub(r"\.py$", ".recommendations", file_name)
-        with codecs.open(test_file) as f:
-            rst = f.read()
+        test_file = file_path.with_suffix(".rst")
+        rst = test_file.read_text()
 
-        assert recommendation_file in rst
+        recommendation_file = file_path.with_suffix(".recommendations")
+        assert recommendation_file.name in rst
 
-    py_files = [
-        fname
-        for fname in os.listdir(gallery_conf["gallery_dir"])
-        if os.path.splitext(fname)[1] == ".py"
-    ]
     gallery_py_files = [
-        os.path.join(gallery_conf["gallery_dir"], fname) for fname in py_files
+        str(fname) for fname in gallery_dir.iterdir() if fname.suffix == ".py"
     ]
     recommender = ExampleRecommender(n_examples=1, min_df=1)
     recommender.fit(gallery_py_files)
-    recommended_example = recommender.predict(file_path)  # dog_jumps_fox.py
+    recommended_example = recommender.predict(str(file_path))  # dog_jumps_fox.py
 
-    assert os.path.basename(recommended_example[0]) == "fox_jumps_dog.py"
+    assert Path(recommended_example[0]).name == "fox_jumps_dog.py"
 
     # _write_recommendations needs a thumbnail, for writing the
     # `_thumbnail_div` we then create a blank png
-    thumb_path = os.path.join(gallery_conf["gallery_dir"], "images/thumb")
-    os.makedirs(thumb_path, exist_ok=True)
-    png_file = "sphx_glr_fox_jumps_dog_thumb.png"
-    png_file_path = os.path.join(thumb_path, png_file)
-    with open(png_file_path, "wb") as f:
-        b"\x89PNG\r\n\x1a\n"  # generic png file signature
+    thumb_path = gallery_dir / "images/thumb"
+    thumb_path.mkdir(parents=True, exist_ok=True)
+    png_file_path = thumb_path / "sphx_glr_fox_jumps_dog_thumb.png"
+    png_file_path.write_bytes(b"\x89PNG\r\n\x1a\n")  # generic png file signature
 
-    recommendation_file = re.sub(r"\.py$", ".recommendations", file_path)
-    _write_recommendations(recommender, file_path, gallery_conf)
-    with codecs.open(recommendation_file) as f:
-        rst = f.read()
+    _write_recommendations(recommender, str(file_path), gallery_conf)
+    recommendation_file = file_path.with_suffix(".recommendations")
+    rst = recommendation_file.read_text()
     assert ".. rubric:: Custom header" in rst

--- a/sphinx_gallery/tests/test_scrapers.py
+++ b/sphinx_gallery/tests/test_scrapers.py
@@ -1,6 +1,6 @@
 """Testing image scrapers."""
 
-import os
+from pathlib import Path
 
 import pytest
 from sphinx.errors import ConfigError, ExtensionError
@@ -55,7 +55,7 @@ def test_save_matplotlib_figures(make_gallery_conf, ext):
     import matplotlib.pyplot as plt  # nest these so that Agg can be set
 
     plt.plot(1, 1)
-    fname_template = os.path.join(gallery_conf["gallery_dir"], "image{0}.png")
+    fname_template = str(Path(gallery_conf["gallery_dir"], "image{0}.png"))
     image_path_iterator = ImagePathIterator(fname_template)
     block = ("",) * 3
     block_vars = dict(image_path_iterator=image_path_iterator)
@@ -64,7 +64,7 @@ def test_save_matplotlib_figures(make_gallery_conf, ext):
     fname = f"/image1.{ext}"
     assert fname in image_rst
     fname = gallery_conf["gallery_dir"] + fname
-    assert os.path.isfile(fname)
+    assert Path(fname).is_file()
 
     def _create_two_images():
         image_path_iterator.next()
@@ -81,7 +81,7 @@ def test_save_matplotlib_figures(make_gallery_conf, ext):
         fname = f"/image{ii}.{ext}"
         assert fname in image_rst
         fname = gallery_conf["gallery_dir"] + fname
-        assert os.path.isfile(fname)
+        assert Path(fname).is_file()
 
     # Test `sphinx_gallery_multi_image(_block)` variables work; these variables prevent
     # images with `sphx-glr-single-img` classes from being converted to
@@ -133,7 +133,7 @@ def test_save_matplotlib_figures_hidpi(make_gallery_conf):
     import matplotlib.pyplot as plt  # nest these so that Agg can be set
 
     plt.plot(1, 1)
-    fname_template = os.path.join(gallery_conf["gallery_dir"], "image{0}.png")
+    fname_template = str(Path(gallery_conf["gallery_dir"], "image{0}.png"))
     image_path_iterator = ImagePathIterator(fname_template)
     block = ("",) * 3
     block_vars = dict(image_path_iterator=image_path_iterator)
@@ -147,8 +147,8 @@ def test_save_matplotlib_figures_hidpi(make_gallery_conf):
     fname = gallery_conf["gallery_dir"] + fname
     fnamehi = gallery_conf["gallery_dir"] + f"/image1_2_00x.{ext}"
 
-    assert os.path.isfile(fname)
-    assert os.path.isfile(fnamehi)
+    assert Path(fname).is_file()
+    assert Path(fnamehi).is_file()
 
     # Test capturing 2 images with shifted start number
     image_path_iterator.next()
@@ -163,11 +163,11 @@ def test_save_matplotlib_figures_hidpi(make_gallery_conf):
         assert fname in image_rst
 
         fname = gallery_conf["gallery_dir"] + fname
-        assert os.path.isfile(fname)
+        assert Path(fname).is_file()
         fname = f"/image{ii}_2_00x.{ext}"
         assert fname in image_rst
         fname = gallery_conf["gallery_dir"] + fname
-        assert os.path.isfile(fname)
+        assert Path(fname).is_file()
 
 
 def _custom_func(x, y, z):
@@ -198,7 +198,7 @@ def test_custom_scraper(make_gallery_conf, monkeypatch):
         (lambda x, y, z: 1.0, "was not a string"),
     ]:
         conf = make_gallery_conf({"image_scrapers": [cust]})
-        fname_template = os.path.join(conf["gallery_dir"], "image{0}.png")
+        fname_template = str(Path(conf["gallery_dir"], "image{0}.png"))
         image_path_iterator = ImagePathIterator(fname_template)
         block = ("",) * 3
         block_vars = dict(image_path_iterator=image_path_iterator)
@@ -254,7 +254,7 @@ def test_figure_rst(ext):
 def test_figure_rst_path():
     """Test figure path correct in figure reSt."""
     # Tests issue #229
-    local_img = [os.path.join(os.getcwd(), "third.png")]
+    local_img = [Path.cwd() / "third.png"]
     image_rst = figure_rst(local_img, ".")
 
     single_image = SG_IMAGE % ("third.png", "", "/third.png")
@@ -297,7 +297,7 @@ def test_figure_rst_srcset():
     assert image_rst == image_list_rst
 
     # test issue #229
-    local_img = [os.path.join(os.getcwd(), "third.png")]
+    local_img = [Path.cwd() / "third.png"]
     image_rst = figure_rst(local_img, ".")
 
     single_image = SG_IMAGE % ("third.png", "", "/third.png")

--- a/sphinx_gallery/tests/test_sorting.py
+++ b/sphinx_gallery/tests/test_sorting.py
@@ -2,7 +2,7 @@
 # License: 3-clause BSD
 r"""Tests for sorting keys on gallery (sub)sections."""
 
-import os.path as op
+from pathlib import Path
 
 import pytest
 from sphinx.errors import ConfigError
@@ -28,7 +28,7 @@ def test_ExplicitOrder_sorting_key():
     assert str(key).startswith("<ExplicitOrder : ")
     assert str(key) == str(ExplicitOrder(explicit_folders))
     assert str(key) != str(ExplicitOrder(explicit_folders[::-1]))
-    src_dir = op.dirname(__file__)
+    src_dir = str(Path(__file__).parent)
     for klass, type_ in (
         (NumberOfCodeLinesSortKey, int),
         (FileNameSortKey, str),
@@ -37,7 +37,7 @@ def test_ExplicitOrder_sorting_key():
     ):
         sorter = klass(src_dir)
         assert str(sorter) == f"<{klass.__name__}>"
-        out = sorter(op.basename(__file__))
+        out = sorter(Path(__file__).name)
         assert isinstance(out, type_), type(out)
 
 

--- a/sphinx_gallery/tests/tinybuild/utils.py
+++ b/sphinx_gallery/tests/tinybuild/utils.py
@@ -1,6 +1,6 @@
 """Utility functions for doc building."""
 
-import os.path as op
+from pathlib import Path
 
 from sphinx_gallery.scrapers import matplotlib_scraper
 
@@ -22,12 +22,12 @@ class MatplotlibFormatScraper:
         """Call Matplotlib scraper with required `format` kwarg for testing."""
         kwargs = dict()
         if (
-            op.basename(block_vars["target_file"]) == "plot_svg.py"
+            Path(block_vars["target_file"]).name == "plot_svg.py"
             and gallery_conf["builder_name"] != "latex"
         ):
             kwargs["format"] = "svg"
         elif (
-            op.basename(block_vars["target_file"]) == "plot_webp.py"
+            Path(block_vars["target_file"]).name == "plot_webp.py"
             and gallery_conf["builder_name"] != "latex"
         ):
             kwargs["format"] = "webp"


### PR DESCRIPTION
But sometimes we need to cast back to `str` because the actual API uses it only. In some cases, there wasn't a huge benefit because of that, but I changed them anyway for consistency across the code base (at least in tests for now).