### PR TITLE
Keep the title of an explicit-title cross-reference in tooltips

### DIFF
--- a/sphinx_gallery/gen_rst.py
+++ b/sphinx_gallery/gen_rst.py
@@ -322,9 +322,13 @@ def _regroup(match: re.Match[str]) -> str:
 
 def _sanitize_rst(string: str) -> str:
     """Use regex to remove at least some sphinx directives."""
-    # :class:`a.b.c <thing here>`, :ref:`abc <thing here>` --> thing here
-    p, e = r"(\s|^):[^:\s]+:`", r"`(\W|$)"
-    string = re.sub(p + r"\S+\s*<([^>`]+)>" + e, r"\1\2\3", string)
+    # :class:`title <a.b.c>`, :ref:`title <thing here>` --> title
+    # Sphinx renders the explicit title, not the target, so keep the title.
+    # The role name is `(?:[^:\s`]+:)+` rather than a single segment so that a
+    # domain-qualified role (:py:class:, :std:doc:) is consumed whole -- matching
+    # from its inner colon would strand the ":py" as literal text (gh-1644).
+    p, e = r"(\s|^):(?:[^:\s`]+:)+`", r"`(\W|$)"
+    string = re.sub(p + r"([^`<>]+?)\s*<[^>`]+>" + e, r"\1\2\3", string)
     # :class:`~a.b.c` --> c
     string = re.sub(p + r"~([^`]+)" + e, _regroup, string)
     # :class:`a.b.c` --> a.b.c
@@ -348,7 +352,7 @@ def _sanitize_rst(string: str) -> str:
     string = re.sub(r"`([^`<>]+) <[^`<>]+>`\_\_?", r"\1", string)
 
     # :anchor:`the term` --> the term
-    string = re.sub(r":[a-z]+:`([^`<>]+)( <[^`<>]+>)?`", r"\1", string)
+    string = re.sub(r":(?:[a-z]+:)+`([^`<>]+)( <[^`<>]+>)?`", r"\1", string)
 
     # r'\\dfrac' --> r'\dfrac'
     string = string.replace("\\\\", "\\")

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -42,7 +42,7 @@ REFERENCE = r"""
         # reST sanitizing
         (
             "1 :class:`~a.b`. 2 :class:`a.b` 3 :ref:`whatever <better name>`",
-            "1 b. 2 a.b 3 better name",
+            "1 b. 2 a.b 3 whatever",
             False,
         ),
         ("use :meth:`mne.io.Raw.plot_psd` to", "use mne.io.Raw.plot_psd to", False),

--- a/sphinx_gallery/tests/test_gen_rst.py
+++ b/sphinx_gallery/tests/test_gen_rst.py
@@ -352,6 +352,39 @@ def test_codestr2rst():
     assert reference == output
 
 
+@pytest.mark.parametrize(
+    "content,expected",
+    [
+        # Explicit title: Sphinx renders the title, so the tooltip must too
+        # (gh-1644).
+        (":term:`ascent <parcel ascent>`", "ascent"),
+        (":term:`wind barbs <wind barb>`", "wind barbs"),
+        (":class:`Sounding <a.b.Sounding>`", "Sounding"),
+        (":ref:`whatever <better name>`", "whatever"),
+        # Domain-qualified roles must not leave the domain behind (gh-1644).
+        (":py:class:`Sounding <a.b.Sounding>`", "Sounding"),
+        (":py:func:`parcel path <a.b.parcel_path>`", "parcel path"),
+        (":std:doc:`the guide <howtos/index>`", "the guide"),
+        (":py:mod:`a.b.c`", "a.b.c"),
+        (":py:class:`~a.b.MyClass`", "MyClass"),
+        # Forms that already worked
+        (":term:`dewpoint`", "dewpoint"),
+        (":class:`a.b.c`", "a.b.c"),
+        (":class:`~a.b.MyClass`", "MyClass"),
+        ("``literal``", "literal"),
+        ("`interpreted`", "interpreted"),
+        ("`~mymodule.MyClass`", "MyClass"),
+        ("**bold**", "bold"),
+        ("*italic*", "italic"),
+        ("`link text <https://example.com>`_", "link text"),
+    ],
+)
+@pytest.mark.parametrize("template", ["See {} here.", "{} starts it.", "It ends {}"])
+def test_sanitize_rst(content, expected, template):
+    """Test that sphinx markup is reduced to what sphinx would render."""
+    assert sg._sanitize_rst(template.format(content)) == template.format(expected)
+
+
 def test_extract_intro_and_title():
     intro, title = sg.extract_intro_and_title("<string>", "\n".join(CONTENT[1:10]))
     assert title == "Docstring header"


### PR DESCRIPTION
Closes #1644.

`_sanitize_rst` mangles ``:role:`title <target>``` three ways, so the thumbnail
`tooltip=` attribute disagrees with what Sphinx renders on the page.

### Before / after

| input | before | after |
|---|---|---|
| ``:term:`wind barbs <wind barb>``` | `wind barbs <wind barb>` | `wind barbs` |
| ``:term:`ascent <parcel ascent>``` | `parcel ascent` | `ascent` |
| ``:py:class:`Sounding <a.b.Sounding>``` | `:pySounding` | `Sounding` |
| ``:std:doc:`the guide <howtos/index>``` | `:stdthe guide` | `the guide` |
| ``:py:mod:`a.b.c``` | `:pya.b.c` | `a.b.c` |
| ``:py:class:`~a.b.MyClass``` | `:py~a.b.MyClass` | `MyClass` |

The last two are not in the issue: widening the role-name group turned out to fix
the bare and `~`-shortened forms of a domain-qualified role as well, not just the
explicit-title one.

### The change

Three edits to the first rule, plus the same role-name widening on the
`:anchor:` catch-all further down (which already kept the title correctly):

- the title pattern `\S+` becomes `[^`<>]+?`, so a **multi-word** title matches.
  Previously it could not span a space, so it fell through to the catch-all rule
  that keeps everything between the backticks verbatim -- leaking the raw
  `<target>` into the tooltip, and stripping the backticks so the correct rule at
  the bottom of the function could no longer match it;
- the group that is kept flips from the target to the **title**, which is what
  Sphinx displays;
- the role-name group `:[^:\s]+:` becomes `:(?:[^:\s`]+:)+`, so a
  domain-qualified role is consumed whole. Matching from the inner colon left
  everything before it -- the `:py` -- untouched as literal text.

### Note for reviewers

This flips one existing assertion. `test_thumbnail_div` had
``:ref:`whatever <better name>``` → `better name`, encoding the old comment's
intent of keeping the target; it is now `whatever`. That is the direction
question raised in the issue, and the one deliberate behaviour change here --
worth a look rather than a skim.

### Testing

New `test_sanitize_rst` in `test_gen_rst.py` covers 18 markup forms across three
positions in the string (start, middle, end). Verified it fails with the fix
reverted -- 27 failed / 27 passed, the failures being exactly the buggy forms and
the previously-working forms staying green.

Full suite: 418 passed, 0 skipped (`test_full.py` included). `pre-commit run -a`
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013N5ykzsUtz2khPJvLMdEpY