### PR TITLE
TST Amend `add_rst` to `add_file` and make flexible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,5 +210,5 @@ ini_options.filterwarnings = [
 ini_options.junit_family = "xunit2"
 ini_options.markers = [
   "add_conf: Configuration file.",
-  "add_rst: Add rst file to src.",
+  "add_rst: Add file to src.",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,5 +210,5 @@ ini_options.filterwarnings = [
 ini_options.junit_family = "xunit2"
 ini_options.markers = [
   "add_conf: Configuration file.",
-  "add_rst: Add file to src.",
+  "add_file: Add file to src.",
 ]

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -15,37 +15,6 @@ from sphinx.util.docutils import docutils_namespace
 from sphinx_gallery import docs_resolv, gen_gallery, gen_rst, py_source_parser
 from sphinx_gallery.scrapers import _import_matplotlib
 
-INDEX_RST = """
-=============
-Own index.rst
-=============
-
-Own index.rst file.
-
-.. toctree::
-
-    plot_1
-    plot_2
-    plot_3
-"""
-
-NESTED_PY = """\"\"\"
-Header
-======
-
-Text.
-\"\"\"
-
-a = 1
-"""
-
-GALLERY_HEADER = """
-Gallery header
-==============
-
-Some text.
-"""
-
 
 def pytest_report_header(config, startdir=None):
     """Add information to the pytest run header."""
@@ -165,12 +134,16 @@ def conf_file(request):
 
 @pytest.fixture
 def rst_file(request):
-    """Adds rst file to environment, see `sphinx_app_wrapper` for details."""
+    """Adds rst file(s) to environment, see `sphinx_app_wrapper` for details.
+
+    This fixture takes a single `file` kwarg, which should be a dictionary
+    of format {key: <file name to be added>, value: <content to be added to file>}.
+    """
     try:
         env = request.node.get_closest_marker("add_rst")
     except AttributeError:  # old pytest
         env = request.node.get_marker("add_rst")
-    file = env.kwargs["file"] if env else ""
+    file = env.kwargs["file"] if env else None
     return file
 
 
@@ -229,16 +202,11 @@ def sphinx_app_wrapper(tmp_path, conf_file, rst_file, req_mpl, req_pil):
     # Copy files to 'examples/' as well because default `examples_dirs` is
     # '../examples' - for tests where we don't update config
     shutil.copytree(_fixturedir / "src", tmp_path / "examples")
-    if rst_file == "own index.rst":
-        (srcdir / "src" / "index.rst").write_text(INDEX_RST)
-    elif rst_file:
-        (srcdir / "minigallery_test.rst").write_text(rst_file)
-        # Add nested gallery
-        if "sub_folder/sub_sub_folder" in rst_file:
-            dir_path = srcdir / "src" / "sub_folder" / "sub_sub_folder"
-            dir_path.mkdir(parents=True)
-            (dir_path / "plot_nested.py").write_text(NESTED_PY)
-            (dir_path / "GALLERY_HEADER.rst").write_text(GALLERY_HEADER)
+    if rst_file:
+        for file_name, content in rst_file.items():
+            full_path = srcdir / file_name
+            full_path.parent.mkdir(parents=True, exist_ok=True)
+            full_path.write_text(content)
 
     base_config = f"""
 import os

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -134,7 +134,7 @@ def conf_file(request):
 
 @pytest.fixture
 def rst_file(request):
-    """Adds rst file(s) to environment, see `sphinx_app_wrapper` for details.
+    """Adds file(s) to environment, see `sphinx_app_wrapper` for details.
 
     This fixture takes a single `file` kwarg, which should be a dictionary
     of format {key: <file name to be added>, value: <content to be added to file>}.

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -140,9 +140,9 @@ def rst_file(request):
     of format {key: <file name to be added>, value: <content to be added to file>}.
     """
     try:
-        env = request.node.get_closest_marker("add_rst")
+        env = request.node.get_closest_marker("add_file")
     except AttributeError:  # old pytest
-        env = request.node.get_marker("add_rst")
+        env = request.node.get_marker("add_file")
     file = env.kwargs["file"] if env else None
     return file
 

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -137,7 +137,9 @@ def rst_file(request):
     """Adds file(s) to environment, see `sphinx_app_wrapper` for details.
 
     This fixture takes a single `file` kwarg, which should be a dictionary
-    of format {key: <file name to be added>, value: <content to be added to file>}.
+    of format {key: <file path>, value: <content to be added to file>}.
+    The file path should be relative to the test documentation source path,
+    see `sphinx_app_wrapper` for details.
     """
     env = request.node.get_closest_marker("add_file")
     file = env.kwargs["file"] if env else None

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -139,10 +139,7 @@ def rst_file(request):
     This fixture takes a single `file` kwarg, which should be a dictionary
     of format {key: <file name to be added>, value: <content to be added to file>}.
     """
-    try:
-        env = request.node.get_closest_marker("add_file")
-    except AttributeError:  # old pytest
-        env = request.node.get_marker("add_file")
+    env = request.node.get_closest_marker("add_file")
     file = env.kwargs["file"] if env else None
     return file
 

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -36,6 +36,38 @@ Description.
 
 """
 
+# Used for `add_rst`
+INDEX_RST = """
+=============
+Own index.rst
+=============
+
+Own index.rst file.
+
+.. toctree::
+
+    plot_1
+    plot_2
+    plot_3
+"""
+
+NESTED_PY = """\"\"\"
+Header
+======
+
+Text.
+\"\"\"
+
+a = 1
+"""
+
+GALLERY_HEADER = """
+Gallery header
+==============
+
+Some text.
+"""
+
 
 def _escape_ansi(s: str) -> str:
     """Remove ANSI terminal formatting characters from a string."""
@@ -536,7 +568,7 @@ sphinx_gallery_conf = {
     'copyfile_regex': r'.*\.rst',
 }"""
 )
-@pytest.mark.add_rst(file="own index.rst")
+@pytest.mark.add_rst(file={Path("src") / "index.rst": INDEX_RST })
 def test_own_index_first(sphinx_app_wrapper):
     """Test `generate_gallery_rst` works when own index gallery is first (and only)."""
     # Issue #1382
@@ -562,7 +594,7 @@ def test_binder_copy_files(sphinx_app_wrapper):
     sphinx_app = sphinx_app_wrapper.create_sphinx_app()
     gallery_conf = sphinx_app.config.sphinx_gallery_conf
     # Create requirements file
-    Path(sphinx_app.srcdir, "requirements.txt").open("w")
+    Path(sphinx_app.srcdir, "requirements.txt").touch()
     copy_binder_files(sphinx_app, None)
 
     for i_file in ["plot_1", "plot_2", "plot_3"]:
@@ -772,13 +804,13 @@ sphinx_gallery_conf = {
     'gallery_dirs': 'ex',
 }"""
 )
-@pytest.mark.add_rst(
-    file="""
+@pytest.mark.add_rst(file={"minigallery_test.rst": """
 Header
 ======
 
 .. minigallery:: index.rst
 """
+}
 )
 def test_minigallery_not_in_examples_dirs(sphinx_app_wrapper):
     """Check error when minigallery directive's path input not in `examples_dirs`."""
@@ -794,13 +826,15 @@ sphinx_gallery_conf = {
     'gallery_dirs': ['ex', 'ex/sub_folder/sub_sub_folder'],
 }"""
 )
-@pytest.mark.add_rst(
-    file="""
+@pytest.mark.add_rst(file={"minigallery_test.rst": """
 Header
 ======
 
 .. minigallery:: src/sub_folder/sub_sub_folder/plot_nested.py
-"""
+""",
+Path("src") / "sub_folder" / "sub_sub_folder" / "plot_nested.py": NESTED_PY,
+Path("src") / "sub_folder" / "sub_sub_folder" / "GALLERY_HEADER.rst": GALLERY_HEADER,
+}
 )
 def test_minigallery_multi_match(sphinx_app_wrapper):
     """Check minigallery directive's path input resolution in nested `examples_dirs`.
@@ -843,13 +877,13 @@ sphinx_gallery_conf = {
     'minigallery_sort_order': FunctionSortKey(custom_minigallery_sort_order_sorter),
 }"""
 )
-@pytest.mark.add_rst(
-    file="""
+@pytest.mark.add_rst(file={"minigallery_test.rst": """
 Header
 ======
 
 .. minigallery:: src/plot_1.py src/plot_2.py src/plot_3.py
 """
+}
 )
 def test_minigallery_sort_order_callable(sphinx_app_wrapper):
     """Check `minigallery_sort_order` works when a callable."""
@@ -867,13 +901,13 @@ sphinx_gallery_conf = {
     'gallery_dirs': 'ex',
 }"""
 )
-@pytest.mark.add_rst(
-    file="""
+@pytest.mark.add_rst(file={"minigallery_test.rst": """
 Header
 ======
 
 .. minigallery:: src/plot_1.py src/plot_1.py
 """
+}
 )
 def test_minigallery_duplicate_path_input(sphinx_app_wrapper):
     """Check minigallery duplicate input paths are de-deuplicated."""
@@ -893,13 +927,13 @@ sphinx_gallery_conf = {
     'doc_module': ('numpy',),
 }"""
 )
-@pytest.mark.add_rst(
-    file="""
+@pytest.mark.add_rst(file={"minigallery_test.rst": """
 Header
 ======
 
 .. minigallery:: sphinx_gallery.py_source_parser.Block src/plot_1.py
 """
+}
 )
 def test_minigallery_duplicate_object_path_input(sphinx_app_wrapper):
     """Check object and path input de-deplication works in minigallery directive.
@@ -1109,7 +1143,7 @@ sphinx_gallery_conf = {
     'nested_sections': False,
 }"""
 )
-@pytest.mark.add_rst(file="own index.rst")
+@pytest.mark.add_rst(file={Path("src") / "index.rst": INDEX_RST })
 def test_nested_sections_false_with_own_index(sphinx_app_wrapper):
     """Check no error with user provided index.rst and `nested_sections=False`."""
     sphinx_app_wrapper.build_sphinx_app()

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -568,7 +568,7 @@ sphinx_gallery_conf = {
     'copyfile_regex': r'.*\.rst',
 }"""
 )
-@pytest.mark.add_rst(file={Path("src") / "index.rst": INDEX_RST })
+@pytest.mark.add_rst(file={Path("src") / "index.rst": INDEX_RST})
 def test_own_index_first(sphinx_app_wrapper):
     """Test `generate_gallery_rst` works when own index gallery is first (and only)."""
     # Issue #1382
@@ -804,13 +804,15 @@ sphinx_gallery_conf = {
     'gallery_dirs': 'ex',
 }"""
 )
-@pytest.mark.add_rst(file={"minigallery_test.rst": """
+@pytest.mark.add_rst(
+    file={
+        "minigallery_test.rst": """
 Header
 ======
 
 .. minigallery:: index.rst
 """
-}
+    }
 )
 def test_minigallery_not_in_examples_dirs(sphinx_app_wrapper):
     """Check error when minigallery directive's path input not in `examples_dirs`."""
@@ -826,15 +828,20 @@ sphinx_gallery_conf = {
     'gallery_dirs': ['ex', 'ex/sub_folder/sub_sub_folder'],
 }"""
 )
-@pytest.mark.add_rst(file={"minigallery_test.rst": """
+@pytest.mark.add_rst(
+    file={
+        "minigallery_test.rst": """
 Header
 ======
 
 .. minigallery:: src/sub_folder/sub_sub_folder/plot_nested.py
 """,
-Path("src") / "sub_folder" / "sub_sub_folder" / "plot_nested.py": NESTED_PY,
-Path("src") / "sub_folder" / "sub_sub_folder" / "GALLERY_HEADER.rst": GALLERY_HEADER,
-}
+        Path("src") / "sub_folder" / "sub_sub_folder" / "plot_nested.py": NESTED_PY,
+        Path("src")
+        / "sub_folder"
+        / "sub_sub_folder"
+        / "GALLERY_HEADER.rst": GALLERY_HEADER,
+    }
 )
 def test_minigallery_multi_match(sphinx_app_wrapper):
     """Check minigallery directive's path input resolution in nested `examples_dirs`.
@@ -877,13 +884,15 @@ sphinx_gallery_conf = {
     'minigallery_sort_order': FunctionSortKey(custom_minigallery_sort_order_sorter),
 }"""
 )
-@pytest.mark.add_rst(file={"minigallery_test.rst": """
+@pytest.mark.add_rst(
+    file={
+        "minigallery_test.rst": """
 Header
 ======
 
 .. minigallery:: src/plot_1.py src/plot_2.py src/plot_3.py
 """
-}
+    }
 )
 def test_minigallery_sort_order_callable(sphinx_app_wrapper):
     """Check `minigallery_sort_order` works when a callable."""
@@ -901,13 +910,15 @@ sphinx_gallery_conf = {
     'gallery_dirs': 'ex',
 }"""
 )
-@pytest.mark.add_rst(file={"minigallery_test.rst": """
+@pytest.mark.add_rst(
+    file={
+        "minigallery_test.rst": """
 Header
 ======
 
 .. minigallery:: src/plot_1.py src/plot_1.py
 """
-}
+    }
 )
 def test_minigallery_duplicate_path_input(sphinx_app_wrapper):
     """Check minigallery duplicate input paths are de-deuplicated."""
@@ -927,13 +938,15 @@ sphinx_gallery_conf = {
     'doc_module': ('numpy',),
 }"""
 )
-@pytest.mark.add_rst(file={"minigallery_test.rst": """
+@pytest.mark.add_rst(
+    file={
+        "minigallery_test.rst": """
 Header
 ======
 
 .. minigallery:: sphinx_gallery.py_source_parser.Block src/plot_1.py
 """
-}
+    }
 )
 def test_minigallery_duplicate_object_path_input(sphinx_app_wrapper):
     """Check object and path input de-deplication works in minigallery directive.
@@ -1143,7 +1156,7 @@ sphinx_gallery_conf = {
     'nested_sections': False,
 }"""
 )
-@pytest.mark.add_rst(file={Path("src") / "index.rst": INDEX_RST })
+@pytest.mark.add_rst(file={Path("src") / "index.rst": INDEX_RST})
 def test_nested_sections_false_with_own_index(sphinx_app_wrapper):
     """Check no error with user provided index.rst and `nested_sections=False`."""
     sphinx_app_wrapper.build_sphinx_app()

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -36,7 +36,7 @@ Description.
 
 """
 
-# Used for `add_rst`
+# Used for `add_file`
 INDEX_RST = """
 =============
 Own index.rst
@@ -568,7 +568,7 @@ sphinx_gallery_conf = {
     'copyfile_regex': r'.*\.rst',
 }"""
 )
-@pytest.mark.add_rst(file={Path("src") / "index.rst": INDEX_RST})
+@pytest.mark.add_file(file={Path("src") / "index.rst": INDEX_RST})
 def test_own_index_first(sphinx_app_wrapper):
     """Test `generate_gallery_rst` works when own index gallery is first (and only)."""
     # Issue #1382
@@ -804,7 +804,7 @@ sphinx_gallery_conf = {
     'gallery_dirs': 'ex',
 }"""
 )
-@pytest.mark.add_rst(
+@pytest.mark.add_file(
     file={
         "minigallery_test.rst": """
 Header
@@ -828,7 +828,7 @@ sphinx_gallery_conf = {
     'gallery_dirs': ['ex', 'ex/sub_folder/sub_sub_folder'],
 }"""
 )
-@pytest.mark.add_rst(
+@pytest.mark.add_file(
     file={
         "minigallery_test.rst": """
 Header
@@ -884,7 +884,7 @@ sphinx_gallery_conf = {
     'minigallery_sort_order': FunctionSortKey(custom_minigallery_sort_order_sorter),
 }"""
 )
-@pytest.mark.add_rst(
+@pytest.mark.add_file(
     file={
         "minigallery_test.rst": """
 Header
@@ -910,7 +910,7 @@ sphinx_gallery_conf = {
     'gallery_dirs': 'ex',
 }"""
 )
-@pytest.mark.add_rst(
+@pytest.mark.add_file(
     file={
         "minigallery_test.rst": """
 Header
@@ -938,7 +938,7 @@ sphinx_gallery_conf = {
     'doc_module': ('numpy',),
 }"""
 )
-@pytest.mark.add_rst(
+@pytest.mark.add_file(
     file={
         "minigallery_test.rst": """
 Header
@@ -1156,7 +1156,7 @@ sphinx_gallery_conf = {
     'nested_sections': False,
 }"""
 )
-@pytest.mark.add_rst(file={Path("src") / "index.rst": INDEX_RST})
+@pytest.mark.add_file(file={Path("src") / "index.rst": INDEX_RST})
 def test_nested_sections_false_with_own_index(sphinx_app_wrapper):
     """Check no error with user provided index.rst and `nested_sections=False`."""
     sphinx_app_wrapper.build_sphinx_app()


### PR DESCRIPTION
As discussed in #1568

* changes `add_rst` to `add_file` - as we can add any type of file to src (and we already use it to add non-rst files)
* amends input to allow a dict of format filename: content, allowing any number of files (and any file type) to be added to src