### PR TITLE
ENH: Allow examples to opt out of parallel execution

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -112,6 +112,7 @@ Some options can also be set or overridden on a file-by-file basis:
 - ``# sphinx_gallery_capture_repr`` (:ref:`capture_repr`)
 - ``# sphinx_gallery_multi_image`` (:ref:`multi_image`)
 - ``# sphinx_gallery_tags`` (:ref:`tagging_examples`)
+- ``# sphinx_gallery_parallel`` (:ref:`parallel`)
 
 Some options can be set on a per-code-block basis in a file:
 
@@ -2328,6 +2329,25 @@ Sphinx warnings during documentation building into errors.
     (e.g., pickling, oversubscription of CPU resources, etc.).
 
     Using parallel building will also disable memory measurements.
+
+Excluding individual examples from parallel execution
+"""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Individual examples that cannot be run in a worker process -- for example because
+they use :mod:`multiprocessing` themselves, require a library that is not
+fork/spawn safe, or need exclusive access to a resource such as a GPU -- can opt out
+by adding the following comment anywhere in the example file::
+
+    # sphinx_gallery_parallel = False
+
+Such examples are executed one at a time in the main process, before anything is
+dispatched to the worker processes, so that no other example is running while they
+execute. This is exactly how they would be run with ``'parallel': False``. The
+setting has no effect when parallel building is disabled.
+
+Note that this affects execution order but not the order of the gallery itself,
+which is still determined by
+:ref:`within_subsection_order <within_gallery_order>`.
 
 .. _recommend_examples:
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -27,6 +27,7 @@ import warnings
 from dataclasses import dataclass
 from functools import lru_cache
 from io import StringIO
+from itertools import islice
 from pathlib import Path
 from shutil import copyfile
 from textwrap import indent
@@ -567,6 +568,33 @@ def _copy_non_example_files(
             _replace_md5(src_file, fname_old=target_file, method="copy")
 
 
+def _split_parallel(
+    sorted_listdir: list[str], src_dir: str, gallery_conf: GalleryConfig
+) -> tuple[list[str], list[str]]:
+    """Split examples into those that opt out of parallel execution, and the rest.
+
+    Both lists keep their relative order from ``sorted_listdir``.
+    """
+    serial_listdir = []
+    parallel_listdir = []
+    for fname in sorted_listdir:
+        parser, _ = _get_parser(fname, gallery_conf)
+        src_file = os.path.normpath(os.path.join(src_dir, fname))
+        # full parse rather than a cheaper regex over the file, so that we see exactly
+        # the same file_conf as `generate_file_rst` (e.g. docstrings are excluded)
+        file_conf = parser.split_code_and_text_blocks(src_file, return_node=True)[0]
+        run_parallel = file_conf.get("parallel", True)
+        if not isinstance(run_parallel, bool):
+            logger.warning(
+                "sphinx_gallery_parallel setting is not a boolean, got %r in file %s",
+                run_parallel,
+                fname,
+            )
+            run_parallel = True
+        (parallel_listdir if run_parallel else serial_listdir).append(fname)
+    return serial_listdir, parallel_listdir
+
+
 def generate_dir_rst(
     src_dir: str,
     target_dir: str,
@@ -656,32 +684,45 @@ def generate_dir_rst(
     costs = []
     toctree_filenames = []
     build_target_dir = os.path.relpath(target_dir, gallery_conf["src_dir"])
+    backrefs_dir: dict[str, list[Backreference]] = {}
+
+    # Always split, so that a bad in-file setting is reported even in serial builds
+    serial_listdir, parallel_listdir = _split_parallel(
+        sorted_listdir, src_dir, gallery_conf
+    )
+    if not gallery_conf["parallel"]:
+        # everything runs here anyway, so keep the original order
+        serial_listdir, parallel_listdir = sorted_listdir, []
+
     iterator = status_iterator(
-        sorted_listdir,
+        serial_listdir + parallel_listdir,
         f"generating gallery for {build_target_dir}... ",
         length=len(sorted_listdir),
     )
 
-    backrefs_dir: dict[str, list[Backreference]] = {}
-
-    parallel = list
-    p_fun = generate_file_rst
-    if gallery_conf["parallel"]:
+    # Examples opting out of parallelism run first, alone in this process, so that
+    # nothing else is executing while they do
+    results = [
+        generate_file_rst(fname, target_dir, src_dir, gallery_conf)
+        for fname in islice(iterator, len(serial_listdir))
+    ]
+    if parallel_listdir:
         from joblib import Parallel, delayed
 
-        p_fun = delayed(generate_file_rst)
         parallel = Parallel(
             n_jobs=gallery_conf["parallel"],
             pre_dispatch="n_jobs",
             batch_size=1,
             backend="loky",
         )
-
-    results = parallel(
-        p_fun(fname, target_dir, src_dir, gallery_conf) for fname in iterator
-    )
-    for fi, (intro, title, (t, mem), out_vars) in enumerate(results):
-        fname = sorted_listdir[fi]
+        results += parallel(
+            delayed(generate_file_rst)(fname, target_dir, src_dir, gallery_conf)
+            for fname in iterator
+        )
+    # Restore gallery (not execution) order so the index and toctree are unaffected
+    results_by_fname = dict(zip(serial_listdir + parallel_listdir, results))
+    for fname in sorted_listdir:
+        intro, title, (t, mem), out_vars = results_by_fname[fname]
         src_file = os.path.normpath(os.path.join(src_dir, fname))
         gallery_conf["titles"][src_file] = title
         # n.b. non-executable files have none of these three variables defined,

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -34,7 +34,7 @@ from sphinx_gallery.utils import (
 #
 # total number of plot_*.py files in
 # (examples + examples_rst_index + examples_with_rst + examples_README_header)
-N_EXAMPLES = 19 + 3 + 2 + 1
+N_EXAMPLES = 20 + 3 + 2 + 1
 N_FAILING = 4
 N_GOOD = N_EXAMPLES - N_FAILING  # galleries that run w/o error
 # passthroughs and non-executed examples in
@@ -906,7 +906,7 @@ def test_rebuild(tmp_path_factory, sphinx_app):
     else:
         assert (
             re.match(
-                ".*[01] added, ([1-9]|1[0-2]) changed, 0 removed$.*",
+                ".*[01] added, ([1-9]|1[0-3]) changed, 0 removed$.*",
                 status,
                 re.MULTILINE | re.DOTALL,
             )
@@ -1072,6 +1072,7 @@ def _rerun(
     # - auto_examples/future/sg_execution_times
     # - auto_examples/plot_failing_example
     # - auto_examples/plot_failing_example_thumbnail
+    # - auto_examples/plot_no_parallel
     # - auto_examples/plot_scraper_broken
     # - auto_examples/rst_gallery_entry
     # - auto_examples/sg_execution_times
@@ -1087,9 +1088,9 @@ def _rerun(
     # - auto_examples/index
     # - auto_examples/plot_numpy_matplotlib
     if how == "modify":
-        n_ch = "([3-9]|1[0-3])"  # 3-13
+        n_ch = "([3-9]|1[0-4])"  # 3-14
     else:
-        n_ch = "([1-9]|1[0-2])"  # 1-12
+        n_ch = "([1-9]|1[0-3])"  # 1-13
     lines = "\n".join([f"\n{how} != {n_ch}:"] + lines)
     want = f".*updating environment:.*[01] added, {n_ch} changed, 0 removed.*"
     assert re.match(want, status, flags) is not None, lines

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -1197,8 +1197,14 @@ def test_split_parallel(gallery_conf, log_collector, fname, content, serial, n_w
 @pytest.mark.parametrize("n_jobs", [2, False])
 def test_parallel_serial_examples(gallery_conf, n_jobs):
     """Examples opting out of parallelism run in the main process, in gallery order."""
-    pytest.importorskip("joblib")
-    gallery_conf.update(parallel=n_jobs, within_subsection_order="FileNameSortKey")
+    if n_jobs:
+        pytest.importorskip("joblib")
+    gallery_conf.update(
+        parallel=n_jobs,
+        within_subsection_order="FileNameSortKey",
+        image_scrapers=(),
+        reset_modules=(),
+    )
     Path(gallery_conf["examples_dir"], "README.txt").write_text("")
     names = ["plot_a", "plot_b", "plot_c"]
     # each example appends "<name>:<main|worker>" as it runs, so we see the real order
@@ -1234,6 +1240,7 @@ def test_parallel_serial_examples(gallery_conf, n_jobs):
 
 def test_split_parallel_serial_build(gallery_conf, log_collector):
     """A bad in-file parallel setting is reported even when parallel is disabled."""
+    gallery_conf.update(image_scrapers=(), reset_modules=())
     Path(gallery_conf["examples_dir"], "README.txt").write_text("")
     Path(gallery_conf["examples_dir"], "plot_a.py").write_text(
         DOCSTRING + "# sphinx_gallery_parallel = 2\n", encoding="utf-8"

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -1158,6 +1158,97 @@ def test_reset_module_order_3_param_invalid_when(gallery_conf):
     assert mock_reset_module.call_count == 0
 
 
+DOCSTRING = '"""\nTitle\n=====\n\nIntro.\n"""\n'
+
+
+@pytest.mark.parametrize(
+    ("fname", "content", "serial", "n_warn"),
+    [
+        ("plot.py", DOCSTRING + "# sphinx_gallery_parallel = False\n", True, 0),
+        ("plot.py", DOCSTRING + "x = 1\n", False, 0),
+        # comment syntax is language-specific, and .rst has no in-file config at all
+        (
+            "plot.cpp",
+            "// Title\n// =====\n// sphinx_gallery_parallel = False\n",
+            True,
+            0,
+        ),
+        ("plot.rst", "Title\n=====\n", False, 0),
+        # a non-bool value warns and is ignored
+        ("plot.py", DOCSTRING + "# sphinx_gallery_parallel = 2\n", False, 1),
+        # merely documenting the flag in the docstring must not set it
+        (
+            "plot.py",
+            '"""\nTitle\n=====\n\n    # sphinx_gallery_parallel = False\n"""\n',
+            False,
+            0,
+        ),
+    ],
+    ids=["py", "py-unset", "cpp", "rst", "non-bool", "docstring"],
+)
+def test_split_parallel(gallery_conf, log_collector, fname, content, serial, n_warn):
+    """Test that the in-file parallel flag is picked up as each parser would."""
+    Path(gallery_conf["examples_dir"], fname).write_text(content, encoding="utf-8")
+    got = sg._split_parallel([fname], gallery_conf["examples_dir"], gallery_conf)
+    assert got == (([fname], []) if serial else ([], [fname]))
+    assert log_collector.warning.call_count == n_warn
+
+
+@pytest.mark.parametrize("n_jobs", [2, False])
+def test_parallel_serial_examples(gallery_conf, n_jobs):
+    """Examples opting out of parallelism run in the main process, in gallery order."""
+    pytest.importorskip("joblib")
+    gallery_conf.update(parallel=n_jobs, within_subsection_order="FileNameSortKey")
+    Path(gallery_conf["examples_dir"], "README.txt").write_text("")
+    names = ["plot_a", "plot_b", "plot_c"]
+    # each example appends "<name>:<main|worker>" as it runs, so we see the real order
+    log = Path(gallery_conf["gallery_dir"], "order.log")
+    for name in names:
+        # only the middle example is serial, so execution order != gallery order
+        flag = "# sphinx_gallery_parallel = False\n" if name == "plot_b" else ""
+        Path(gallery_conf["examples_dir"], f"{name}.py").write_text(
+            f"{DOCSTRING}{flag}import multiprocessing\nfrom pathlib import Path\n"
+            'where = "main" if multiprocessing.parent_process() is None else "worker"\n'
+            f'Path(r"{log}").open("a").write(f"{name}:{{where}} ")\n',
+            encoding="utf-8",
+        )
+
+    _, index_content, _, toctree_items, _ = generate_dir_rst(
+        gallery_conf["examples_dir"],
+        gallery_conf["gallery_dir"],
+        gallery_conf,
+        set(),
+        is_subsection=False,
+    )
+
+    ran = log.read_text(encoding="utf-8").split()
+    if n_jobs:
+        # serial examples finish before anything is dispatched; the rest race
+        assert ran[0] == "plot_b:main"
+        assert sorted(ran[1:]) == ["plot_a:worker", "plot_c:worker"]
+    else:
+        assert ran == [f"{name}:main" for name in names]
+    assert [Path(item).name for item in toctree_items] == names
+    assert re.findall(r"sphx_glr_(plot_[abc])_thumb", index_content) == names
+
+
+def test_split_parallel_serial_build(gallery_conf, log_collector):
+    """A bad in-file parallel setting is reported even when parallel is disabled."""
+    Path(gallery_conf["examples_dir"], "README.txt").write_text("")
+    Path(gallery_conf["examples_dir"], "plot_a.py").write_text(
+        DOCSTRING + "# sphinx_gallery_parallel = 2\n", encoding="utf-8"
+    )
+    generate_dir_rst(
+        gallery_conf["examples_dir"],
+        gallery_conf["gallery_dir"],
+        gallery_conf,
+        set(),
+        is_subsection=False,
+    )
+    assert log_collector.warning.call_count == 1
+    assert "not a boolean" in log_collector.warning.call_args[0][0]
+
+
 @pytest.fixture
 def log_collector_wrap(log_collector):
     """Wrap our log_collector."""

--- a/sphinx_gallery/tests/tinybuild/examples/plot_no_parallel.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_no_parallel.py
@@ -1,0 +1,13 @@
+"""
+No parallel
+-----------
+
+This example opts out of parallel execution.
+"""
+
+import multiprocessing
+
+# sphinx_gallery_parallel = False
+
+assert multiprocessing.parent_process() is None, "did not run in the main process"
+print("ran serially")


### PR DESCRIPTION
Closes #1519

@rossbar can you give it a shot locally or in your file? You can add:
```
# sphinx_gallery_parallel = False
```
To the serial-only examples. (Someday we could make this regex-able, but I think a per-example config option makes sense to start to see if it's good enough.)

Changes drafted by Claude Opus 5 and reviewed by me.
