### PR TITLE
Fix backref

### DIFF
--- a/sphinx_gallery/backreferences.py
+++ b/sphinx_gallery/backreferences.py
@@ -498,7 +498,9 @@ def _write_backreferences(
             ex_file.write(
                 _thumbnail_div(
                     target_dir,
-                    src_dir,
+                    # the Sphinx srcdir, not the example src_dir: the paths land in
+                    # a file under `backreferences_dir` and are srcdir-absolute
+                    gallery_conf["src_dir"],
                     fname,
                     intro,
                     title,

--- a/sphinx_gallery/tests/test_backreferences.py
+++ b/sphinx_gallery/tests/test_backreferences.py
@@ -318,3 +318,39 @@ def test_write_backreferences_sanitized_filename(gallery_conf, tmp_path):
     # the heading still shows the real name
     assert "Examples using ``mne:mne.Epochs``" in content
     assert content.count("<div") == content.count("</div")
+
+
+def test_write_backreferences_examples_outside_srcdir(gallery_conf, tmp_path):
+    """Thumbnail paths are srcdir-absolute even when examples live outside srcdir."""
+    src_dir = tmp_path / "doc"
+    examples_dir = tmp_path / "examples" / "sub"
+    target_dir = src_dir / "auto_examples" / "sub"
+    backrefs_dir = src_dir / "generated"
+    backrefs_dir.mkdir(parents=True)
+    examples_dir.mkdir(parents=True)
+    gallery_conf["backreferences_dir"] = "generated"
+    gallery_conf["src_dir"] = str(src_dir)
+    thumb = target_dir / "images" / "thumb" / "sphx_glr_plot_example_thumb.png"
+    thumb.parent.mkdir(parents=True)
+    thumb.touch()
+    seen_backrefs = set()
+
+    sg._write_backreferences(
+        {"mod.func"},
+        seen_backrefs,
+        gallery_conf,
+        examples_dir,
+        target_dir,
+        "plot_example.py",
+        "intro",
+        "title",
+    )
+    sg._finalize_backreferences(seen_backrefs, gallery_conf)
+    content = (backrefs_dir / "mod.func.examples").read_text("utf-8")
+    assert ":doc:`/auto_examples/sub/plot_example`" in content
+    assert (
+        ".. image:: /auto_examples/sub/images/thumb/sphx_glr_plot_example_thumb.png"
+        in content
+    )
+    # a path that climbs above srcdir can never resolve
+    assert "/../" not in content

--- a/sphinx_gallery/tests/test_full.py
+++ b/sphinx_gallery/tests/test_full.py
@@ -2,6 +2,7 @@
 # License: 3-clause BSD
 """Test the SG pipeline used with Sphinx and tinybuild."""
 
+import itertools
 import json
 import os
 import re
@@ -796,6 +797,13 @@ def test_backreferences_examples_rst(sphinx_app, rst_file, example_used_in):
     n_open = lines.count("<div")
     n_close = lines.count("</div")
     assert n_open == n_close
+    # tinybuild's examples_dirs is outside srcdir, so resolving these srcdir-absolute
+    # paths against it would climb above srcdir and never resolve
+    assert "/../" not in lines
+    targets = re.findall(r":doc:`(.*?)`|\.\. image:: (\S+)", lines)
+    assert targets
+    for target in itertools.chain.from_iterable(targets):
+        assert not target or target.startswith("/auto_examples/"), target
 
 
 def test_backreferences_filenames(sphinx_app):


### PR DESCRIPTION
Small bug I found while working on mne-realtime where backref links were wrong. Will mark for self-merge since this one is pretty trivial