### PR TITLE
Switch to ty for type checking

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,7 @@ jobs:
           python-version: '3.13'
       - run: pip install check-manifest
       - run: check-manifest
+      - uses: j178/prek-action@v2
   pytest:
     name: '${{ matrix.os }} / ${{ matrix.python }} / ${{ matrix.distrib }} / ${{ matrix.sphinx_version }}'
     timeout-minutes: 30
@@ -29,6 +30,7 @@ jobs:
     defaults:
       run:
         shell: bash -el {0}
+    needs: [style]
     env:
       PYTHON_VERSION: '${{ matrix.python }}'
       SPHINX_VERSION: '${{ matrix.sphinx_version }}'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - uses: j178/prek-action@v2
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - run: pip install check-manifest
       - run: check-manifest
-      - uses: j178/prek-action@v2
   pytest:
     name: '${{ matrix.os }} / ${{ matrix.python }} / ${{ matrix.distrib }} / ${{ matrix.sphinx_version }}'
     timeout-minutes: 30
@@ -30,7 +30,6 @@ jobs:
     defaults:
       run:
         shell: bash -el {0}
-    needs: [style]
     env:
       PYTHON_VERSION: '${{ matrix.python }}'
       SPHINX_VERSION: '${{ matrix.sphinx_version }}'

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ target/
 
 # Default JupyterLite content
 jupyterlite_contents
+
+# ty pre-commit
+/uv.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,7 @@ repos:
           - types-Pillow
           - types-Pygments
           - sphinx <9.1  # last to support 3.10
+        args: [--no-python-downloads, --no-project]
 
 # https://github.com/astral-sh/ty-pre-commit#running-pre-commit-in-ci-with-ty-pre-commit
 ci:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,14 +38,14 @@ repos:
     hooks:
       - id: validate-pyproject
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.59
     hooks:
-      - id: mypy
-        exclude: "^(examples|doc)/"
+      - id: ty
         additional_dependencies:
           - numpy
           - types-docutils
           - types-Pillow
           - types-Pygments
           - sphinx <9.1  # last to support 3.10
+        args: [--no-python-downloads, --no-project]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,4 +48,7 @@ repos:
           - types-Pillow
           - types-Pygments
           - sphinx <9.1  # last to support 3.10
-        args: [--no-python-downloads, --no-project]
+
+# https://github.com/astral-sh/ty-pre-commit#running-pre-commit-in-ci-with-ty-pre-commit
+ci:
+  skip: [ty]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/astral-sh/ty-pre-commit
-    rev: v0.0.58
+    rev: v0.0.59
     hooks:
       - id: ty
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/astral-sh/ty-pre-commit
-    rev: v0.0.59
+    rev: v0.0.58
     hooks:
       - id: ty
         additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ optional-dependencies.dev = [
   "jupyterlite-sphinx>=0.17.1",
   "lxml",
   "matplotlib",
-  "mypy",
   "numpy",
   "packaging",
   "plotly",
@@ -56,9 +55,7 @@ optional-dependencies.dev = [
   "sphinx-design",
   "sphinxcontrib-video",
   "statsmodels",
-  "types-docutils",
-  "types-pillow",
-  "types-pygments",
+  "ty",
 ]
 optional-dependencies.jupyterlite = [
   "jupyterlite-sphinx",
@@ -144,48 +141,37 @@ builtin = "clear,rare,informal,names,usage"
 # Words are case sensitive based on how they are written in the dictionary file
 ignore-words-list = "master"
 
-[tool.mypy]
-exclude = [
-  "^build/",
-  "^doc/",
-  "^examples/",
-  "^examples/plotly_examples/",
-  "^pyvista_examples/",
-  "^sphinx_gallery/tests/tinybuild/",
-  "^sphinx_gallery\\.egg-info/",
-  "^tutorials/",
+[tool.ty]
+src.exclude = [
+  "build/",
+  "doc/",
+  "examples/",
+  "plotly_examples/",
+  "pyvista_examples/",
+  "sphinx_gallery.egg-info/",
+  "sphinx_gallery/tests/tinybuild/",
+  "tutorials/",
 ]
-python_version = "3.10"  # keep in sync with requires-python
-disallow_untyped_defs = false
-disallow_incomplete_defs = false
-check_untyped_defs = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-warn_no_return = true
-warn_return_any = true
-local_partial_types = true
-strict_equality = true
-warn_unused_configs = true
-no_implicit_optional = true
-show_error_codes = true
-
-# Ignore test files for now
-[[tool.mypy.overrides]]
-module = "sphinx_gallery.tests.*"
-ignore_errors = true
-
+environment.python-version = "3.10"  # keep in sync with requires-python
+overrides = [
+  # Ignore test files for now
+  { include = [ "sphinx_gallery/tests/**" ], rules.all = "ignore" },
+]
 # Third-party packages without type stubs
-[[tool.mypy.overrides]]
-module = [
+analysis.allowed-unresolved-imports = [
   "graphviz",
+  "joblib",
   "joblib.*",
+  "matplotlib",
   "matplotlib.*",
+  "memory_profiler",
   "memory_profiler.*",
+  "plotly",
   "plotly.*",
   "pypandoc",
+  "seaborn",
   "seaborn.*",
 ]
-ignore_missing_imports = true
 
 [tool.pytest]
 ini_options.norecursedirs = "build _build auto_examples gen_modules sphinx_gallery/tests/tinybuild"

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -457,7 +457,7 @@ def _write_backreferences(
         )
         seen = backref in seen_backrefs
         mode = "a" if seen else "w"
-        with open(include_path, mode, **_W_KW) as ex_file:  # type: ignore[call-overload]
+        with open(include_path, mode, **_W_KW) as ex_file:
             if not seen:
                 # Be aware that if the number of lines of this heading changes,
                 # the minigallery directive should be modified accordingly
@@ -502,7 +502,7 @@ def _finalize_backreferences(
         if os.path.isfile(path):
             # Close div containing all thumbnails
             # (it was open in _write_backreferences)
-            with open(path, "a", **_W_KW) as ex_file:  # type: ignore[call-overload]
+            with open(path, "a", **_W_KW) as ex_file:
                 ex_file.write(THUMBNAIL_PARENT_DIV_CLOSE)
             _replace_md5(path, mode="t")
         else:

--- a/sphinx_gallery/block_parser.py
+++ b/sphinx_gallery/block_parser.py
@@ -243,7 +243,7 @@ class BlockParser:
         block: list[str] = []
         mode: Literal["text", "code"] | None = None
         for n, (token, text) in enumerate(self._get_content_lines(content)):
-            if mode == "text" and token in pygments.token.Whitespace:  # type: ignore[comparison-overlap]
+            if mode == "text" and token in pygments.token.Whitespace:
                 # Blank line ends current text block
                 if block:
                     yield finalize_block(mode, block)
@@ -286,7 +286,9 @@ class BlockParser:
                     else:
                         block.append(text)
                 else:
-                    block.append(self.continue_text.search(text).group(1))  # type: ignore[union-attr]
+                    m = self.continue_text.search(text)
+                    assert m is not None
+                    block.append(m.group(1))
             elif mode != "code":
                 # start of a code block
                 if block:

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -329,8 +329,8 @@ def _get_intersphinx_inventory(app: sphinx.application.Sphinx) -> IntersphinxInv
     adds that additional module mapping.
     """
     inventory: IntersphinxInventory
-    if inventory := getattr(app.env, "sg_intersphinx_inventory", None):  # type: ignore[assignment]
-        return inventory  # type: ignore[no-any-return]
+    if inventory := getattr(app.env, "sg_intersphinx_inventory", None):  # ty: ignore[invalid-assignment]
+        return inventory
 
     # Make a copy of the inventories, because this dict is created by intersphinx and we
     # don't want to break whatever assumptions it has made about it.
@@ -343,7 +343,7 @@ def _get_intersphinx_inventory(app: sphinx.application.Sphinx) -> IntersphinxInv
         for other_module_name in documented_modules - {module_name}:
             intersphinx_inv[other_module_name] = inventory
 
-    app.env.sg_intersphinx_inventory = intersphinx_inv  # type: ignore[attr-defined]
+    setattr(app.env, "sg_intersphinx_inventory", intersphinx_inv)
     return intersphinx_inv
 
 
@@ -500,7 +500,7 @@ def _embed_code_links(
         if len(str_repl) > 0:
             with open(full_fname, "r", encoding="utf-8") as fid:
                 lines_in = fid.readlines()
-            with open(full_fname, "w", **_W_KW) as fid:  # type: ignore[call-overload]
+            with open(full_fname, "w", **_W_KW) as fid:
                 for line in lines_in:
                     line_out = regex.sub(substitute_link, line)
                     fid.write(line_out)

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -310,7 +310,7 @@ def _check_matplotlib_animations(
         )
     # Handle file format
     if len(animations) > 1:
-        fmt = animations[1]
+        fmt = animations[1]  # ty: ignore[index-out-of-bounds]
         if fmt is not None:
             if not isinstance(fmt, str):
                 raise ConfigError(
@@ -371,7 +371,7 @@ def _fill_gallery_conf_defaults(
     check_keys: bool = True,
 ) -> GalleryConfig:
     """Handle user configs, update default gallery configs and check values."""
-    gallery_conf = copy.deepcopy(DEFAULT_GALLERY_CONF)
+    gallery_conf: GalleryConfig = copy.deepcopy(DEFAULT_GALLERY_CONF)
     _check_extra_config_keys(gallery_conf, sphinx_gallery_conf, check_keys)
 
     gallery_conf.update(sphinx_gallery_conf)
@@ -402,7 +402,7 @@ def _fill_gallery_conf_defaults(
     # Check capture_repr
     _check_config_type(gallery_conf, "capture_repr", (tuple, list), str_to_list=True)
     supported_reprs = ["__repr__", "__str__", "_repr_html_"]
-    for rep in gallery_conf["capture_repr"]:  # type: ignore[attr-defined]
+    for rep in gallery_conf["capture_repr"]:
         if rep not in supported_reprs:
             raise ConfigError(
                 "All entries in 'capture_repr' must be one "
@@ -494,17 +494,17 @@ def _fill_gallery_conf_defaults(
         gallery_conf["backreferences_dir"] = str(backref)
 
     # binder
-    gallery_conf["binder"] = check_binder_conf(gallery_conf["binder"])  # type: ignore[arg-type]
+    gallery_conf["binder"] = check_binder_conf(gallery_conf["binder"])
 
     # jupyterlite
     gallery_conf["jupyterlite"] = check_jupyterlite_conf(
-        gallery_conf["jupyterlite"],  # type: ignore[arg-type]
+        gallery_conf["jupyterlite"],
         app,
     )
 
     # css
     _check_config_type(gallery_conf, "css", (list, tuple), str_to_list=True)
-    for css in gallery_conf["css"]:  # type: ignore[attr-defined]
+    for css in gallery_conf["css"]:
         if css not in _KNOWN_CSS:
             raise ConfigError(f"Unknown css {css!r}, must be one of {_KNOWN_CSS!r}")
         if app is not None:  # can be None in testing

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -16,6 +16,7 @@ import contextlib
 import copy
 import gc
 import importlib
+import importlib.util
 import inspect
 import os
 import re
@@ -30,7 +31,7 @@ from pathlib import Path
 from shutil import copyfile
 from textwrap import indent
 from time import time
-from typing import TYPE_CHECKING, Any, Callable, Literal, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, TextIO, cast
 
 import sphinx.util
 from sphinx.errors import ConfigError, ExtensionError
@@ -534,7 +535,7 @@ def _write_subsection_index(
     if gallery_conf["nested_sections"] and not user_index_rst and is_subsection:
         index_path = os.path.join(target_dir, "index.rst.new")
         head_ref = os.path.relpath(target_dir, gallery_conf["src_dir"])
-        with open(index_path, "w", **_W_KW) as findex:  # type: ignore [call-overload]
+        with open(index_path, "w", **_W_KW) as findex:
             findex.write(
                 "\n\n.. _sphx_glr_{}:\n\n".format(head_ref.replace(os.sep, "_"))
             )
@@ -802,7 +803,7 @@ def handle_exception(
             # Our internal input() check
             elif s.name == "_check_input" and ii == len(stack):
                 stop = ii - 1
-    stack = stack[start:stop]  # type: ignore[assignment]
+    stack = stack[start:stop]
 
     formatted_exception = "Traceback (most recent call last):\n" + "".join(
         traceback.format_list(stack) + traceback.format_exception_only(etype, exc)
@@ -843,7 +844,7 @@ def _showwarning(
     category: type[Warning],
     filename: str,
     lineno: int,
-    file: Any = None,
+    file: TextIO | None = None,
     line: str | None = None,
 ) -> None:
     if file is None:
@@ -867,7 +868,7 @@ def patch_warnings() -> Any:
     # capture them, so let's patch over their patch...
     orig_showwarning = warnings.showwarning
     try:
-        warnings.showwarning = _showwarning
+        warnings.showwarning = _showwarning  # ty: ignore[invalid-assignment]
         yield
     finally:
         warnings.showwarning = orig_showwarning
@@ -961,10 +962,15 @@ def _exec_and_get_memory(
     call_memory, _ = _get_call_memory_and_base(gallery_conf)
     if len(code_ast.body) and isinstance(code_ast.body[-1], ast.Expr):
         is_last_expr = True
-        last_val = code_ast.body.pop().value  # type: ignore[attr-defined]
+        last_stmt = code_ast.body.pop()
+        assert isinstance(last_stmt, ast.Expr)
+        last_val = last_stmt.value
         # exec body minus last expression
         mem_body, _ = call_memory(
-            _exec_once(compiler(code_ast, src_file, "exec"), script_vars["fake_main"])  # type: ignore[arg-type]
+            _exec_once(
+                compiler(code_ast, src_file, "exec"),  # ty: ignore[invalid-argument-type]
+                script_vars["fake_main"],
+            )
         )
         # exec last expression, made into assignment
         body: list[ast.stmt] = [
@@ -975,14 +981,17 @@ def _exec_and_get_memory(
         ast.fix_missing_locations(last_val_ast)
         mem_last, _ = call_memory(
             _exec_once(
-                compiler(last_val_ast, src_file, "exec"),  # type: ignore[arg-type]
+                compiler(last_val_ast, src_file, "exec"),  # ty: ignore[invalid-argument-type]
                 script_vars["fake_main"],
             )
         )
         mem_max = max(mem_body, mem_last)
     else:
         mem_max, _ = call_memory(
-            _exec_once(compiler(code_ast, src_file, "exec"), script_vars["fake_main"])  # type: ignore[arg-type]
+            _exec_once(
+                compiler(code_ast, src_file, "exec"),  # ty: ignore[invalid-argument-type]
+                script_vars["fake_main"],
+            )
         )
     return is_last_expr, mem_max
 
@@ -1066,8 +1075,8 @@ def _get_code_output(
     captured_std = ansi_escape.sub("", captured_std)
 
     # give html output its own header
-    if repr_meth == "_repr_html_":
-        captured_html = HTML_HEADER.format(indent(last_repr, " " * 4))  # type: ignore[arg-type]
+    if repr_meth == "_repr_html_" and last_repr is not None:
+        captured_html = HTML_HEADER.format(indent(last_repr, " " * 4))
     else:
         captured_html = ""
 
@@ -1149,7 +1158,7 @@ def execute_code_block(
     # `sphinx_gallery_capture_repr_block` setting, then the file-level
     # `sphinx_gallery_capture_repr` setting, and finally the
     # global `capture_repr` gallery setting.
-    capture_repr: tuple[str, ...] = block_conf.get(  # type: ignore[assignment]
+    capture_repr: tuple[str, ...] = block_conf.get(
         "capture_repr_block",
         file_conf.get("capture_repr", gallery_conf["capture_repr"]),
     )
@@ -1274,9 +1283,9 @@ def execute_script(
     # sys.modules when running our example
     call_memory, _ = _get_call_memory_and_base(gallery_conf)
 
-    fake_main = importlib.util.module_from_spec(
-        importlib.util.spec_from_loader("__main__", None)  # type: ignore[arg-type]
-    )
+    fake_main_spec = importlib.util.spec_from_loader("__main__", None)
+    assert fake_main_spec is not None
+    fake_main = importlib.util.module_from_spec(fake_main_spec)
     example_globals = fake_main.__dict__
 
     example_globals.update(
@@ -1791,7 +1800,7 @@ def save_rst_example(
         example_rst += SPHX_GLR_SIG
 
     write_file_new = example_file.with_suffix(".rst.new")
-    with open(write_file_new, "w", **_W_KW) as f:  # type: ignore[call-overload]
+    with open(write_file_new, "w", **_W_KW) as f:
         f.write(example_rst)
     # make it read-only so that people don't try to edit it
     mode = os.stat(write_file_new).st_mode

--- a/sphinx_gallery/notebook.py
+++ b/sphinx_gallery/notebook.py
@@ -140,7 +140,7 @@ def rst2md(
     text = re.sub(
         headings,
         lambda match: "{1}{0} {2}".format(
-            "#" * heading_levels[match.group("over", "under")],  # type: ignore[index]
+            "#" * heading_levels[match.group("over", "under")],
             *match.group("pre", "heading"),
         ),
         text,

--- a/sphinx_gallery/recommender.py
+++ b/sphinx_gallery/recommender.py
@@ -209,6 +209,7 @@ class ExampleRecommender:
         ):
             raise ValueError("max_df must be float in range [0.0, 1.0] or int")
 
+        file_names = list(file_names)
         freq_func = self.token_freqs
         counts_matrix = self.dict_vectorizer(
             [freq_func(Path(fname).read_text(encoding="utf-8")) for fname in file_names]

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -19,7 +19,7 @@ import re
 import sys
 from pathlib import Path, PurePosixPath
 from textwrap import indent
-from typing import TYPE_CHECKING, Any, Callable, Iterator, TypeAlias
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, TypeAlias
 from warnings import filterwarnings
 
 from sphinx.errors import ExtensionError
@@ -28,6 +28,7 @@ from .typing import GalleryConfig
 from .utils import optipng
 
 if TYPE_CHECKING:
+    import matplotlib.animation
     import matplotlib.figure
 
     from .py_source_parser import Block
@@ -98,7 +99,7 @@ def _matplotlib_fig_titles(fig: matplotlib.figure.Figure) -> str:
     if suptitle is not None:
         titles.append(suptitle.get_text())
     # get titles from all axes, for all locs
-    title_locs = ["left", "center", "right"]
+    title_locs: list[Literal["left", "center", "right"]] = ["left", "center", "right"]
     for ax in fig.axes:
         for loc in title_locs:
             text = ax.get_title(loc=loc)
@@ -635,8 +636,9 @@ def clean_modules(gallery_conf: GalleryConfig, fname: str | None, when: str) -> 
         if len(sig.parameters) == 3:
             third_param = list(sig.parameters.keys())[2]
             if third_param != "when":
+                name = getattr(reset_module, "__name__", repr(reset_module))
                 raise ValueError(
-                    f"3rd parameter in {reset_module.__name__} "
+                    f"3rd parameter in {name} "
                     "function signature must be 'when', "
                     f"got {third_param}"
                 )

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -263,7 +263,7 @@ def _anim_rst(
 
     # output the thumbnail as the image, as it will just be copied
     # if it's the file thumbnail
-    fig = anim._fig  # ty: ignore[unresolved-attribute]
+    fig = anim._fig
     gif_image_path = Path(image_path).with_suffix(".gif")
     fig_size = fig.get_size_inches()
     thumb_size = gallery_conf["thumbnail_size"]

--- a/sphinx_gallery/scrapers.py
+++ b/sphinx_gallery/scrapers.py
@@ -263,7 +263,7 @@ def _anim_rst(
 
     # output the thumbnail as the image, as it will just be copied
     # if it's the file thumbnail
-    fig = anim._fig
+    fig = anim._fig  # ty: ignore[unresolved-attribute]
     gif_image_path = Path(image_path).with_suffix(".gif")
     fig_size = fig.get_size_inches()
     thumb_size = gallery_conf["thumbnail_size"]

--- a/sphinx_gallery/utils.py
+++ b/sphinx_gallery/utils.py
@@ -15,22 +15,28 @@ import zipfile
 from functools import partial
 from pathlib import Path
 from shutil import copyfile, move
-from typing import Any, Callable, Iterator, Literal, Tuple
+from typing import Any, Callable, Iterator, Literal, Tuple, TypedDict
 
 import sphinx.util
 
 try:
     from sphinx.util.display import status_iterator  # noqa: F401
 except Exception:  # Sphinx < 6
-    from sphinx.util import status_iterator  # type: ignore[no-redef]  # noqa: F401
+    from sphinx.util import status_iterator  # noqa: F401
 
 from .typing import GalleryConfig
 
 logger = sphinx.util.logging.getLogger("sphinx-gallery")
 
 
-# Text writing kwargs for builtins.open
-_W_KW = dict(encoding="utf-8", newline="\n")
+class _WriteKwargs(TypedDict):
+    """Text writing kwargs for builtins.open."""
+
+    encoding: str
+    newline: str
+
+
+_W_KW: _WriteKwargs = {"encoding": "utf-8", "newline": "\n"}
 
 
 def scale_image(in_fname: str, out_fname: str, max_width: int, max_height: int) -> None:
@@ -345,7 +351,7 @@ def _format_toctree(items: list[str], includehidden: bool = False) -> str:
 def _write_json(target_file: Path, to_save: dict, name: str = "") -> None:
     """Write dictionary to JSON file."""
     codeobj_fname = Path(target_file).with_name(target_file.stem + f"{name}.json.new")
-    with open(codeobj_fname, "w", **_W_KW) as fid:  # type: ignore[call-overload]
+    with open(codeobj_fname, "w", **_W_KW) as fid:
         json.dump(
             to_save,
             fid,


### PR DESCRIPTION
The `mypy` failure in https://github.com/sphinx-gallery/sphinx-gallery/pull/1623 is annoying -- let's switch to `ty`. It's much faster and I've been using it successfully in a few projects for months now. It already caught some issues here in the switch!

Worked with Claude Opus 4.8 to make these changes but fully understand them