### PR TITLE
ENH: Accept Paths in split_code_and_text_blocks

### DIFF
--- a/sphinx_gallery/block_parser.py
+++ b/sphinx_gallery/block_parser.py
@@ -126,14 +126,14 @@ class BlockParser:
 
     def split_code_and_text_blocks(
         self,
-        source_file: str,
+        source_file: str | Path,
         return_node: bool = False,
     ) -> tuple[dict, list[Block], None]:
         """Return list with source file separated into code and text blocks.
 
         Parameters
         ----------
-        source_file : str
+        source_file : str or Path
             Path to the source file.
         return_node : bool
             Ignored; returning an ast node is not supported
@@ -150,8 +150,7 @@ class BlockParser:
         node : None
             Returning an ast node is not supported.
         """
-        with open(source_file, "r", encoding="utf-8") as fid:
-            content = fid.read()
+        content = Path(source_file).read_text(encoding="utf-8")
         # change from Windows format to UNIX for uniformity
         content = content.replace("\r\n", "\n")
         return self._split_content(content)

--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -8,6 +8,7 @@ import re
 import tokenize
 from collections import namedtuple
 from io import BytesIO
+from pathlib import Path
 from textwrap import dedent
 from typing import Any, Literal, overload
 
@@ -44,12 +45,12 @@ IGNORE_BLOCK_PATTERN = re.compile(
 )
 
 
-def parse_source_file(filename: str) -> tuple[ast.Module | None, str]:
+def parse_source_file(filename: str | Path) -> tuple[ast.Module | None, str]:
     """Parse source file into AST node.
 
     Parameters
     ----------
-    filename : str
+    filename : str or Path
         File path
 
     Returns
@@ -57,9 +58,8 @@ def parse_source_file(filename: str) -> tuple[ast.Module | None, str]:
     node : AST node
     content : utf-8 encoded string
     """
-    # builtin open automatically converts \r\n to \n
-    with open(filename, "r", encoding="utf-8") as fid:
-        content = fid.read()
+    # read_text automatically converts \r\n to \n
+    content = Path(filename).read_text(encoding="utf-8")
 
     try:
         node = ast.parse(content)
@@ -68,7 +68,7 @@ def parse_source_file(filename: str) -> tuple[ast.Module | None, str]:
         return None, content
 
 
-def _get_docstring_and_rest(filename: str) -> tuple[str, str, int, ast.Module | None]:
+def _get_docstring_and_rest(filename: Path) -> tuple[str, str, int, ast.Module | None]:
     """Separate ``filename`` content between docstring and the rest.
 
     Strongly inspired from ast.get_docstring.
@@ -159,24 +159,24 @@ Block = namedtuple("Block", ["type", "content", "lineno"])
 
 @overload
 def split_code_and_text_blocks(
-    source_file: str,
+    source_file: str | Path,
     return_node: Literal[True],
 ) -> tuple[dict[str, Any], list, ast.Module | None]: ...
 
 
 @overload
 def split_code_and_text_blocks(
-    source_file: str,
+    source_file: str | Path,
     return_node: Literal[False] = False,
 ) -> tuple[dict[str, Any], list]: ...
 
 
-def split_code_and_text_blocks(source_file, return_node=False):
+def split_code_and_text_blocks(source_file: str | Path, return_node: bool = False):
     """Return list with source file separated into code and text blocks.
 
     Parameters
     ----------
-    source_file : str
+    source_file : str or Path
         Path to the source file.
     return_node : bool
         If True, return the ast node.
@@ -193,7 +193,9 @@ def split_code_and_text_blocks(source_file, return_node=False):
     node : ast.Module
         The parsed ast node.
     """
-    docstring, rest_of_content, lineno, node = _get_docstring_and_rest(source_file)
+    docstring, rest_of_content, lineno, node = _get_docstring_and_rest(
+        Path(source_file)
+    )
     blocks = [Block("text", docstring, 1)]
 
     file_conf = extract_file_config(rest_of_content)

--- a/sphinx_gallery/rst_source_parser.py
+++ b/sphinx_gallery/rst_source_parser.py
@@ -10,7 +10,7 @@ from .py_source_parser import Block
 
 
 def split_code_and_text_blocks(
-    source_file: str,
+    source_file: str | Path,
     return_node: Literal[False] = False,
 ) -> tuple[dict[str, Any], list, None]:
     """Return list with source file separated into code and text blocks.

--- a/sphinx_gallery/tests/conftest.py
+++ b/sphinx_gallery/tests/conftest.py
@@ -83,7 +83,7 @@ _ = plt.figure()
 
     fname = tmp_path / "unicode_sample.py"
     fname.write_bytes(code_str)
-    return str(fname)
+    return fname
 
 
 @pytest.fixture

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -229,7 +229,7 @@ h.i.j()
     fname = tmp_path / "identify_names.py"
     fname.write_bytes(code_str)
 
-    _, script_blocks = split_code_and_text_blocks(str(fname))
+    _, script_blocks = split_code_and_text_blocks(fname)
     ref_regex = sg._make_ref_regex()
     res = sg.identify_names(script_blocks, ref_regex)
 

--- a/sphinx_gallery/tests/test_py_source_parser.py
+++ b/sphinx_gallery/tests/test_py_source_parser.py
@@ -3,6 +3,7 @@
 r"""Test source parser."""
 
 import textwrap
+from pathlib import Path
 
 import pytest
 from sphinx.errors import ExtensionError
@@ -24,7 +25,7 @@ def test_get_docstring_and_rest(unicode_sample, tmp_path, monkeypatch):
     assert sg._get_docstring_and_rest(fname)[0] == sg.SYNTAX_ERROR_DOCSTRING
     monkeypatch.setattr(sg, "parse_source_file", lambda x: ("", None))
     with pytest.raises(ExtensionError, match="only supports modules"):
-        sg._get_docstring_and_rest("")
+        sg._get_docstring_and_rest(Path(""))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Tests already pass `Path`s to these functions, so this just codifies that allowance in the types, but also simplifies a few internal cases by assuming there's only `Path`.