### PR TITLE
Sanitize backref filenames

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -867,7 +867,10 @@ Each .rst file will contain a reduced version of the
 gallery, containing examples where that "object" that is used.
 '<object>.examples' files will be generated for all objects to prevent inclusion
 errors. Empty '<object>.examples' files are created for objects not used in any
-example.
+example. Characters that cannot appear in a filename (``<>:"/\|?*``) are replaced
+with an underscore, so that a name picked up from markup that carries an
+intersphinx inventory prefix (``:obj:`inventory:package.object```) still yields a
+usable filename on every platform.
 
 .. _exclude_implicit_doc:
 

--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -412,6 +412,19 @@ class Backreference(NamedTuple):
     title: str
 
 
+# Explicit backreference names come from reST roles in the example text, so they are
+# not restricted to Python identifiers: an intersphinx inventory prefix such as
+# ``:ref:`pkg:target``` leaves a ``:`` behind, which cannot appear in a filename on
+# Windows. Cover the whole Windows-invalid set; ``/`` also keeps a name from escaping
+# ``backreferences_dir``.
+_INVALID_FNAME_CHARS = re.compile(r'[<>:"/\\|?*]')
+
+
+def _sanitize_backref(backref: str) -> str:
+    """Make a backreference name safe to use as a filename."""
+    return _INVALID_FNAME_CHARS.sub("_", backref)
+
+
 def _write_backreferences(
     backrefs: set[str],
     seen_backrefs: set[str],
@@ -432,7 +445,8 @@ def _write_backreferences(
     backrefs : set[str]
         Back references to write.
     seen_backrefs: set[str]
-        Back references already encountered when parsing this example.
+        Filename-sanitized back references already encountered when parsing this
+        example, updated in place.
     gallery_conf : Dict[str, Any]
         Gallery configurations.
     src_dir : str | pathlib.Path
@@ -462,12 +476,13 @@ def _write_backreferences(
 
     backrefs_example = defaultdict(list)
     for backref in backrefs:
+        fname_backref = _sanitize_backref(backref)
         include_path = (
             Path(gallery_conf["src_dir"])
             / gallery_conf["backreferences_dir"]
-            / f"{backref}.examples.new"
+            / f"{fname_backref}.examples.new"
         )
-        seen = backref in seen_backrefs
+        seen = fname_backref in seen_backrefs
         mode = "a" if seen else "w"
         with open(include_path, mode, **_W_KW) as ex_file:
             if not seen:
@@ -490,7 +505,7 @@ def _write_backreferences(
                     is_backref=True,
                 )
             )
-            seen_backrefs.add(backref)
+            seen_backrefs.add(fname_backref)
             backrefs_example[backref].append(
                 Backreference(str(fname), str(src_dir), str(target_dir), intro, title)
             )
@@ -500,7 +515,11 @@ def _write_backreferences(
 def _finalize_backreferences(
     seen_backrefs: set[str], gallery_conf: GalleryConfig
 ) -> None:
-    """Replace backref files only if necessary."""
+    """Replace backref files only if necessary.
+
+    ``seen_backrefs`` holds names already passed through ``_sanitize_backref``, so
+    they are used as filenames as-is.
+    """
     logger = sphinx.util.logging.getLogger("sphinx-gallery")
     if gallery_conf["backreferences_dir"] is None:
         return

--- a/sphinx_gallery/gen_gallery.py
+++ b/sphinx_gallery/gen_gallery.py
@@ -27,7 +27,11 @@ from sphinx.util.console import blue, bold, purple, red
 from . import __version__ as _sg_version
 from . import glr_path_static
 from ._doctree_links import setup_doctree_links
-from .backreferences import Backreference, _finalize_backreferences
+from .backreferences import (
+    Backreference,
+    _finalize_backreferences,
+    _sanitize_backref,
+)
 from .directives import ImageSg, MiniGallery, imagesg_addnode
 from .downloads import generate_zipfiles
 from .gen_rst import (
@@ -1551,10 +1555,12 @@ def touch_empty_backreferences(
     if not bool(app.config.sphinx_gallery_conf["backreferences_dir"]):
         return
 
+    # a dotted Python name needs no sanitizing, but keep the name -> filename
+    # mapping in one place so this matches what `_write_backreferences` produced
     examples_path = (
         Path(app.srcdir)
         / app.config.sphinx_gallery_conf["backreferences_dir"]
-        / f"{name}.examples"
+        / f"{_sanitize_backref(name)}.examples"
     )
 
     if not examples_path.exists():

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -237,6 +237,11 @@ h.i.j()
 
 
 cobj = dict(module="m", module_short="m", name="n", is_class=False, is_explicit=True)
+# a py-like default_role lets any role prefix through, so an intersphinx inventory
+# prefix (``:ref:`inv:target```) ends up in the name -- see `_sanitize_backref`
+cobj_colon = dict(
+    module="inv:m", module_short="inv:m", name="n", is_class=False, is_explicit=True
+)
 
 
 @pytest.mark.parametrize(
@@ -251,6 +256,7 @@ cobj = dict(module="m", module_short="m", name="n", is_class=False, is_explicit=
         (":ref:`m.n`", None, None, None),
         ("`m.n`", "ref", None, None),
         ("``literal``", "obj", None, None),
+        (":ref:`inv:m.n`", "obj", "inv:m.n", cobj_colon),
     ],
     ids=[
         "regular",
@@ -262,6 +268,7 @@ cobj = dict(module="m", module_short="m", name="n", is_class=False, is_explicit=
         "non-python role",
         "non-python default_role",
         "literal",
+        "inventory prefix",
     ],
 )
 # the sphinx default value for default_role is None = no change, the docutils
@@ -276,3 +283,38 @@ def test_identify_names_explicit(text, default_role, ref, cobj, gallery_conf):
     ref_regex = sg._make_ref_regex(default_role)
     actual = sg.identify_names(script_blocks, ref_regex)
     assert expected == actual
+
+
+def test_write_backreferences_sanitized_filename(gallery_conf, tmp_path):
+    """Colons in backreference names must not reach the filesystem."""
+    backrefs_dir = tmp_path / "backreferences"
+    backrefs_dir.mkdir()
+    gallery_conf["backreferences_dir"] = "backreferences"
+    gallery_conf["src_dir"] = str(tmp_path)
+    thumb = tmp_path / "images" / "thumb" / "sphx_glr_plot_example_thumb.png"
+    thumb.parent.mkdir(parents=True)
+    thumb.touch()
+    seen_backrefs = set()
+
+    backrefs_example = sg._write_backreferences(
+        {"mne:mne.Epochs"},
+        seen_backrefs,
+        gallery_conf,
+        tmp_path,
+        tmp_path,
+        "plot_example.py",
+        "intro",
+        "title",
+    )
+    # the name is untouched: `backreferences_all.json` and the minigallery
+    # directive are keyed by it
+    assert list(backrefs_example) == ["mne:mne.Epochs"]
+    assert seen_backrefs == {"mne_mne.Epochs"}
+    assert [p.name for p in backrefs_dir.iterdir()] == ["mne_mne.Epochs.examples.new"]
+
+    sg._finalize_backreferences(seen_backrefs, gallery_conf)
+    assert [p.name for p in backrefs_dir.iterdir()] == ["mne_mne.Epochs.examples"]
+    content = (backrefs_dir / "mne_mne.Epochs.examples").read_text("utf-8")
+    # the heading still shows the real name
+    assert "Examples using ``mne:mne.Epochs``" in content
+    assert content.count("<div") == content.count("</div")

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -777,6 +777,13 @@ def test_backreferences_dirhtml(sphinx_dirhtml_app):
             "plot_second_future_imports",
             id="ExplicitOrder",
         ),
+        # an intersphinx inventory prefix survives into the backreference name, so
+        # its colon must be sanitized out of the filename (invalid on Windows)
+        pytest.param(
+            "sphinx_gallery_sphinx_gallery.sorting.ExplicitOrder.examples",
+            "plot_second_future_imports",
+            id="inventory-prefix",
+        ),
     ],
 )
 def test_backreferences_examples_rst(sphinx_app, rst_file, example_used_in):
@@ -789,6 +796,13 @@ def test_backreferences_examples_rst(sphinx_app, rst_file, example_used_in):
     n_open = lines.count("<div")
     n_close = lines.count("</div")
     assert n_open == n_close
+
+
+def test_backreferences_filenames(sphinx_app):
+    """Backreference filenames must be usable on every platform."""
+    backref_dir = Path(sphinx_app.srcdir, "gen_modules", "backreferences")
+    bad = [p.name for p in backref_dir.iterdir() if set(p.name) & set(r'<>:"/\|?*')]
+    assert bad == []
 
 
 def test_backreferences_examples_html(sphinx_app):

--- a/sphinx_gallery/tests/tinybuild/doc/conf.py
+++ b/sphinx_gallery/tests/tinybuild/doc/conf.py
@@ -107,6 +107,11 @@ sphinx_gallery_conf = {
     "parallel": 2,
 }
 nitpicky = True
+# deliberately unresolvable: plot_second_future_imports.py references it to check that
+# a colon in a backreference name does not end up in a filename
+nitpick_ignore = [
+    ("py:obj", "sphinx_gallery:sphinx_gallery.sorting.ExplicitOrder"),
+]
 highlight_language = "python3"
 html_static_path = ["_static_nonstandard"]
 

--- a/sphinx_gallery/tests/tinybuild/examples/plot_second_future_imports.py
+++ b/sphinx_gallery/tests/tinybuild/examples/plot_second_future_imports.py
@@ -8,6 +8,10 @@ plot_future_statements.py. We should eventually update this script to actually
 test this... we require Python 3 nowadays so the ``__future__`` statements there
 don't do anything. So for now let's repurpose this to look at some
 backreferences. We should probably also change the filename in another PR!
+
+A cross-reference carrying an intersphinx inventory prefix, such as
+:obj:`sphinx_gallery:sphinx_gallery.sorting.ExplicitOrder`, becomes a backreference
+whose name contains a colon -- which is not a legal filename character on Windows.
 """
 
 # sphinx_gallery_thumbnail_path = '_static_nonstandard/demo.png'


### PR DESCRIPTION
We shouldn't be writing filenames with `:` (or other filesystem-incompatible values!) in them -- replace them with `_`. Trivial change with unit tests (including end-to-end in `tinybuild`). @drammock okay for you?

Closes mne-tools/mne-python#12950

Drafted with Opus 5, reviewed by me