### PR TITLE
Fix Binder links in published documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -410,6 +410,7 @@ sphinx_gallery_conf = {
         "branch": "master",
         "binderhub_url": "https://mybinder.org",
         "dependencies": "./binder/requirements.txt",
+        "filepath_prefix": "dev" if "dev" in version else "stable",
         "notebooks_dir": "notebooks",
         "use_jupyter_lab": True,
     },

--- a/sphinx_gallery/tests/test_interactive_example.py
+++ b/sphinx_gallery/tests/test_interactive_example.py
@@ -4,6 +4,7 @@
 
 import os
 import re
+import runpy
 from copy import deepcopy
 from pathlib import Path
 from unittest.mock import Mock
@@ -12,6 +13,7 @@ import pytest
 from sphinx.application import Sphinx
 from sphinx.errors import ConfigError
 
+import sphinx_gallery
 from sphinx_gallery.interactive_example import (
     _copy_binder_reqs,
     check_binder_conf,
@@ -20,6 +22,16 @@ from sphinx_gallery.interactive_example import (
     gen_binder_url,
     gen_jupyterlite_rst,
 )
+
+
+@pytest.mark.parametrize(
+    ("package_version", "docs_version"),
+    [("1.2.3", "stable"), ("1.3.dev0", "dev")],
+)
+def test_doc_binder_filepath_prefix(monkeypatch, package_version, docs_version):
+    monkeypatch.setattr(sphinx_gallery, "__version__", package_version)
+    conf = runpy.run_path(Path(__file__).parents[2] / "doc" / "conf.py")
+    assert conf["sphinx_gallery_conf"]["binder"]["filepath_prefix"] == docs_version
 
 
 def test_binder():


### PR DESCRIPTION
The Binder links in the published stable and development documentation currently omit the deployment directory, so they point to notebooks that do not exist.

This sets `filepath_prefix` from the package version, using `dev` for development builds and `stable` for releases. It also adds a regression test for both paths.

Fixes #1092

Checks:

- `uv run --extra dev pytest -q sphinx_gallery/tests/test_interactive_example.py`
- `uv run --extra dev pytest -q sphinx_gallery/tests/test_full.py::test_interactive_example_logo_exists`
- `uvx pre-commit run --files doc/conf.py sphinx_gallery/tests/test_interactive_example.py`
