### PR TITLE
TST: Use tmp_path fixture instead of tempfile

### DIFF
--- a/sphinx_gallery/block_parser.py
+++ b/sphinx_gallery/block_parser.py
@@ -33,13 +33,13 @@ class BlockParser:
 
     Parameters
     ----------
-    source_file : str
+    source_file : str or Path
         A file name that has a suffix compatible with files that are subsequently parsed
     gallery_conf : dict
         Contains the configuration of Sphinx-Gallery.
     """
 
-    def __init__(self, source_file: str, gallery_conf: GalleryConfig) -> None:
+    def __init__(self, source_file: str | Path, gallery_conf: GalleryConfig) -> None:
         source_path = Path(source_file)
         if name := gallery_conf["filetype_parsers"].get(source_path.suffix):
             self.lexer = pygments.lexers.find_lexer_class_by_name(name)()

--- a/sphinx_gallery/tests/test_block_parser.py
+++ b/sphinx_gallery/tests/test_block_parser.py
@@ -1,7 +1,5 @@
 """test BlockParser."""
 
-import os
-import tempfile
 from textwrap import dedent
 
 import pytest
@@ -193,7 +191,7 @@ def test_rst_blocks(filetype, title, special, expected):
     assert blocks[2].content == expected
 
 
-def test_cpp_file_to_rst():
+def test_cpp_file_to_rst(tmp_path):
     CODE = """\
 // Do stuff
 // --------
@@ -214,14 +212,11 @@ int main(int argc, char** argv) {
     // sphinx_gallery_foobar = 14
 }
 """
-    with tempfile.NamedTemporaryFile("wb", suffix=".cpp", delete=False) as f:
-        f.write(CODE.encode())
+    filename = tmp_path / "example.cpp"
+    filename.write_text(CODE)
 
-    try:
-        parser = BlockParser(f.name, DEFAULT_GALLERY_CONF)
-        file_conf, blocks, _ = parser.split_code_and_text_blocks(f.name)
-    finally:
-        os.remove(f.name)
+    parser = BlockParser(filename, DEFAULT_GALLERY_CONF)
+    file_conf, blocks, _ = parser.split_code_and_text_blocks(filename)
 
     assert parser.language == "C++"
     assert file_conf == {"foobar": 14}

--- a/sphinx_gallery/tests/test_docs_resolv.py
+++ b/sphinx_gallery/tests/test_docs_resolv.py
@@ -2,9 +2,6 @@
 # License: 3-clause BSD
 """Testing the rst files generator."""
 
-import os
-import tempfile
-
 import pytest
 from sphinx.errors import ExtensionError
 
@@ -20,19 +17,18 @@ def test_embed_code_links_get_data():
 def test_shelve(tmp_path):
     """Test if shelve can cache and retrieve data after file is deleted."""
     test_string = "test information"
-    tmp_cache = str(tmp_path)
-    with tempfile.NamedTemporaryFile("w", delete=False) as f:
-        f.write(test_string)
-    try:
-        # recovers data from temporary file and caches it in the shelve
-        file_data = sg.get_data(f.name, tmp_cache)
-    finally:
-        os.remove(f.name)
+    tmp_cache = tmp_path / "cache"
+    tmp_cache.mkdir(parents=True, exist_ok=True)
+    test_file = tmp_path / "example.txt"
+    test_file.write_text(test_string)
+    # recovers data from temporary file and caches it in the shelve
+    file_data = sg.get_data(str(test_file), str(tmp_cache))
     # tests recovered data matches
     assert file_data == test_string
 
     # test if cached data is available after temporary file has vanished
-    assert sg.get_data(f.name, tmp_cache) == test_string
+    test_file.unlink()
+    assert sg.get_data(str(test_file), str(tmp_cache)) == test_string
 
 
 def test_parse_sphinx_docopts():

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -10,7 +10,6 @@ import logging
 import os
 import re
 import shutil
-import tempfile
 import zipfile
 from pathlib import Path
 from unittest import mock
@@ -92,25 +91,22 @@ def test_bug_cases_of_notebook_syntax():
     assert blocks == ref_blocks
 
 
-def test_direct_comment_after_docstring():
+def test_direct_comment_after_docstring(tmp_path):
     # For more details see
     # https://github.com/sphinx-gallery/sphinx-gallery/pull/49
-    with tempfile.NamedTemporaryFile("w", delete=False) as f:
-        f.write(
-            "\n".join(
-                [
-                    '"Docstring"',
-                    "# and now comes the module code",
-                    "# with a second line of comment",
-                    "x, y = 1, 2",
-                    "",
-                ]
-            )
+    filename = tmp_path / "example.txt"
+    filename.write_text(
+        "\n".join(
+            [
+                '"Docstring"',
+                "# and now comes the module code",
+                "# with a second line of comment",
+                "x, y = 1, 2",
+                "",
+            ]
         )
-    try:
-        file_conf, result = split_code_and_text_blocks(f.name)
-    finally:
-        os.remove(f.name)
+    )
+    file_conf, result = split_code_and_text_blocks(filename)
 
     assert file_conf == {}
     expected_result = [
@@ -717,14 +713,11 @@ def test_pattern_matching(gallery_conf, log_collector, req_pil):
         "    # sphinx_gallery_thumbnail_number=2",
     ],
 )
-def test_thumbnail_number(test_str):
+def test_thumbnail_number(test_str, tmp_path):
     """Test correct plot used as thumbnail image."""
-    with tempfile.NamedTemporaryFile("w", delete=False) as f:
-        f.write("\n".join(['"Docstring"', test_str]))
-    try:
-        file_conf, blocks = split_code_and_text_blocks(f.name)
-    finally:
-        os.remove(f.name)
+    filename = tmp_path / "example.py"
+    filename.write_text("\n".join(['"Docstring"', test_str]))
+    file_conf, blocks = split_code_and_text_blocks(filename)
     assert file_conf == {"thumbnail_number": 2}
 
 
@@ -737,14 +730,11 @@ def test_thumbnail_number(test_str):
         "    # sphinx_gallery_thumbnail_path='_static/demo.png'",
     ],
 )
-def test_thumbnail_path(test_str):
+def test_thumbnail_path(test_str, tmp_path):
     """Test correct plot used for thumbnail image."""
-    with tempfile.NamedTemporaryFile("w", delete=False) as f:
-        f.write("\n".join(['"Docstring"', test_str]))
-    try:
-        file_conf, blocks = split_code_and_text_blocks(f.name)
-    finally:
-        os.remove(f.name)
+    filename = tmp_path / "example.py"
+    filename.write_text("\n".join(['"Docstring"', test_str]))
+    file_conf, blocks = split_code_and_text_blocks(filename)
     assert file_conf == {"thumbnail_path": "_static/demo.png"}
 
 

--- a/sphinx_gallery/tests/test_notebook.py
+++ b/sphinx_gallery/tests/test_notebook.py
@@ -4,10 +4,8 @@ r"""Testing the Jupyter notebook parser."""
 
 import base64
 import json
-import os
 import re
 import shutil
-import tempfile
 import textwrap
 from collections import defaultdict
 from itertools import count
@@ -339,19 +337,16 @@ def test_notebook_images_data_uri(gallery_conf):
         rst2md(rst, gallery_conf, str(target_dir), {})
 
 
-def test_jupyter_notebook(gallery_conf):
+def test_jupyter_notebook(gallery_conf, tmp_path):
     """Test that written ipython notebook file corresponds to python object."""
     file_conf, blocks = split_code_and_text_blocks(root / "tutorials" / "plot_parse.py")
     target_dir = "tutorials"
     example_nb = jupyter_notebook(blocks, gallery_conf, target_dir)
 
-    with tempfile.NamedTemporaryFile("w", delete=False) as f:
-        save_notebook(example_nb, f.name)
-    try:
-        with open(f.name) as fname:
-            assert json.load(fname) == example_nb
-    finally:
-        os.remove(f.name)
+    filename = tmp_path / "example.ipynb"
+    save_notebook(example_nb, filename)
+    with filename.open() as fname:
+        assert json.load(fname) == example_nb
 
     # Test custom first cell text
     test_text = "# testing\n%matplotlib notebook"


### PR DESCRIPTION
This removes the need to manage deletions ourselves, and simplifies some code as we have the Path API available.

Also, note that `BlockParser` accepts `Path`.