### PR TITLE
Run the duplicate checks and tag warnings with a type and subtype

### DIFF
--- a/.circleci/build_docs_skl.sh
+++ b/.circleci/build_docs_skl.sh
@@ -30,5 +30,8 @@ uv pip install --only-binary=:all: \
 # Checkout scikit-learn main branch, to build docs from repo
 git clone git@github.com:scikit-learn/scikit-learn.git --single-branch --depth 1 --branch ${VERSION}.X
 cd scikit-learn/doc
-export EXAMPLES_PATTERN="plot_grid_search_text_feature_extraction|plot_display_object_visualization"
+# plot_roc_curve_visualization_api rather than plot_display_object_visualization:
+# same Display objects, but the wine dataset ships with scikit-learn, where the
+# latter fetches from OpenML and fails the build whenever that times out
+export EXAMPLES_PATTERN="plot_grid_search_text_feature_extraction|plot_roc_curve_visualization_api"
 make html

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -173,6 +173,9 @@ to your ``conf.py`` file.
 
 Note that the above Matplotlib warning is removed by default.
 
+This section is about warnings raised by your example code. To silence warnings
+raised by Sphinx-Gallery itself, see :ref:`suppressing_warnings`.
+
 .. _importing_callables:
 
 Importing callables
@@ -1372,6 +1375,60 @@ The log level can be set with::
 
 The only valid key currently is ``backreference_missing``.
 The valid values are ``'debug'``, ``'info'``, ``'warning'``, and ``'error'``.
+
+
+.. _suppressing_warnings:
+
+Suppressing Sphinx-Gallery warnings
+===================================
+
+Every warning Sphinx-Gallery emits is tagged with the warning type
+``sphinx_gallery`` and a subtype naming the kind of problem, so Sphinx's
+:confval:`sphinx:suppress_warnings` can silence them by category. This is most
+useful when building with ``-W``, where an unwanted warning otherwise fails the
+whole build. For example, to keep building when an example file name is
+duplicated across galleries::
+
+    suppress_warnings = ['sphinx_gallery.duplicate_filename']
+
+Giving the type on its own silences all Sphinx-Gallery warnings::
+
+    suppress_warnings = ['sphinx_gallery']
+
+The subtypes, and what each one warns about, are:
+
+``backreference_missing``
+    A backreference file that was not written, usually because the filesystem
+    is not case sensitive (see :ref:`log_level`).
+
+``config``
+    A configuration value that could not be honoured, and was ignored or
+    overridden.
+
+``dependency``
+    An optional dependency that is not installed, such as ``optipng``,
+    ``pypandoc`` or ``memory_profiler``.
+
+``duplicate_filename``
+    Example files sharing a name across gallery directories, which breaks some
+    links.
+
+``example_error``
+    An example that failed to execute (see :ref:`warning_on_error`).
+
+``file_conf``
+    An invalid ``# sphinx_gallery_*`` setting in an example file.
+
+``space_in_filename``
+    Example file names containing spaces, which breaks some links.
+
+``thumbnail``
+    A ``sphinx_gallery_thumbnail_path`` that does not exist (see
+    :ref:`providing_thumbnail`).
+
+``url_fetch``
+    A documentation inventory that could not be fetched (see
+    :ref:`link_to_documentation`).
 
 
 .. _disable_all_scripts_download:

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -14,6 +14,7 @@ import os
 import re
 import sys
 from collections import defaultdict
+from functools import partial
 from html import escape
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
@@ -24,7 +25,7 @@ from sphinx.errors import ExtensionError
 from ._dummy import DummyClass  # noqa: F401
 from .scrapers import _find_image_ext
 from .typing import GalleryConfig, PathLikeStr
-from .utils import _W_KW, _replace_md5
+from .utils import _W_KW, WARNING_TYPE, _replace_md5
 
 if TYPE_CHECKING:
     from .py_source_parser import Block
@@ -515,7 +516,11 @@ def _finalize_backreferences(
             _replace_md5(path, mode="t")
         else:
             level = gallery_conf["log_level"]["backreference_missing"]
-            func = getattr(logger, level)
+            func = partial(
+                getattr(logger, level),
+                type=WARNING_TYPE,
+                subtype="backreference_missing",
+            )
             func(f"Could not find backreferences file: {path}")
             func(
                 "The backreferences are likely to be erroneous "

--- a/sphinx_gallery/block_parser.py
+++ b/sphinx_gallery/block_parser.py
@@ -13,6 +13,7 @@ from sphinx.util.logging import getLogger
 
 from .py_source_parser import FLAG_BODY, Block
 from .typing import GalleryConfig, PathLikeStr
+from .utils import WARNING_TYPE
 
 logger = getLogger("sphinx-gallery")
 
@@ -341,7 +342,11 @@ class BlockParser:
                 value = ast.literal_eval(value)
             except (SyntaxError, ValueError):
                 logger.warning(
-                    "Sphinx-gallery option %s was passed invalid value %s", name, value
+                    "Sphinx-gallery option %s was passed invalid value %s",
+                    name,
+                    value,
+                    type=WARNING_TYPE,
+                    subtype="file_conf",
                 )
             else:
                 file_conf[name] = value

--- a/sphinx_gallery/directives.py
+++ b/sphinx_gallery/directives.py
@@ -22,7 +22,7 @@ from .backreferences import (
 from .gen_rst import extract_intro_and_title
 from .py_source_parser import split_code_and_text_blocks
 from .typing import PathLikeStr
-from .utils import _read_json
+from .utils import WARNING_TYPE, _read_json
 
 if TYPE_CHECKING:
     import sphinx.application
@@ -135,7 +135,9 @@ class MiniGallery(Directive):
         if backreferences_dir is None:
             logger.warning(
                 "'backreferences_dir' config is None, minigallery "
-                "directive will resolve all inputs as file paths or globs."
+                "directive will resolve all inputs as file paths or globs.",
+                type=WARNING_TYPE,
+                subtype="config",
             )
 
         # Retrieve source directory

--- a/sphinx_gallery/docs_resolv.py
+++ b/sphinx_gallery/docs_resolv.py
@@ -30,7 +30,7 @@ from .typing import (
     LinkType,
     PathLikeStr,
 )
-from .utils import _W_KW, _read_json, status_iterator
+from .utils import _W_KW, WARNING_TYPE, _read_json, status_iterator
 
 logger = sphinx.util.logging.getLogger("sphinx-gallery")
 
@@ -314,7 +314,9 @@ def _handle_http_url_error(e: Exception, msg: str = "fetching") -> None:
     elif isinstance(e, URLError):
         error_msg = f"{msg}: {e.reason}"
     logger.warning(
-        "The following {} has occurred {}".format(type(e).__name__, error_msg)
+        "The following {} has occurred {}".format(type(e).__name__, error_msg),
+        type=WARNING_TYPE,
+        subtype="url_fetch",
     )
 
 

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -52,6 +52,7 @@ from .sorting import ExplicitOrder
 from .typing import GalleryConfig, PathLikeStr
 from .utils import (
     _W_KW,
+    WARNING_TYPE,
     _collect_gallery_files,
     _combine_backreferences,
     _format_toctree,
@@ -292,6 +293,8 @@ def _check_compress_images(gallery_conf: GalleryConfig) -> None:
         logger.warning(
             "optipng binaries not found, PNG %s will not be optimized",
             " and ".join(compress_images),
+            type=WARNING_TYPE,
+            subtype="dependency",
         )
         compress_images = ()
     gallery_conf["compress_images"] = compress_images
@@ -345,7 +348,9 @@ def _check_pypandoc_config(gallery_conf: GalleryConfig) -> None:
     if isinstance(gallery_conf["pypandoc"], dict) and has_pypandoc is None:
         logger.warning(
             "'pypandoc' not available. Using Sphinx-Gallery to "
-            "convert rst text blocks to markdown for .ipynb files."
+            "convert rst text blocks to markdown for .ipynb files.",
+            type=WARNING_TYPE,
+            subtype="dependency",
         )
         gallery_conf["pypandoc"] = False
     elif isinstance(gallery_conf["pypandoc"], dict):
@@ -610,7 +615,9 @@ def _prepare_sphx_glr_dirs(
     if len(examples_dirs) != len(gallery_dirs):
         logger.warning(
             "'examples_dirs' and 'gallery_dirs' are of different lengths. "
-            "Surplus entries will be ignored."
+            "Surplus entries will be ignored.",
+            type=WARNING_TYPE,
+            subtype="config",
         )
 
     if bool(gallery_conf["backreferences_dir"]):
@@ -772,8 +779,10 @@ def generate_gallery_rst(app: Sphinx) -> None:
     src_root = Path(app.builder.srcdir)
     workdirs = _prepare_sphx_glr_dirs(gallery_conf, src_root)
 
-    # Check for duplicate filenames to make sure linking works as expected
-    examples_dirs = [ex_dir for ex_dir, _ in workdirs]
+    # Check for duplicate filenames to make sure linking works as expected.
+    # `examples_dirs` is relative to `src_root`, and resolving it against the cwd
+    # instead would silently collect nothing.
+    examples_dirs = [src_root / ex_dir for ex_dir, _ in workdirs]
     _collect_gallery_files(examples_dirs, gallery_conf, check_filenames=True)
 
     backrefs_all: dict[str, list[Backreference]] = {}
@@ -1656,7 +1665,7 @@ def summarize_failing_examples(app: Sphinx, exception: Exception | None) -> None
             )
         )
         if gallery_conf["only_warn_on_example_error"]:
-            logger.warning(fail_message)
+            logger.warning(fail_message, type=WARNING_TYPE, subtype="example_error")
         else:
             raise ExtensionError(fail_message)
 

--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -66,6 +66,7 @@ from .scrapers import (
 from .typing import GalleryConfig, Parser, PathLikeStr
 from .utils import (
     _W_KW,
+    WARNING_TYPE,
     _collect_gallery_files,
     _combine_backreferences,
     _format_toctree,
@@ -460,6 +461,8 @@ def save_thumbnail(
             "using default thumbnail.",
             image_path,
             src_file,
+            type=WARNING_TYPE,
+            subtype="thumbnail",
         )
 
     base_image_name = src_file.stem
@@ -604,6 +607,8 @@ def _split_parallel(
                 "sphinx_gallery_parallel setting is not a boolean, got %r in file %s",
                 run_parallel,
                 fname,
+                type=WARNING_TYPE,
+                subtype="file_conf",
             )
             run_parallel = True
         (parallel_listdir if run_parallel else serial_listdir).append(fname)
@@ -881,6 +886,8 @@ def handle_exception(
             f"\n{bold(red('%s'))} unexpectedly failed to execute correctly:\n\n%s",
             src_file_rel,
             red(indent(formatted_exception, "    ")),
+            type=WARNING_TYPE,
+            subtype="example_error",
         )
 
     except_rst = codestr2rst(formatted_exception, lang="pytb")
@@ -2036,7 +2043,9 @@ def _get_call_memory_and_base(
             if update:
                 logger.warning(
                     f"{gallery_conf['show_memory']=} disabled due to "
-                    f"{gallery_conf['parallel']=}."
+                    f"{gallery_conf['parallel']=}.",
+                    type=WARNING_TYPE,
+                    subtype="config",
                 )
                 gallery_conf["show_memory"] = False
         else:
@@ -2070,7 +2079,9 @@ def _get_memprof_call_memory() -> (
         from memory_profiler import memory_usage  # noqa
     except ImportError:
         logger.warning(
-            "Please install 'memory_profiler' to enable peak memory measurements."
+            "Please install 'memory_profiler' to enable peak memory measurements.",
+            type=WARNING_TYPE,
+            subtype="dependency",
         )
         return None
     else:

--- a/sphinx_gallery/py_source_parser.py
+++ b/sphinx_gallery/py_source_parser.py
@@ -16,6 +16,7 @@ from sphinx.errors import ExtensionError
 from sphinx.util.logging import getLogger
 
 from .typing import PathLikeStr
+from .utils import WARNING_TYPE
 
 logger = getLogger("sphinx-gallery")
 
@@ -145,7 +146,11 @@ def extract_file_config(content: str) -> dict[str, Any]:
             value = ast.literal_eval(value)
         except (SyntaxError, ValueError):
             logger.warning(
-                "Sphinx-gallery option %s was passed invalid value %s", name, value
+                "Sphinx-gallery option %s was passed invalid value %s",
+                name,
+                value,
+                type=WARNING_TYPE,
+                subtype="file_conf",
             )
         else:
             file_conf[name] = value

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -316,6 +316,54 @@ def test_spaces_in_files_warn(sphinx_app_wrapper):
     assert msg.format(m) in build_warn
 
 
+_DUPLICATE_CONF = """
+sphinx_gallery_conf = {
+    'examples_dirs': ['../dup_a', '../dup_b'],
+    'gallery_dirs': ['auto_a', 'auto_b'],
+}"""
+
+
+def _write_duplicate_examples(tmp_path):
+    """Write the same example file name into two `examples_dirs`."""
+    for examples_dir in ("dup_a", "dup_b"):
+        example_dir = tmp_path / examples_dir
+        example_dir.mkdir()
+        (example_dir / "GALLERY_HEADER.rst").write_text(GALLERY_HEADER)
+        (example_dir / "plot_dup.py").write_text(MINIMAL_HEADER)
+
+
+@pytest.mark.add_conf(content=_DUPLICATE_CONF)
+def test_duplicate_files_warn_during_build(sphinx_app_wrapper, tmp_path):
+    """The duplicate check must see the examples, not silently collect nothing.
+
+    `examples_dirs` is relative to the source directory, so resolving it against
+    the current working directory makes the whole check a no-op.
+    """
+    _write_duplicate_examples(tmp_path)
+
+    sphinx_app = sphinx_app_wrapper.create_sphinx_app()
+
+    build_warn = sphinx_app._warning.getvalue()
+    assert "Duplicate example file name(s) found" in build_warn
+    assert str(Path("dup_b", "plot_dup.py")) in build_warn
+    assert sphinx_app._warncount == 1
+
+
+@pytest.mark.add_conf(
+    content="suppress_warnings = ['sphinx_gallery.duplicate_filename']\n"
+    + _DUPLICATE_CONF
+)
+def test_suppress_warnings(sphinx_app_wrapper, tmp_path):
+    """Our warnings carry a type and subtype, so `suppress_warnings` can drop them."""
+    _write_duplicate_examples(tmp_path)
+
+    sphinx_app = sphinx_app_wrapper.create_sphinx_app()
+
+    assert "Duplicate example file name(s) found" not in sphinx_app._warning.getvalue()
+    # `-W` fails the build on this count, so suppressed warnings must not reach it
+    assert sphinx_app._warncount == 0
+
+
 def _check_order(sphinx_app, key, expected_order=None):
     """Iterates through sphx-glr-thumbcontainer divs and reads key from the tooltip.
 

--- a/sphinx_gallery/tests/test_gen_gallery.py
+++ b/sphinx_gallery/tests/test_gen_gallery.py
@@ -345,7 +345,8 @@ def test_duplicate_files_warn_during_build(sphinx_app_wrapper, tmp_path):
 
     build_warn = sphinx_app._warning.getvalue()
     assert "Duplicate example file name(s) found" in build_warn
-    assert str(Path("dup_b", "plot_dup.py")) in build_warn
+    # the message renders a list, so each path is repr'd -- escaped on Windows
+    assert repr(str(Path("dup_b", "plot_dup.py")))[1:-1] in build_warn
     assert sphinx_app._warncount == 1
 
 

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -1260,15 +1260,17 @@ def test_parallel_serial_examples(gallery_conf, n_jobs):
     )
     Path(gallery_conf["examples_dir"], "README.txt").write_text("")
     names = ["plot_a", "plot_b", "plot_c"]
-    # each example appends "<name>:<main|worker>" as it runs, so we see the real order
-    log = Path(gallery_conf["gallery_dir"], "order.log")
+    # Each example records where and when it ran, so we see the real order. One file
+    # per example rather than a shared log: the workers would otherwise append
+    # concurrently, and on Windows O_APPEND is a seek-then-write that can lose one.
+    gallery_dir = Path(gallery_conf["gallery_dir"])
     for name in names:
         # only the middle example is serial, so execution order != gallery order
         flag = "# sphinx_gallery_parallel = False\n" if name == "plot_b" else ""
         Path(gallery_conf["examples_dir"], f"{name}.py").write_text(
-            f"{DOCSTRING}{flag}import multiprocessing\nfrom pathlib import Path\n"
+            f"{DOCSTRING}{flag}import multiprocessing, time\nfrom pathlib import Path\n"
             'where = "main" if multiprocessing.parent_process() is None else "worker"\n'
-            f'Path(r"{log}").open("a").write(f"{name}:{{where}} ")\n',
+            f'Path(r"{gallery_dir}", "{name}.ran").write_text(f"{{where}} {{time.time()}}")\n',
             encoding="utf-8",
         )
 
@@ -1280,13 +1282,20 @@ def test_parallel_serial_examples(gallery_conf, n_jobs):
         is_subsection=False,
     )
 
-    ran = log.read_text(encoding="utf-8").split()
+    assert gallery_conf["failing_examples"] == {}
+    ran = {
+        path.stem: path.read_text(encoding="utf-8").split()
+        for path in gallery_dir.glob("*.ran")
+    }
+    where = {name: entry[0] for name, entry in ran.items()}
+    started = {name: float(entry[1]) for name, entry in ran.items()}
     if n_jobs:
+        assert where == {"plot_a": "worker", "plot_b": "main", "plot_c": "worker"}
         # serial examples finish before anything is dispatched; the rest race
-        assert ran[0] == "plot_b:main"
-        assert sorted(ran[1:]) == ["plot_a:worker", "plot_c:worker"]
+        assert started["plot_b"] < min(started["plot_a"], started["plot_c"])
     else:
-        assert ran == [f"{name}:main" for name in names]
+        assert where == {name: "main" for name in names}
+        assert sorted(started, key=started.__getitem__) == names
     assert [Path(item).name for item in toctree_items] == names
     assert re.findall(r"sphx_glr_(plot_[abc])_thumb", index_content) == names
 

--- a/sphinx_gallery/tests/test_utils.py
+++ b/sphinx_gallery/tests/test_utils.py
@@ -1,6 +1,74 @@
 """Test utility functions."""
 
-from sphinx_gallery.utils import _combine_backreferences, _read_json, _write_json
+import ast
+from pathlib import Path
+
+import pytest
+
+import sphinx_gallery
+from sphinx_gallery.utils import (
+    WARNING_TYPE,
+    _combine_backreferences,
+    _read_json,
+    _write_json,
+)
+
+DOCUMENTED_SUBTYPES = {
+    "backreference_missing",
+    "config",
+    "dependency",
+    "duplicate_filename",
+    "example_error",
+    "file_conf",
+    "space_in_filename",
+    "thumbnail",
+    "url_fetch",
+}
+
+
+def _iter_logger_warning_calls():
+    """Yield every ``logger.warning(...)`` call made by the package."""
+    for path in sorted(Path(sphinx_gallery.__file__).parent.glob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "warning"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "logger"
+            ):
+                yield f"{path.name}:{node.lineno}", node
+
+
+def test_warnings_are_suppressible():
+    """Every warning must be tagged so users can filter it via `suppress_warnings`."""
+    calls = dict(_iter_logger_warning_calls())
+    assert len(calls) > 10, "found almost no warnings, has the AST match gone stale?"
+    for location, node in calls.items():
+        keywords = {kw.arg: kw.value for kw in node.keywords}
+        assert "type" in keywords and "subtype" in keywords, (
+            f"{location}: pass type=WARNING_TYPE and a subtype, so that readers can "
+            "silence this warning with suppress_warnings"
+        )
+        assert getattr(keywords["type"], "id", None) == "WARNING_TYPE", (
+            f"{location}: pass the WARNING_TYPE constant rather than a literal"
+        )
+        subtype = keywords["subtype"]
+        assert isinstance(subtype, ast.Constant), f"{location}: subtype must be literal"
+        assert subtype.value in DOCUMENTED_SUBTYPES, (
+            f"{location}: unknown subtype {subtype.value!r}, add it to "
+            "DOCUMENTED_SUBTYPES and to the table in doc/configuration.rst"
+        )
+
+
+@pytest.mark.parametrize("subtype", sorted(DOCUMENTED_SUBTYPES))
+def test_subtypes_documented(subtype):
+    """Each subtype is documented, and named as `sphinx_gallery.<subtype>`."""
+    doc = Path(sphinx_gallery.__file__).parents[1] / "doc" / "configuration.rst"
+    if not doc.is_file():
+        pytest.skip("docs not available (installed package)")
+    assert f"``{subtype}``" in doc.read_text(encoding="utf-8")
+    assert WARNING_TYPE == "sphinx_gallery"
 
 
 def test_combine_backreferences():

--- a/sphinx_gallery/utils.py
+++ b/sphinx_gallery/utils.py
@@ -38,6 +38,19 @@ from .typing import GalleryConfig, PathLikeStr
 
 logger = sphinx.util.logging.getLogger("sphinx-gallery")
 
+WARNING_TYPE = "sphinx_gallery"
+"""Warning ``type`` for every warning Sphinx-Gallery emits.
+
+Pass it together with a ``subtype`` naming the kind of problem::
+
+    logger.warning("...", type=WARNING_TYPE, subtype="config")
+
+Readers can then silence a kind of warning with ``suppress_warnings =
+["sphinx_gallery.config"]`` in their ``conf.py``, or all of ours with
+``["sphinx_gallery"]``. Keep the subtypes documented in
+``doc/configuration.rst`` in sync with the ones used here.
+"""
+
 
 class _WriteKwargs(TypedDict):
     """Text writing kwargs for builtins.open."""
@@ -262,6 +275,8 @@ def check_duplicate_filenames(files: Sequence[PathLikeStr]) -> None:
             "names will break some links. "
             "List of files: %s",
             sorted(str(name) for name in dup_names),
+            type=WARNING_TYPE,
+            subtype="duplicate_filename",
         )
 
 
@@ -275,6 +290,8 @@ def check_spaces_in_filenames(files: Sequence[PathLikeStr]) -> None:
             "file names will break some links. "
             "List of files: %s",
             sorted(files_with_space),
+            type=WARNING_TYPE,
+            subtype="space_in_filename",
         )
 
 


### PR DESCRIPTION
1. Fix our deduplication checks (they were silently not working!)
2. Add sphinx-gallery warning types and subtypes so things like the above can be ignored more easily if needed, especially in `-nWT` contexts

Changes drafted by Claude Opus 5, reviewed by me.