### PR TITLE
TYP: Fix typing for back references

### DIFF
--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -13,16 +13,17 @@ import json
 import os
 import re
 import sys
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 from html import escape
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import sphinx.util
 from sphinx.errors import ExtensionError
 
 from ._dummy import DummyClass  # noqa: F401
 from .scrapers import _find_image_ext
+from .typing import GalleryConfig
 from .utils import _W_KW, _replace_md5
 
 if TYPE_CHECKING:
@@ -395,14 +396,24 @@ def _thumbnail_div(
     )
 
 
-Backreference = namedtuple(
-    "Backreference", ["fname", "src_dir", "target_dir", "intro", "title"]
-)
+class Backreference(NamedTuple):
+    fname: str
+    src_dir: str
+    target_dir: str
+    intro: str
+    title: str
 
 
 def _write_backreferences(
-    backrefs, seen_backrefs, gallery_conf, src_dir, target_dir, fname, intro, title
-) -> dict[str, Backreference] | None:
+    backrefs: set[str],
+    seen_backrefs: set[str],
+    gallery_conf: GalleryConfig,
+    src_dir: str,
+    target_dir: str,
+    fname: str,
+    intro: str,
+    title: str,
+) -> dict[str, list[Backreference]] | None:
     """Write and return backreferences for one example.
 
     Backreferences '.examples' file written includes reST of the list of examples
@@ -412,7 +423,7 @@ def _write_backreferences(
     ----------
     backrefs : set[str]
         Back references to write.
-    seen_backrefs: set
+    seen_backrefs: set[str]
         Back references already encountered when parsing this example.
     gallery_conf : Dict[str, Any]
         Gallery configurations.
@@ -429,9 +440,9 @@ def _write_backreferences(
 
     Returns
     -------
-    backrefs_example : dict[str, Backreference]
-        Dictionary where value is the backreference object and value
-        is a tuple containing: example filename, full path to example source directory,
+    backrefs_example : dict[str, list[Backreference]]
+        Dictionary where key is the backreference object name and value is a list of
+        tuples containing: example filename, full path to example source directory,
         full path to example target directory, intro, title.
     """
     if gallery_conf["backreferences_dir"] is None:
@@ -474,7 +485,9 @@ def _write_backreferences(
     return dict(backrefs_example)
 
 
-def _finalize_backreferences(seen_backrefs, gallery_conf):
+def _finalize_backreferences(
+    seen_backrefs: set[str], gallery_conf: GalleryConfig
+) -> None:
     """Replace backref files only if necessary."""
     logger = sphinx.util.logging.getLogger("sphinx-gallery")
     if gallery_conf["backreferences_dir"] is None:

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -771,7 +771,7 @@ def generate_gallery_rst(app: Sphinx) -> None:
     examples_dirs = [ex_dir for ex_dir, _ in workdirs]
     _collect_gallery_files(examples_dirs, gallery_conf, check_filenames=True)
 
-    backrefs_all: dict[str, Backreference] = {}
+    backrefs_all: dict[str, list[Backreference]] = {}
 
     for examples_dir, gallery_dir in workdirs:
         examples_dir_abs_path = os.path.join(str(app.builder.srcdir), examples_dir)

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -577,7 +577,7 @@ def generate_dir_rst(
     str | None,
     list[ExampleCost],
     list[str],
-    dict[str, Backreference],
+    dict[str, list[Backreference]],
 ]:
     """Generate output example reST files for one gallery (sub)directory.
 
@@ -608,9 +608,9 @@ def generate_dir_rst(
         List of runtime costs for building each element of the gallery.
     toctree_items: list,
         List of example file names we generated ReST for.
-    backrefs_dir : dict[str, tuple]
-        Dictionary where value is the backreference object and value
-        is a tuple containing: example filename, full path to example source directory,
+    backrefs_dir : dict[str, list[tuple]]
+        Dictionary where key is the backreference object name and value is a list of
+        tuples containing: example filename, full path to example source directory,
         full path to example target directory, intro, title.
 
     """
@@ -661,7 +661,7 @@ def generate_dir_rst(
         length=len(sorted_listdir),
     )
 
-    backrefs_dir: dict[str, Backreference] = {}
+    backrefs_dir: dict[str, list[Backreference]] = {}
 
     parallel = list
     p_fun = generate_file_rst
@@ -715,7 +715,7 @@ def generate_dir_rst(
 
         # Write backreferences
         if "backrefs" in out_vars:
-            backrefs_example: dict[str, Backreference] | None = _write_backreferences(
+            backrefs_example = _write_backreferences(
                 out_vars["backrefs"],
                 seen_backrefs,
                 gallery_conf,


### PR DESCRIPTION
`_write_backreferences` clearly returns a `list` of `Backreferences` in the `dict` (created with `defaultdict(list)`), not a singular `Backreference`.