### PR TITLE
Re-enable Sphinx dev CI

### DIFF
--- a/.github/install.sh
+++ b/.github/install.sh
@@ -30,10 +30,9 @@ fi
 
 # Sphinx version
 if [ "$SPHINX_VERSION" == "dev" ]; then
-    # TODO: Reenable once sphinx-design and pydata-sphinx-theme are 9.0+ compatible,
-    # Then also add a sphinx-9 test job
-    # PIP_DEPENDENCIES="--upgrade --pre https://api.github.com/repos/sphinx-doc/sphinx/zipball/master --default-timeout=60 --extra-index-url 'https://pypi.anaconda.org/scientific-python-nightly-wheels/simple' $PIP_DEPENDENCIES"
-    PIP_DEPENDENCIES="--upgrade --pre sphinx<9 --default-timeout=60 --extra-index-url 'https://pypi.anaconda.org/scientific-python-nightly-wheels/simple' $PIP_DEPENDENCIES"
+    PIP_DEPENDENCIES="--upgrade --pre https://api.github.com/repos/sphinx-doc/sphinx/zipball/master --default-timeout=60 --extra-index-url 'https://pypi.anaconda.org/scientific-python-nightly-wheels/simple' $PIP_DEPENDENCIES"
+    # Use after new Sphinx release, before dependencies have supported it
+    # PIP_DEPENDENCIES="--upgrade --pre sphinx<10 --default-timeout=60 --extra-index-url 'https://pypi.anaconda.org/scientific-python-nightly-wheels/simple' $PIP_DEPENDENCIES"
 elif [ "$SPHINX_VERSION" != "default" ]; then
     PIP_DEPENDENCIES="sphinx==${SPHINX_VERSION}.* $PIP_DEPENDENCIES"
 else


### PR DESCRIPTION
closes #1526

There was also a note about adding a CI for sphinx v9, but I think this has already been done in #1558